### PR TITLE
Provide reference dictionaries in extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,27 @@ Here's what the CIF hover text looks like in VS Code:
 
 # Configuration
 
-To use the CIF extension, specify the dictionary file paths in your `settings.json`:
+A minimal set of CIF dictionary files are provided. These include
+
+DDL1 dictionaries:
+- [cif_core.dic](https://github.com/COMCIFS/DDL1-legacy-dictionaries/raw/refs/heads/main/dictionaries/cif_core.dic)
+- [ddl_core.dic](https://github.com/COMCIFS/DDL1-legacy-dictionaries/raw/refs/heads/main/dictionaries/ddl_core.dic)
+- [cif_pd.dic](https://github.com/COMCIFS/DDL1-legacy-dictionaries/raw/refs/heads/main/dictionaries/cif_pd.dic)
+
+DDL2 dictionary:
+- [mmcif_pdbx_v50.dic](https://mmcif.wwpdb.org/dictionaries/ascii/mmcif_pdbx_v50.dic)
+- [mmcif_ddl.dic](https://mmcif.wwpdb.org/dictionaries/ascii/mmcif_ddl.dic)
+
+DDLm dictionaries:
+- [cif_core.dic](https://github.com/COMCIFS/cif_core/raw/refs/heads/master/cif_core.dic)
+- [ddl.dic](https://github.com/COMCIFS/cif_core/raw/refs/heads/master/ddl.dic)
+- [templ_attr.cif](https://github.com/COMCIFS/cif_core/raw/refs/heads/master/templ_attr.cif)
+- [templ_enum.cif](https://github.com/COMCIFS/cif_core/raw/refs/heads/master/templ_enum.cif)
+- [cif_pow.dic](https://github.com/COMCIFS/Powder_Dictionary/raw/refs/heads/master/cif_pow.dic)
+- [multi_block_core.dic](https://github.com/COMCIFS/MultiBlock_Dictionary/raw/refs/heads/main/multi_block_core.dic)
+
+
+If you want to use your own, customised set of dictionaries, you can specify them in your `settings.json`:
 
 ```json
   "cifTools.dictionaryPaths": [
@@ -48,25 +68,9 @@ To use the CIF extension, specify the dictionary file paths in your `settings.js
   ]
 ```
 
-For DDL1 dictionaries, the recommended minimum files are:
-- [cif_core.dic](https://github.com/COMCIFS/DDL1-legacy-dictionaries/raw/refs/heads/main/dictionaries/cif_core.dic)
-- [ddl_core.dic](https://github.com/COMCIFS/DDL1-legacy-dictionaries/raw/refs/heads/main/dictionaries/ddl_core.dic)
+Specifying your own dictionaries will override all default dictionaries.
 
-Additionally, if working with powder diffraction files, include the following:
-- [cif_pd.dic](https://github.com/COMCIFS/DDL1-legacy-dictionaries/raw/refs/heads/main/dictionaries/cif_pd.dic)
-
-
-For DDLm dictionaries, the recommended minimum files are:
-- [cif_core.dic](https://github.com/COMCIFS/cif_core/raw/refs/heads/master/cif_core.dic)
-- [ddl.dic](https://github.com/COMCIFS/cif_core/raw/refs/heads/master/ddl.dic)
-- [templ_attr.cif](https://github.com/COMCIFS/cif_core/raw/refs/heads/master/templ_attr.cif)
-- [templ_enum.cif](https://github.com/COMCIFS/cif_core/raw/refs/heads/master/templ_enum.cif)
-
-Additionally, if working with powder diffraction files, include the following, noting that they are drafts:
-- [cif_pow.dic](https://github.com/COMCIFS/Powder_Dictionary/raw/refs/heads/master/cif_pow.dic)
-- [multi_block_core.dic](https://github.com/COMCIFS/MultiBlock_Dictionary/raw/refs/heads/main/multi_block_core.dic)
-
-See the [COMCIFS github](https://github.com/COMCIFS) for other available dictionaries.
+See the [COMCIFS github](https://github.com/COMCIFS) or [PDBx/mmCIF Dictionary Resources](https://mmcif.wwpdb.org/dictionaries/downloads.html) for other available dictionaries.
 
 ## License
 

--- a/dictionaries/cif_core.dic
+++ b/dictionaries/cif_core.dic
@@ -1,0 +1,28088 @@
+#\#CIF_2.0
+##########################################################################
+#                                                                        #
+#  CIF CORE DICTIONARY                                                   #
+#                                                                        #
+##########################################################################
+
+data_CIF_CORE
+
+    _dictionary.title             CIF_CORE
+    _dictionary.class             Instance
+    _dictionary.version           3.3.0
+    _dictionary.date              2024-11-12
+    _dictionary.uri
+        https://raw.githubusercontent.com/COMCIFS/cif_core/master/cif_core.dic
+    _dictionary.ddl_conformance   4.2.0
+    _dictionary.namespace         CifCore
+    _description.text
+;
+    The CIF_CORE dictionary defines data items that are common to all domains
+    of crystallographic studies. These definitions are mostly used within the
+    Crystallographic Information Framework (CIF).
+;
+
+save_CIF_CORE_HEAD
+
+    _definition.id                CIF_CORE_HEAD
+    _definition.scope             Category
+    _definition.class             Head
+    _definition.update            2024-05-15
+    _description.text
+;
+    The CIF_CORE_HEAD category is the top-level category for all categories in
+    the CIF_CORE dictionary.
+;
+    _name.category_id             CIF_CORE
+    _name.object_id               CIF_CORE_HEAD
+
+save_
+
+save_DIFFRACTION
+
+    _definition.id                DIFFRACTION
+    _definition.scope             Category
+    _definition.class             Set
+    _definition.update            2024-05-15
+    _description.text
+;
+    The DICTIONARY group encompassing the CORE DIFFRACTION data items defined
+    and used within the Crystallographic Information Framework (CIF).
+;
+    _name.category_id             CIF_CORE_HEAD
+    _name.object_id               DIFFRACTION
+
+save_
+
+save_DIFFRN
+
+    _definition.id                DIFFRN
+    _definition.scope             Category
+    _definition.class             Set
+    _definition.update            2022-05-09
+    _description.text
+;
+    The CATEGORY of data items used to describe the diffraction experiment.
+;
+    _name.category_id             DIFFRACTION
+    _name.object_id               DIFFRN
+    _category_key.name            '_diffrn.id'
+
+save_
+
+save_diffrn.ambient_environment
+
+    _definition.id                '_diffrn.ambient_environment'
+    _alias.definition_id          '_diffrn_ambient_environment'
+    _definition.update            2012-11-26
+    _description.text
+;
+    The gas or liquid environment of the crystal sample, if not air.
+;
+    _name.category_id             diffrn
+    _name.object_id               ambient_environment
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+
+    loop_
+      _description_example.case
+         'He'
+         'vacuum'
+         'mother liquor'
+
+save_
+
+save_diffrn.ambient_pressure
+
+    _definition.id                '_diffrn.ambient_pressure'
+    _alias.definition_id          '_diffrn_ambient_pressure'
+    _definition.update            2023-01-13
+    _description.text
+;
+    Mean hydrostatic pressure at which intensities were measured.
+;
+    _name.category_id             diffrn
+    _name.object_id               ambient_pressure
+    _type.purpose                 Measurand
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   kilopascals
+
+save_
+
+save_diffrn.ambient_pressure_su
+
+    _definition.id                '_diffrn.ambient_pressure_su'
+
+    loop_
+      _alias.definition_id
+         '_diffrn_ambient_pressure_su'
+         '_diffrn.ambient_pressure_esd'
+
+    _definition.update            2023-07-01
+    _description.text
+;
+    Standard uncertainty of _diffrn.ambient_pressure.
+;
+    _name.category_id             diffrn
+    _name.object_id               ambient_pressure_su
+    _name.linked_item_id          '_diffrn.ambient_pressure'
+    _units.code                   kilopascals
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+save_
+
+save_diffrn.ambient_pressure_gt
+
+    _definition.id                '_diffrn.ambient_pressure_gt'
+    _alias.definition_id          '_diffrn_ambient_pressure_gt'
+    _definition.update            2012-12-13
+    _description.text
+;
+    Mean hydrostatic pressure above which intensities were measured.
+    These items allow for a pressure range to be given.
+    _diffrn.ambient_pressure should be used in preference to this
+    item when possible.
+;
+    _name.category_id             diffrn
+    _name.object_id               ambient_pressure_gt
+    _type.purpose                 Number
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   kilopascals
+
+save_
+
+save_diffrn.ambient_pressure_lt
+
+    _definition.id                '_diffrn.ambient_pressure_lt'
+    _alias.definition_id          '_diffrn_ambient_pressure_lt'
+    _definition.update            2012-12-13
+    _description.text
+;
+    Mean hydrostatic pressure below which intensities were measured.
+    These items allow for a pressure range to be given.
+    _diffrn.ambient_pressure should be used in preference to this
+    item when possible.
+;
+    _name.category_id             diffrn
+    _name.object_id               ambient_pressure_lt
+    _type.purpose                 Number
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   kilopascals
+
+save_
+
+save_diffrn.ambient_temperature
+
+    _definition.id                '_diffrn.ambient_temperature'
+
+    loop_
+      _alias.definition_id
+         '_diffrn_ambient_temperature'
+         '_diffrn_ambient_temp'
+         '_diffrn.ambient_temp'
+
+    _definition.update            2012-11-26
+    _description.text
+;
+    Mean temperature at which intensities were measured.
+;
+    _name.category_id             diffrn
+    _name.object_id               ambient_temperature
+    _type.purpose                 Measurand
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   kelvins
+
+save_
+
+save_diffrn.ambient_temperature_su
+
+    _definition.id                '_diffrn.ambient_temperature_su'
+
+    loop_
+      _alias.definition_id
+         '_diffrn_ambient_temperature_su'
+         '_diffrn_ambient_temp_su'
+         '_diffrn.ambient_temp_esd'
+
+    _definition.update            2021-03-03
+    _description.text
+;
+    Standard uncertainty of _diffrn.ambient_temperature.
+;
+    _name.category_id             diffrn
+    _name.object_id               ambient_temperature_su
+    _name.linked_item_id          '_diffrn.ambient_temperature'
+    _units.code                   kelvins
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+save_
+
+save_diffrn.ambient_temperature_details
+
+    _definition.id                '_diffrn.ambient_temperature_details'
+
+    loop_
+      _alias.definition_id
+         '_diffrn_ambient_temp_details'
+         '_diffrn.ambient_temp_details'
+
+    _definition.update            2014-06-12
+    _description.text
+;
+    A description of special aspects of temperature control during
+    data collection.
+;
+    _name.category_id             diffrn
+    _name.object_id               ambient_temperature_details
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_diffrn.ambient_temperature_gt
+
+    _definition.id                '_diffrn.ambient_temperature_gt'
+
+    loop_
+      _alias.definition_id
+         '_diffrn_ambient_temp_gt'
+         '_diffrn_ambient_temperature_gt'
+         '_diffrn.ambient_temp_gt'
+
+    _definition.update            2012-12-13
+    _description.text
+;
+    Mean temperature above which intensities were measured.
+    These items allow for a temperature range to be given.
+    _diffrn.ambient_temperature should be used in preference to
+    this item when possible.
+;
+    _name.category_id             diffrn
+    _name.object_id               ambient_temperature_gt
+    _type.purpose                 Number
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   kelvins
+
+save_
+
+save_diffrn.ambient_temperature_lt
+
+    _definition.id                '_diffrn.ambient_temperature_lt'
+
+    loop_
+      _alias.definition_id
+         '_diffrn_ambient_temp_lt'
+         '_diffrn_ambient_temperature_lt'
+         '_diffrn.ambient_temp_lt'
+
+    _definition.update            2012-12-13
+    _description.text
+;
+    Mean temperature below which intensities were measured.
+    These items allow for a temperature range to be given.
+    _diffrn.ambient_temperature should be used in preference to
+    this item when possible.
+;
+    _name.category_id             diffrn
+    _name.object_id               ambient_temperature_lt
+    _type.purpose                 Number
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   kelvins
+
+save_
+
+save_diffrn.crystal_id
+
+    _definition.id                '_diffrn.crystal_id'
+    _definition.update            2022-05-09
+    _description.text
+;
+    Identifier for the crystal from which diffraction data were
+    collected. This is a pointer to _exptl_crystal.id.
+;
+    _name.category_id             diffrn
+    _name.object_id               crystal_id
+    _name.linked_item_id          '_exptl_crystal.id'
+    _type.purpose                 Link
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Word
+
+save_
+
+save_diffrn.crystal_support
+
+    _definition.id                '_diffrn.crystal_support'
+    _definition.update            2014-06-12
+    _description.text
+;
+    The physical device used to support the crystal during data
+    collection.
+;
+    _name.category_id             diffrn
+    _name.object_id               crystal_support
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+
+    loop_
+      _description_example.case
+         'glass capillary'
+         'quartz capillary'
+         'fiber'
+         'metal loop'
+
+save_
+
+save_diffrn.crystal_treatment
+
+    _definition.id                '_diffrn.crystal_treatment'
+    _alias.definition_id          '_diffrn_crystal_treatment'
+    _definition.update            2012-11-26
+    _description.text
+;
+    Remarks about how the crystal was treated prior to intensity measurement.
+    Particularly relevant when intensities were measured at low temperature.
+;
+    _name.category_id             diffrn
+    _name.object_id               crystal_treatment
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+
+    loop_
+      _description_example.case
+         'equilibrated in hutch for 24 hours'
+         'flash frozen in liquid nitrogen'
+         'slow cooled with direct air stream'
+
+save_
+
+save_diffrn.id
+
+    _definition.id                '_diffrn.id'
+    _definition.update            2022-05-09
+    _description.text
+;
+    Unique identifier for a diffraction data set collected under
+    particular diffraction conditions.
+;
+    _name.category_id             diffrn
+    _name.object_id               id
+    _type.purpose                 Key
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Word
+
+save_
+
+save_diffrn.measured_fraction_theta_full
+
+    _definition.id                '_diffrn.measured_fraction_theta_full'
+    _alias.definition_id          '_diffrn_measured_fraction_theta_full'
+    _definition.update            2013-01-20
+    _description.text
+;
+    Fraction of unique (symmetry-independent) reflections measured
+    out to _diffrn_reflns.theta_full.
+;
+    _name.category_id             diffrn
+    _name.object_id               measured_fraction_theta_full
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:1.0
+    _units.code                   none
+
+save_
+
+save_diffrn.measured_fraction_theta_max
+
+    _definition.id                '_diffrn.measured_fraction_theta_max'
+    _alias.definition_id          '_diffrn_measured_fraction_theta_max'
+    _definition.update            2013-01-20
+    _description.text
+;
+    Fraction of unique (symmetry-independent) reflections measured
+    out to _diffrn_reflns.theta_max.
+;
+    _name.category_id             diffrn
+    _name.object_id               measured_fraction_theta_max
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:1.0
+    _units.code                   none
+
+save_
+
+save_diffrn.special_details
+
+    _definition.id                '_diffrn.special_details'
+
+    loop_
+      _alias.definition_id
+         '_diffrn_special_details'
+         '_diffrn.details'
+
+    _definition.update            2012-11-26
+    _description.text
+;
+    Special details of the diffraction measurement process. Should include
+    information about source instability, crystal motion, degradation, etc.
+;
+    _name.category_id             diffrn
+    _name.object_id               special_details
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+    _description_example.case
+;
+    The results may not be entirely reliable as the measurement was
+    made during a heat wave when the air-conditioning had failed.
+;
+
+save_
+
+save_diffrn.symmetry_description
+
+    _definition.id                '_diffrn.symmetry_description'
+    _alias.definition_id          '_diffrn_symmetry_description'
+    _definition.update            2012-11-26
+    _description.text
+;
+    Recorded diffraction point symmetry, systematic absences and possible
+    space group(s) or superspace group(s) compatible with these.
+;
+    _name.category_id             diffrn
+    _name.object_id               symmetry_description
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_CELL
+
+    _definition.id                CELL
+    _definition.scope             Category
+    _definition.class             Set
+    _definition.update            2023-03-02
+    _description.text
+;
+    The CATEGORY of data items used to describe the parameters of
+    the crystal unit cell.
+;
+    _name.category_id             DIFFRN
+    _name.object_id               CELL
+    _category_key.name            '_cell.diffrn_id'
+
+save_
+
+save_cell.angle_alpha
+
+    _definition.id                '_cell.angle_alpha'
+    _alias.definition_id          '_cell_angle_alpha'
+    _name.category_id             cell
+    _name.object_id               angle_alpha
+
+    _import.get                   [{'file':templ_attr.cif  'save':cell_angle}]
+
+save_
+
+save_cell.angle_alpha_su
+
+    _definition.id                '_cell.angle_alpha_su'
+
+    loop_
+      _alias.definition_id
+         '_cell_angle_alpha_su'
+         '_cell.angle_alpha_esd'
+
+    _name.category_id             cell
+    _name.object_id               angle_alpha_su
+    _name.linked_item_id          '_cell.angle_alpha'
+
+    _import.get
+        [{'file':templ_attr.cif  'save':cell_angle_su}]
+
+save_
+
+save_cell.angle_beta
+
+    _definition.id                '_cell.angle_beta'
+    _alias.definition_id          '_cell_angle_beta'
+    _name.category_id             cell
+    _name.object_id               angle_beta
+
+    _import.get                   [{'file':templ_attr.cif  'save':cell_angle}]
+
+save_
+
+save_cell.angle_beta_su
+
+    _definition.id                '_cell.angle_beta_su'
+
+    loop_
+      _alias.definition_id
+         '_cell_angle.beta_su'
+         '_cell_angle_beta_su'
+         '_cell.angle_beta_esd'
+
+    _name.category_id             cell
+    _name.object_id               angle_beta_su
+    _name.linked_item_id          '_cell.angle_beta'
+
+    _import.get
+        [{'file':templ_attr.cif  'save':cell_angle_su}]
+
+save_
+
+save_cell.angle_gamma
+
+    _definition.id                '_cell.angle_gamma'
+    _alias.definition_id          '_cell_angle_gamma'
+    _name.category_id             cell
+    _name.object_id               angle_gamma
+
+    _import.get                   [{'file':templ_attr.cif  'save':cell_angle}]
+
+save_
+
+save_cell.angle_gamma_su
+
+    _definition.id                '_cell.angle_gamma_su'
+
+    loop_
+      _alias.definition_id
+         '_cell_angle.gamma_su'
+         '_cell_angle_gamma_su'
+         '_cell.angle_gamma_esd'
+
+    _name.category_id             cell
+    _name.object_id               angle_gamma_su
+    _name.linked_item_id          '_cell.angle_gamma'
+
+    _import.get
+        [{'file':templ_attr.cif  'save':cell_angle_su}]
+
+save_
+
+save_cell.atomic_mass
+
+    _definition.id                '_cell.atomic_mass'
+    _definition.update            2012-11-22
+    _description.text
+;
+    Atomic mass of the contents of the unit cell. This calculated
+    from the atom sites present in the ATOM_TYPE list, rather than
+    the ATOM_SITE lists of atoms in the refined model.
+;
+    _name.category_id             cell
+    _name.object_id               atomic_mass
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   dalton
+    _method.purpose               Evaluation
+    _method.expression
+;
+    mass = 0.
+
+    Loop t as atom_type  {
+
+                   mass += t.number_in_cell * t.atomic_mass
+    }
+      _cell.atomic_mass = mass
+;
+
+save_
+
+save_cell.convert_uij_to_betaij
+
+    _definition.id                '_cell.convert_Uij_to_betaij'
+    _definition.update            2021-09-24
+    _description.text
+;
+    The reciprocal space matrix for converting the U(ij) matrix of
+    atomic displacement parameters to a dimensionless beta(IJ) matrix.
+    The ADP factor in a structure factor expression:
+
+    t = exp - 2π^2^ ( U11 h h a* a* + ...... 2 U23 k l b* c* )
+    t = exp - 0.25  ( B11 h h a* a* + ...... 2 B23 k l b* c* )
+      = exp -       ( β11 h h + ............ 2 β23 k l )
+
+    The conversion of the U or B matrices to the β matrix
+
+        β =   C U C   =    C B C /8π^2^
+
+    where C is conversion matrix defined here.
+;
+    _name.category_id             cell
+    _name.object_id               convert_Uij_to_betaij
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               Matrix
+    _type.dimension               '[3,3]'
+    _type.contents                Real
+    _units.code                   reciprocal_angstroms
+    _method.purpose               Evaluation
+    _method.expression
+;
+    With c  as  cell
+
+    _cell.convert_Uij_to_betaij =                              1.4142 * Pi *
+    Matrix([[ c.reciprocal_length_a, 0, 0 ],
+                [ 0, c.reciprocal_length_b, 0 ],
+                    [ 0, 0, c.reciprocal_length_c ]])
+;
+
+save_
+
+save_cell.convert_uij_to_betaij_su
+
+    _definition.id                '_cell.convert_Uij_to_betaij_su'
+    _definition.update            2023-07-01
+    _description.text
+;
+    Standard uncertainty of _cell.convert_Uij_to_betaij.
+;
+    _name.category_id             cell
+    _name.object_id               convert_Uij_to_betaij_su
+    _name.linked_item_id          '_cell.convert_Uij_to_betaij'
+    _type.purpose                 SU
+    _type.source                  Related
+    _type.container               Matrix
+    _type.dimension               '[3,3]'
+    _type.contents                Real
+    _units.code                   reciprocal_angstroms
+
+save_
+
+save_cell.convert_uiso_to_uij
+
+    _definition.id                '_cell.convert_Uiso_to_Uij'
+    _definition.update            2021-07-07
+    _description.text
+;
+    The reciprocal space matrix for converting the isotropic Uiso
+    atomic displacement parameter to the anisotropic matrix Uij.
+
+                     | 1        cos(γ*)  cos(β*) |
+    U[i,j]  = Uiso * | cos(γ*)  1        cos(α*) |
+                     | cos(β*)  cos(α*)  1       |
+;
+    _name.category_id             cell
+    _name.object_id               convert_Uiso_to_Uij
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               Matrix
+    _type.dimension               '[3,3]'
+    _type.contents                Real
+    _units.code                   none
+    _method.purpose               Evaluation
+    _method.expression
+;
+    With c  as  cell
+
+    _cell.convert_Uiso_to_Uij =                           [[ 1.,
+    Cosd(c.reciprocal_angle_gamma), Cosd(c.reciprocal_angle_beta)  ],
+                 [ Cosd(c.reciprocal_angle_gamma), 1.,
+    Cosd(c.reciprocal_angle_alpha) ],                        [
+    Cosd(c.reciprocal_angle_beta), Cosd(c.reciprocal_angle_alpha), 1.  ]]
+;
+
+save_
+
+save_cell.convert_uiso_to_uij_su
+
+    _definition.id                '_cell.convert_Uiso_to_Uij_su'
+    _definition.update            2023-07-01
+    _description.text
+;
+    Standard uncertainty of _cell.convert_Uiso_to_Uij.
+;
+    _name.category_id             cell
+    _name.object_id               convert_Uiso_to_Uij_su
+    _name.linked_item_id          '_cell.convert_Uiso_to_Uij'
+    _type.purpose                 SU
+    _type.source                  Related
+    _type.container               Matrix
+    _type.dimension               '[3,3]'
+    _type.contents                Real
+    _units.code                   none
+
+save_
+
+save_cell.diffrn_id
+
+    _definition.id                '_cell.diffrn_id'
+    _definition.update            2023-02-01
+    _description.text
+;
+    A pointer to the diffraction conditions to which this cell has been applied,
+    for example, to locate and extract diffraction peaks. These will normally be
+    the same conditions as those under which the cell was measured, but some
+    legacy data sets may have used a cell measured under differing conditions,
+    in which case those conditions should be indicated using the
+    _cell_measurement.condition_id data item.
+;
+    _name.category_id             cell
+    _name.object_id               diffrn_id
+    _name.linked_item_id          '_diffrn.id'
+    _type.purpose                 Link
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Word
+
+save_
+
+save_cell.formula_units_z
+
+    _definition.id                '_cell.formula_units_Z'
+    _alias.definition_id          '_cell_formula_units_Z'
+    _definition.update            2021-03-01
+    _description.text
+;
+    The number of the formula units in the unit cell as specified
+    by _chemical_formula.structural, _chemical_formula.moiety or
+    _chemical_formula.sum.
+;
+    _name.category_id             cell
+    _name.object_id               formula_units_Z
+    _type.purpose                 Number
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Integer
+    _enumeration.range            1:
+    _units.code                   none
+
+save_
+
+save_cell.length_a
+
+    _definition.id                '_cell.length_a'
+    _alias.definition_id          '_cell_length_a'
+    _name.category_id             cell
+    _name.object_id               length_a
+
+    _import.get                   [{'file':templ_attr.cif  'save':cell_length}]
+
+save_
+
+save_cell.length_a_su
+
+    _definition.id                '_cell.length_a_su'
+
+    loop_
+      _alias.definition_id
+         '_cell_length_a_su'
+         '_cell.length_a_esd'
+
+    _name.category_id             cell
+    _name.object_id               length_a_su
+    _name.linked_item_id          '_cell.length_a'
+
+    _import.get
+        [{'file':templ_attr.cif  'save':cell_length_su}]
+
+save_
+
+save_cell.length_b
+
+    _definition.id                '_cell.length_b'
+    _alias.definition_id          '_cell_length_b'
+    _name.category_id             cell
+    _name.object_id               length_b
+
+    _import.get                   [{'file':templ_attr.cif  'save':cell_length}]
+
+save_
+
+save_cell.length_b_su
+
+    _definition.id                '_cell.length_b_su'
+
+    loop_
+      _alias.definition_id
+         '_cell_length_b_su'
+         '_cell.length_b_esd'
+
+    _name.category_id             cell
+    _name.object_id               length_b_su
+    _name.linked_item_id          '_cell.length_b'
+
+    _import.get
+        [{'file':templ_attr.cif  'save':cell_length_su}]
+
+save_
+
+save_cell.length_c
+
+    _definition.id                '_cell.length_c'
+    _alias.definition_id          '_cell_length_c'
+    _name.category_id             cell
+    _name.object_id               length_c
+
+    _import.get                   [{'file':templ_attr.cif  'save':cell_length}]
+
+save_
+
+save_cell.length_c_su
+
+    _definition.id                '_cell.length_c_su'
+
+    loop_
+      _alias.definition_id
+         '_cell_length_c_su'
+         '_cell.length_c_esd'
+
+    _name.category_id             cell
+    _name.object_id               length_c_su
+    _name.linked_item_id          '_cell.length_c'
+
+    _import.get
+        [{'file':templ_attr.cif  'save':cell_length_su}]
+
+save_
+
+save_cell.metric_tensor
+
+    _definition.id                '_cell.metric_tensor'
+    _definition.update            2021-07-07
+    _description.text
+;
+    The direct space (covariant) metric tensor used to transform
+    vectors and coordinates from real (direct) to reciprocal space.
+;
+    _name.category_id             cell
+    _name.object_id               metric_tensor
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Matrix
+    _type.dimension               '[3,3]'
+    _type.contents                Real
+    _units.code                   angstrom_squared
+    _method.purpose               Evaluation
+    _method.expression
+;
+    with c  as  cell
+
+          _cell.metric_tensor = [[ c.vector_a*c.vector_a,
+    c.vector_a*c.vector_b, c.vector_a*c.vector_c ],
+     [ c.vector_b*c.vector_a, c.vector_b*c.vector_b, c.vector_b*c.vector_c ],
+                               [ c.vector_c*c.vector_a, c.vector_c*c.vector_b,
+    c.vector_c*c.vector_c ]]
+;
+
+save_
+
+save_cell.orthogonal_matrix
+
+    _definition.id                '_cell.orthogonal_matrix'
+    _definition.update            2021-07-07
+    _description.text
+;
+    Orthogonal matrix of the crystal unit cell. Definition uses
+    Rollet's axial assignments with cell vectors a,b,c aligned
+    with orthogonal axes X,Y,Z so that c||Z and b in plane YZ.
+;
+    _name.category_id             cell
+    _name.object_id               orthogonal_matrix
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Matrix
+    _type.dimension               '[3,3]'
+    _type.contents                Real
+    _units.code                   angstroms
+    _method.purpose               Evaluation
+    _method.expression
+;
+     With c as cell
+    _cell.orthogonal_matrix =   [
+          [  c.length_a*Sind(c.angle_beta)*Sind(c.reciprocal_angle_gamma), 0,
+                                 0 ],       [
+    -c.length_a*Sind(c.angle_beta)*Cosd(c.reciprocal_angle_gamma),
+    c.length_b*Sind(c.angle_alpha),   0 ],       [
+    c.length_a*Cosd(c.angle_beta),
+    c.length_b*Cosd(c.angle_alpha), c.length_c ]]
+;
+
+save_
+
+save_cell.reciprocal_angle_alpha
+
+    _definition.id                '_cell.reciprocal_angle_alpha'
+    _alias.definition_id          '_cell_reciprocal_angle_alpha'
+    _definition.update            2013-01-18
+    _description.text
+;
+    Reciprocal of the angle between _cell.length_b and _cell.length_c.
+    Ref: Buerger, M. J. (1942). X-ray Crystallography, p. 360.
+         New York: John Wiley & Sons Inc.
+;
+    _name.category_id             cell
+    _name.object_id               reciprocal_angle_alpha
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:180.0
+    _units.code                   degrees
+    _method.purpose               Evaluation
+    _method.expression
+;
+     With c as cell
+
+    _cell.reciprocal_angle_alpha =
+    Acosd((Cosd(c.angle_beta)*Cosd(c.angle_gamma)-Cosd(c.angle_alpha))/
+    (Sind(c.angle_beta)*Sind(c.angle_gamma)))
+;
+
+save_
+
+save_cell.reciprocal_angle_alpha_su
+
+    _definition.id                '_cell.reciprocal_angle_alpha_su'
+
+    loop_
+      _alias.definition_id
+         '_cell_reciprocal_angle_alpha_su'
+         '_cell.reciprocal_angle_alpha_esd'
+
+    _definition.update            2021-03-03
+    _description.text
+;
+    Standard uncertainty of _cell.reciprocal_angle_alpha.
+;
+    _name.category_id             cell
+    _name.object_id               reciprocal_angle_alpha_su
+    _name.linked_item_id          '_cell.reciprocal_angle_alpha'
+    _units.code                   degrees
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+save_
+
+save_cell.reciprocal_angle_beta
+
+    _definition.id                '_cell.reciprocal_angle_beta'
+    _alias.definition_id          '_cell_reciprocal_angle_beta'
+    _definition.update            2013-01-18
+    _description.text
+;
+    Reciprocal of the angle between _cell.length_a and _cell.length_c.
+    Ref: Buerger, M. J. (1942). X-ray Crystallography, p. 360.
+         New York: John Wiley & Sons Inc.
+;
+    _name.category_id             cell
+    _name.object_id               reciprocal_angle_beta
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:180.0
+    _units.code                   degrees
+    _method.purpose               Evaluation
+    _method.expression
+;
+     With c as cell
+
+    _cell.reciprocal_angle_beta =
+    Acosd((Cosd(c.angle_alpha)*Cosd(c.angle_gamma)-Cosd(c.angle_beta))/
+    (Sind(c.angle_alpha)*Sind(c.angle_gamma)))
+;
+
+save_
+
+save_cell.reciprocal_angle_beta_su
+
+    _definition.id                '_cell.reciprocal_angle_beta_su'
+
+    loop_
+      _alias.definition_id
+         '_cell_reciprocal_angle_beta_su'
+         '_cell.reciprocal_angle_beta_esd'
+
+    _definition.update            2021-03-03
+    _description.text
+;
+    Standard uncertainty of _cell.reciprocal_angle_beta.
+;
+    _name.category_id             cell
+    _name.object_id               reciprocal_angle_beta_su
+    _name.linked_item_id          '_cell.reciprocal_angle_beta'
+    _units.code                   degrees
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+save_
+
+save_cell.reciprocal_angle_gamma
+
+    _definition.id                '_cell.reciprocal_angle_gamma'
+    _alias.definition_id          '_cell_reciprocal_angle_gamma'
+    _definition.update            2016-09-09
+    _description.text
+;
+    Reciprocal of the angle between _cell.length_a and _cell.length_b.
+    Ref: Buerger, M. J. (1942). X-ray Crystallography, p. 360.
+         New York: John Wiley & Sons Inc.
+;
+    _name.category_id             cell
+    _name.object_id               reciprocal_angle_gamma
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:180.0
+    _units.code                   degrees
+    _method.purpose               Evaluation
+    _method.expression
+;
+     With c as cell
+
+    _cell.reciprocal_angle_gamma =
+    Acosd((Cosd(c.angle_alpha)*Cosd(c.angle_beta)-Cosd(c.angle_gamma))/
+    (Sind(c.angle_alpha)*Sind(c.angle_beta)))
+;
+
+save_
+
+save_cell.reciprocal_angle_gamma_su
+
+    _definition.id                '_cell.reciprocal_angle_gamma_su'
+
+    loop_
+      _alias.definition_id
+         '_cell_reciprocal_angle_gamma_su'
+         '_cell.reciprocal_angle_gamma_esd'
+
+    _definition.update            2023-07-01
+    _description.text
+;
+    Standard uncertainty of _cell.reciprocal_angle_gamma.
+;
+    _name.category_id             cell
+    _name.object_id               reciprocal_angle_gamma_su
+    _name.linked_item_id          '_cell.reciprocal_angle_gamma'
+    _units.code                   degrees
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+save_
+
+save_cell.reciprocal_length_a
+
+    _definition.id                '_cell.reciprocal_length_a'
+    _alias.definition_id          '_cell_reciprocal_length_a'
+    _definition.update            2012-11-22
+    _description.text
+;
+    Reciprocal of the _cell.length_a.
+;
+    _name.category_id             cell
+    _name.object_id               reciprocal_length_a
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   reciprocal_angstroms
+    _method.purpose               Evaluation
+    _method.expression
+;
+    _cell.reciprocal_length_a = Norm ( _cell.reciprocal_vector_a )
+;
+
+save_
+
+save_cell.reciprocal_length_a_su
+
+    _definition.id                '_cell.reciprocal_length_a_su'
+
+    loop_
+      _alias.definition_id
+         '_cell_reciprocal_length_a_su'
+         '_cell.reciprocal_length_a_esd'
+
+    _definition.update            2021-03-03
+    _description.text
+;
+    Standard uncertainty of _cell.reciprocal_length_a.
+;
+    _name.category_id             cell
+    _name.object_id               reciprocal_length_a_su
+    _name.linked_item_id          '_cell.reciprocal_length_a'
+    _units.code                   reciprocal_angstroms
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+save_
+
+save_cell.reciprocal_length_b
+
+    _definition.id                '_cell.reciprocal_length_b'
+    _alias.definition_id          '_cell_reciprocal_length_b'
+    _definition.update            2012-11-22
+    _description.text
+;
+    Reciprocal of the _cell.length_b.
+;
+    _name.category_id             cell
+    _name.object_id               reciprocal_length_b
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   reciprocal_angstroms
+    _method.purpose               Evaluation
+    _method.expression
+;
+    _cell.reciprocal_length_b = Norm ( _cell.reciprocal_vector_b )
+;
+
+save_
+
+save_cell.reciprocal_length_b_su
+
+    _definition.id                '_cell.reciprocal_length_b_su'
+
+    loop_
+      _alias.definition_id
+         '_cell_reciprocal_length_b_su'
+         '_cell.reciprocal_length_b_esd'
+
+    _definition.update            2021-03-03
+    _description.text
+;
+    Standard uncertainty of _cell.reciprocal_length_b.
+;
+    _name.category_id             cell
+    _name.object_id               reciprocal_length_b_su
+    _name.linked_item_id          '_cell.reciprocal_length_b'
+    _units.code                   reciprocal_angstroms
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+save_
+
+save_cell.reciprocal_length_c
+
+    _definition.id                '_cell.reciprocal_length_c'
+    _alias.definition_id          '_cell_reciprocal_length_c'
+    _definition.update            2012-11-22
+    _description.text
+;
+    Reciprocal of the _cell.length_c.
+;
+    _name.category_id             cell
+    _name.object_id               reciprocal_length_c
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   reciprocal_angstroms
+    _method.purpose               Evaluation
+    _method.expression
+;
+    _cell.reciprocal_length_c = Norm ( _cell.reciprocal_vector_c )
+;
+
+save_
+
+save_cell.reciprocal_length_c_su
+
+    _definition.id                '_cell.reciprocal_length_c_su'
+
+    loop_
+      _alias.definition_id
+         '_cell_reciprocal_length_c_su'
+         '_cell.reciprocal_length_c_esd'
+
+    _definition.update            2023-07-01
+    _description.text
+;
+    Standard uncertainty of _cell.reciprocal_length_c.
+;
+    _name.category_id             cell
+    _name.object_id               reciprocal_length_c_su
+    _name.linked_item_id          '_cell.reciprocal_length_c'
+    _units.code                   reciprocal_angstroms
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+save_
+
+save_cell.reciprocal_metric_tensor
+
+    _definition.id                '_cell.reciprocal_metric_tensor'
+    _definition.update            2021-07-07
+    _description.text
+;
+    The reciprocal (contravariant) metric tensor used to transform
+    vectors and coordinates from reciprocal space to real (direct)
+    space.
+;
+    _name.category_id             cell
+    _name.object_id               reciprocal_metric_tensor
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               Matrix
+    _type.dimension               '[3,3]'
+    _type.contents                Real
+    _units.code                   reciprocal_angstrom_squared
+    _method.purpose               Evaluation
+    _method.expression
+;
+     with c as cell
+    _cell.reciprocal_metric_tensor = [
+         [ c.reciprocal_vector_a*c.reciprocal_vector_a,
+    c.reciprocal_vector_a*c.reciprocal_vector_b,
+    c.reciprocal_vector_a*c.reciprocal_vector_c ],      [
+    c.reciprocal_vector_b*c.reciprocal_vector_a,
+    c.reciprocal_vector_b*c.reciprocal_vector_b,
+    c.reciprocal_vector_b*c.reciprocal_vector_c ],      [
+    c.reciprocal_vector_c*c.reciprocal_vector_a,
+    c.reciprocal_vector_c*c.reciprocal_vector_b,
+    c.reciprocal_vector_c*c.reciprocal_vector_c ]]
+;
+
+save_
+
+save_cell.reciprocal_metric_tensor_su
+
+    _definition.id                '_cell.reciprocal_metric_tensor_su'
+    _definition.update            2023-07-01
+    _description.text
+;
+    Standard uncertainty of _cell.reciprocal_metric_tensor.
+;
+    _name.category_id             cell
+    _name.object_id               reciprocal_metric_tensor_su
+    _name.linked_item_id          '_cell.reciprocal_metric_tensor'
+    _type.purpose                 SU
+    _type.source                  Related
+    _type.container               Matrix
+    _type.dimension               '[3,3]'
+    _type.contents                Real
+    _units.code                   reciprocal_angstrom_squared
+
+save_
+
+save_cell.reciprocal_orthogonal_matrix
+
+    _definition.id                '_cell.reciprocal_orthogonal_matrix'
+    _definition.update            2021-07-07
+    _description.text
+;
+    Orthogonal matrix of the reciprocal space. The matrix may be
+    used to transform the non-orthogonal vector h = (h,k,l) into
+    the orthogonal indices p = (p,q,r)
+
+                    M h = p
+;
+    _name.category_id             cell
+    _name.object_id               reciprocal_orthogonal_matrix
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               Matrix
+    _type.dimension               '[3,3]'
+    _type.contents                Real
+    _units.code                   reciprocal_angstroms
+    _method.purpose               Evaluation
+    _method.expression
+;
+    _cell.reciprocal_orthogonal_matrix  =  Inverse(
+
+                           Transpose( _cell.orthogonal_matrix ))
+;
+
+save_
+
+save_cell.reciprocal_orthogonal_matrix_su
+
+    _definition.id                '_cell.reciprocal_orthogonal_matrix_su'
+    _definition.update            2023-07-01
+    _description.text
+;
+    Standard uncertainty of _cell.reciprocal_orthogonal_matrix.
+;
+    _name.category_id             cell
+    _name.object_id               reciprocal_orthogonal_matrix_su
+    _name.linked_item_id          '_cell.reciprocal_orthogonal_matrix'
+    _type.purpose                 SU
+    _type.source                  Related
+    _type.container               Matrix
+    _type.dimension               '[3,3]'
+    _type.contents                Real
+    _units.code                   reciprocal_angstroms
+
+save_
+
+save_cell.reciprocal_vector_a
+
+    _definition.id                '_cell.reciprocal_vector_a'
+    _definition.update            2021-07-07
+    _description.text
+;
+    Reciprocal of the _cell.vector_a.
+;
+    _name.category_id             cell
+    _name.object_id               reciprocal_vector_a
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               Matrix
+    _type.dimension               '[3]'
+    _type.contents                Real
+    _units.code                   reciprocal_angstroms
+    _method.purpose               Evaluation
+    _method.expression
+;
+     With c  as  cell
+
+    _cell.reciprocal_vector_a = c.vector_b ^ c.vector_c / _cell.volume
+;
+
+save_
+
+save_cell.reciprocal_vector_a_su
+
+    _definition.id                '_cell.reciprocal_vector_a_su'
+    _definition.update            2023-07-01
+    _description.text
+;
+    Standard uncertainty of _cell.reciprocal_vector_a.
+;
+    _name.category_id             cell
+    _name.object_id               reciprocal_vector_a_su
+    _name.linked_item_id          '_cell.reciprocal_vector_a'
+    _type.purpose                 SU
+    _type.source                  Related
+    _type.container               Matrix
+    _type.dimension               '[3]'
+    _type.contents                Real
+    _units.code                   reciprocal_angstroms
+
+save_
+
+save_cell.reciprocal_vector_b
+
+    _definition.id                '_cell.reciprocal_vector_b'
+    _definition.update            2021-07-07
+    _description.text
+;
+    Reciprocal of the _cell.vector_b.
+;
+    _name.category_id             cell
+    _name.object_id               reciprocal_vector_b
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               Matrix
+    _type.dimension               '[3]'
+    _type.contents                Real
+    _units.code                   reciprocal_angstroms
+    _method.purpose               Evaluation
+    _method.expression
+;
+     With c  as  cell
+
+    _cell.reciprocal_vector_b = c.vector_c ^ c.vector_a / _cell.volume
+;
+
+save_
+
+save_cell.reciprocal_vector_b_su
+
+    _definition.id                '_cell.reciprocal_vector_b_su'
+    _definition.update            2023-07-01
+    _description.text
+;
+    Standard uncertainty of _cell.reciprocal_vector_b.
+;
+    _name.category_id             cell
+    _name.object_id               reciprocal_vector_b_su
+    _name.linked_item_id          '_cell.reciprocal_vector_b'
+    _type.purpose                 SU
+    _type.source                  Related
+    _type.container               Matrix
+    _type.dimension               '[3]'
+    _type.contents                Real
+    _units.code                   reciprocal_angstroms
+
+save_
+
+save_cell.reciprocal_vector_c
+
+    _definition.id                '_cell.reciprocal_vector_c'
+    _definition.update            2021-07-07
+    _description.text
+;
+    Reciprocal of the _cell.vector_c.
+;
+    _name.category_id             cell
+    _name.object_id               reciprocal_vector_c
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               Matrix
+    _type.dimension               '[3]'
+    _type.contents                Real
+    _units.code                   reciprocal_angstroms
+    _method.purpose               Evaluation
+    _method.expression
+;
+     With c  as  cell
+
+    _cell.reciprocal_vector_c = c.vector_a ^ c.vector_b / _cell.volume
+;
+
+save_
+
+save_cell.reciprocal_vector_c_su
+
+    _definition.id                '_cell.reciprocal_vector_c_su'
+    _definition.update            2023-07-01
+    _description.text
+;
+    Standard uncertainty of _cell.reciprocal_vector_c.
+;
+    _name.category_id             cell
+    _name.object_id               reciprocal_vector_c_su
+    _name.linked_item_id          '_cell.reciprocal_vector_c'
+    _type.purpose                 SU
+    _type.source                  Related
+    _type.container               Matrix
+    _type.dimension               '[3]'
+    _type.contents                Real
+    _units.code                   reciprocal_angstroms
+
+save_
+
+save_cell.special_details
+
+    _definition.id                '_cell.special_details'
+
+    loop_
+      _alias.definition_id
+         '_cell_special_details'
+         '_cell.details'
+
+    _definition.update            2012-11-22
+    _description.text
+;
+    Description of special aspects of the cell choice, noting
+    possible alternative settings.
+;
+    _name.category_id             cell
+    _name.object_id               special_details
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_cell.vector_a
+
+    _definition.id                '_cell.vector_a'
+    _definition.update            2021-07-07
+    _description.text
+;
+    The cell vector along the x axis.
+;
+    _name.category_id             cell
+    _name.object_id               vector_a
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               Matrix
+    _type.dimension               '[3]'
+    _type.contents                Real
+    _units.code                   angstroms
+    _method.purpose               Evaluation
+    _method.expression
+;
+    _cell.vector_a = _cell.orthogonal_matrix * Matrix([1,0,0])
+;
+
+save_
+
+save_cell.vector_a_su
+
+    _definition.id                '_cell.vector_a_su'
+    _definition.update            2023-07-01
+    _description.text
+;
+    Standard uncertainty of _cell.vector_a.
+;
+    _name.category_id             cell
+    _name.object_id               vector_a_su
+    _name.linked_item_id          '_cell.vector_a'
+    _type.purpose                 SU
+    _type.source                  Related
+    _type.container               Matrix
+    _type.dimension               '[3]'
+    _type.contents                Real
+    _units.code                   angstroms
+
+save_
+
+save_cell.vector_b
+
+    _definition.id                '_cell.vector_b'
+    _definition.update            2021-07-07
+    _description.text
+;
+    The cell vector along the y axis.
+;
+    _name.category_id             cell
+    _name.object_id               vector_b
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               Matrix
+    _type.dimension               '[3]'
+    _type.contents                Real
+    _units.code                   angstroms
+    _method.purpose               Evaluation
+    _method.expression
+;
+    _cell.vector_b = _cell.orthogonal_matrix * Matrix([0,1,0])
+;
+
+save_
+
+save_cell.vector_b_su
+
+    _definition.id                '_cell.vector_b_su'
+    _definition.update            2023-07-01
+    _description.text
+;
+    Standard uncertainty of _cell.vector_b.
+;
+    _name.category_id             cell
+    _name.object_id               vector_b_su
+    _name.linked_item_id          '_cell.vector_b'
+    _type.purpose                 SU
+    _type.source                  Related
+    _type.container               Matrix
+    _type.dimension               '[3]'
+    _type.contents                Real
+    _units.code                   angstroms
+
+save_
+
+save_cell.vector_c
+
+    _definition.id                '_cell.vector_c'
+    _definition.update            2021-07-07
+    _description.text
+;
+    The cell vector along the z axis.
+;
+    _name.category_id             cell
+    _name.object_id               vector_c
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               Matrix
+    _type.dimension               '[3]'
+    _type.contents                Real
+    _units.code                   angstroms
+    _method.purpose               Evaluation
+    _method.expression
+;
+    _cell.vector_c = _cell.orthogonal_matrix * Matrix([0,0,1])
+;
+
+save_
+
+save_cell.vector_c_su
+
+    _definition.id                '_cell.vector_c_su'
+    _definition.update            2023-07-01
+    _description.text
+;
+    Standard uncertainty of _cell.vector_c.
+;
+    _name.category_id             cell
+    _name.object_id               vector_c_su
+    _name.linked_item_id          '_cell.vector_c'
+    _type.purpose                 SU
+    _type.source                  Related
+    _type.container               Matrix
+    _type.dimension               '[3]'
+    _type.contents                Real
+    _units.code                   angstroms
+
+save_
+
+save_cell.volume
+
+    _definition.id                '_cell.volume'
+    _alias.definition_id          '_cell_volume'
+    _definition.update            2013-03-07
+    _description.text
+;
+    Volume of the crystal unit cell.
+;
+    _name.category_id             cell
+    _name.object_id               volume
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   angstrom_cubed
+    _method.purpose               Evaluation
+    _method.expression
+;
+    With c  as  cell
+
+    _cell.volume =  c.vector_a * ( c.vector_b ^ c.vector_c )
+;
+
+save_
+
+save_cell.volume_su
+
+    _definition.id                '_cell.volume_su'
+
+    loop_
+      _alias.definition_id
+         '_cell_volume_su'
+         '_cell.volume_esd'
+
+    _definition.update            2014-06-08
+    _description.text
+;
+    Standard uncertainty of _cell.volume.
+;
+    _name.category_id             cell
+    _name.object_id               volume_su
+    _name.linked_item_id          '_cell.volume'
+    _units.code                   angstrom_cubed
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+save_
+
+save_CELL_MEASUREMENT
+
+    _definition.id                CELL_MEASUREMENT
+    _definition.scope             Category
+    _definition.class             Set
+    _definition.update            2022-05-25
+    _description.text
+;
+    The CATEGORY of data items used to describe the measurement of
+    the cell parameters.
+;
+    _name.category_id             CELL
+    _name.object_id               CELL_MEASUREMENT
+    _category_key.name            '_cell_measurement.diffrn_id'
+
+save_
+
+save_cell_measurement.condition_id
+
+    _definition.id                '_cell_measurement.condition_id'
+    _definition.update            2023-02-01
+    _description.text
+;
+    A pointer to the diffraction conditions used for cell measurement,
+    where different to the diffraction conditions used for data
+    collection.
+;
+    _name.category_id             cell_measurement
+    _name.object_id               condition_id
+    _name.linked_item_id          '_diffrn.id'
+    _type.purpose                 Link
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Word
+    _method.purpose               Definition
+    _method.expression
+;
+    _enumeration.default = _cell_measurement.diffrn_id
+;
+
+save_
+
+save_cell_measurement.diffrn_id
+
+    _definition.id                '_cell_measurement.diffrn_id'
+    _definition.update            2023-02-01
+    _description.text
+;
+    A pointer to the diffraction experiment to which the measured cell
+    has been applied.
+;
+    _name.category_id             cell_measurement
+    _name.object_id               diffrn_id
+    _name.linked_item_id          '_diffrn.id'
+    _type.purpose                 Link
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Word
+
+save_
+
+save_cell_measurement.pressure
+
+    _definition.id                '_cell_measurement.pressure'
+    _definition_replaced.id       1
+    _definition_replaced.by       '_diffrn.ambient_pressure'
+    _alias.definition_id          '_cell_measurement_pressure'
+    _definition.update            2022-05-25
+    _description.text
+;
+    **DEPRECATED**
+
+    The pressure at which the unit-cell parameters were measured
+    (not the pressure used to synthesize the sample).
+    Replaced by '_diffrn.ambient_pressure'
+;
+    _name.category_id             cell_measurement
+    _name.object_id               pressure
+    _type.purpose                 Measurand
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   kilopascals
+
+save_
+
+save_cell_measurement.pressure_su
+
+    _definition.id                '_cell_measurement.pressure_su'
+    _definition_replaced.id       1
+    _definition_replaced.by       '_diffrn.ambient_pressure_su'
+
+    loop_
+      _alias.definition_id
+         '_cell_measurement_pressure_su'
+         '_cell_measurement.pressure_esd'
+
+    _definition.update            2022-05-22
+    _description.text
+;
+    ** DEPRECATED **
+
+    Standard uncertainty of _cell_measurement.pressure.
+;
+    _name.category_id             cell_measurement
+    _name.object_id               pressure_su
+    _name.linked_item_id          '_cell_measurement.pressure'
+    _units.code                   kilopascals
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+save_
+
+save_cell_measurement.radiation
+
+    _definition.id                '_cell_measurement.radiation'
+    _definition_replaced.id       1
+    _definition_replaced.by       .
+    _alias.definition_id          '_cell_measurement_radiation'
+    _definition.update            2022-05-22
+    _description.text
+;
+    ** DEPRECATED **
+
+    Description of the radiation used to measure the unit-cell data.
+    Items from the DIFFRN_RADIATION category should be used instead
+    of this item.
+;
+    _name.category_id             cell_measurement
+    _name.object_id               radiation
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+
+    loop_
+      _description_example.case
+         'neutron'
+         'X-ray tube'
+         'synchrotron'
+
+save_
+
+save_cell_measurement.reflns_used
+
+    _definition.id                '_cell_measurement.reflns_used'
+    _alias.definition_id          '_cell_measurement_reflns_used'
+    _definition.update            2021-03-01
+    _description.text
+;
+    Total number of reflections used to determine the unit cell.
+    The reflections may be specified as cell_measurement_refln items.
+;
+    _name.category_id             cell_measurement
+    _name.object_id               reflns_used
+    _type.purpose                 Number
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Integer
+    _enumeration.range            3:
+    _units.code                   none
+
+save_
+
+save_cell_measurement.temperature
+
+    _definition.id                '_cell_measurement.temperature'
+    _definition_replaced.id       1
+    _definition_replaced.by       '_diffrn.ambient_temperature'
+
+    loop_
+      _alias.definition_id
+         '_cell_measurement_temperature'
+         '_cell_measurement_temp'
+         '_cell_measurement.temp'
+
+    _definition.update            2022-05-25
+    _description.text
+;
+    ** DEPRECATED **
+
+    The temperature at which the unit-cell parameters were measured
+    (not the temperature of synthesis).
+    _diffrn.ambient_temperature should be used instead of this item.
+;
+    _name.category_id             cell_measurement
+    _name.object_id               temperature
+    _type.purpose                 Measurand
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   kelvins
+
+save_
+
+save_cell_measurement.temperature_su
+
+    _definition.id                '_cell_measurement.temperature_su'
+    _definition_replaced.id       1
+    _definition_replaced.by       '_diffrn.ambient_temperature_su'
+
+    loop_
+      _alias.definition_id
+         '_cell_measurement_temp_su'
+         '_cell_measurement.temp_esd'
+
+    _definition.update            2022-05-22
+    _description.text
+;
+    ** DEPRECATED **
+
+    Standard uncertainty of _cell_measurement.temperature.
+;
+    _name.category_id             cell_measurement
+    _name.object_id               temperature_su
+    _name.linked_item_id          '_cell_measurement.temperature'
+    _units.code                   kelvins
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+save_
+
+save_cell_measurement.theta_max
+
+    _definition.id                '_cell_measurement.theta_max'
+    _alias.definition_id          '_cell_measurement_theta_max'
+    _definition.update            2012-11-22
+    _description.text
+;
+    Maximum θ scattering angle of reflections used to measure
+    the crystal unit cell.
+;
+    _name.category_id             cell_measurement
+    _name.object_id               theta_max
+    _type.purpose                 Number
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:90.0
+    _units.code                   degrees
+
+save_
+
+save_cell_measurement.theta_min
+
+    _definition.id                '_cell_measurement.theta_min'
+    _alias.definition_id          '_cell_measurement_theta_min'
+    _definition.update            2012-11-22
+    _description.text
+;
+    Minimum θ scattering angle of reflections used to measure
+    the crystal unit cell.
+;
+    _name.category_id             cell_measurement
+    _name.object_id               theta_min
+    _type.purpose                 Number
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:90.0
+    _units.code                   degrees
+
+save_
+
+save_cell_measurement.wavelength
+
+    _definition.id                '_cell_measurement.wavelength'
+    _definition_replaced.id       1
+    _definition_replaced.by       '_diffrn_radiation_wavelength.value'
+    _alias.definition_id          '_cell_measurement_wavelength'
+    _definition.update            2024-07-17
+    _description.text
+;
+    ** DEPRECATED **
+
+    Wavelength of the radiation used to measure the unit cell.
+    Items from the DIFFRN_RADIATION_WAVELENGTH category should
+    be used instead of this item.
+;
+    _name.category_id             cell_measurement
+    _name.object_id               wavelength
+    _type.purpose                 Measurand
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   angstroms
+
+save_
+
+save_cell_measurement.wavelength_su
+
+    _definition.id                '_cell_measurement.wavelength_su'
+    _definition_replaced.id       1
+    _definition_replaced.by       '_diffrn_radiation_wavelength.value_su'
+    _definition.update            2024-07-17
+    _description.text
+;
+    ** DEPRECATED **
+
+    Standard uncertainty of _cell_measurement.wavelength.
+;
+    _name.category_id             cell_measurement
+    _name.object_id               wavelength_su
+    _name.linked_item_id          '_cell_measurement.wavelength'
+    _units.code                   angstroms
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+save_
+
+save_CELL_MEASUREMENT_REFLN
+
+    _definition.id                CELL_MEASUREMENT_REFLN
+    _definition.scope             Category
+    _definition.class             Loop
+    _definition.update            2021-06-29
+    _description.text
+;
+    The CATEGORY of data items used to describe the reflection data
+    used in the measurement of the crystal unit cell.
+;
+    _name.category_id             CELL_MEASUREMENT
+    _name.object_id               CELL_MEASUREMENT_REFLN
+
+    loop_
+      _category_key.name
+         '_cell_measurement_refln.index_h'
+         '_cell_measurement_refln.index_k'
+         '_cell_measurement_refln.index_l'
+
+save_
+
+save_cell_measurement_refln.hkl
+
+    _definition.id                '_cell_measurement_refln.hkl'
+    _definition.update            2021-03-01
+    _description.text
+;
+    Miller indices of a reflection used to measure the unit cell.
+;
+    _name.category_id             cell_measurement_refln
+    _name.object_id               hkl
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Matrix
+    _type.dimension               '[3]'
+    _type.contents                Integer
+    _units.code                   none
+    _method.purpose               Evaluation
+    _method.expression
+;
+    With c  as  cell_measurement_refln
+
+    _cell_measurement_refln.hkl = [c.index_h, c.index_k, c.index_l]
+;
+
+save_
+
+save_cell_measurement_refln.index_h
+
+    _definition.id                '_cell_measurement_refln.index_h'
+    _alias.definition_id          '_cell_measurement_refln_index_h'
+    _name.category_id             cell_measurement_refln
+    _name.object_id               index_h
+
+    _import.get                   [{'file':templ_attr.cif  'save':miller_index}]
+
+save_
+
+save_cell_measurement_refln.index_k
+
+    _definition.id                '_cell_measurement_refln.index_k'
+    _alias.definition_id          '_cell_measurement_refln_index_k'
+    _name.category_id             cell_measurement_refln
+    _name.object_id               index_k
+
+    _import.get                   [{'file':templ_attr.cif  'save':miller_index}]
+
+save_
+
+save_cell_measurement_refln.index_l
+
+    _definition.id                '_cell_measurement_refln.index_l'
+    _alias.definition_id          '_cell_measurement_refln_index_l'
+    _name.category_id             cell_measurement_refln
+    _name.object_id               index_l
+
+    _import.get                   [{'file':templ_attr.cif  'save':miller_index}]
+
+save_
+
+save_cell_measurement_refln.theta
+
+    _definition.id                '_cell_measurement_refln.theta'
+    _alias.definition_id          '_cell_measurement_refln_theta'
+    _definition.update            2012-11-22
+    _description.text
+;
+    Theta angle of reflection used to measure the crystal unit cell.
+;
+    _name.category_id             cell_measurement_refln
+    _name.object_id               theta
+    _type.purpose                 Measurand
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:90.0
+    _units.code                   degrees
+
+save_
+
+save_cell_measurement_refln.theta_su
+
+    _definition.id                '_cell_measurement_refln.theta_su'
+    _definition.update            2023-07-01
+    _description.text
+;
+    Standard uncertainty of _cell_measurement_refln.theta.
+;
+    _name.category_id             cell_measurement_refln
+    _name.object_id               theta_su
+    _name.linked_item_id          '_cell_measurement_refln.theta'
+    _units.code                   degrees
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+save_
+
+save_DIFFRN_ATTENUATOR
+
+    _definition.id                DIFFRN_ATTENUATOR
+    _definition.scope             Category
+    _definition.class             Loop
+    _definition.update            2021-06-29
+    _description.text
+;
+    The CATEGORY of data items which specify the attenuators used in the
+    diffraction source.
+;
+    _name.category_id             DIFFRN
+    _name.object_id               DIFFRN_ATTENUATOR
+    _category_key.name            '_diffrn_attenuator.code'
+
+save_
+
+save_diffrn_attenuator.code
+
+    _definition.id                '_diffrn_attenuator.code'
+    _alias.definition_id          '_diffrn_attenuator_code'
+    _definition.update            2012-11-26
+    _description.text
+;
+    Code identifying a particular attenuator setting; referenced by the
+    _diffrn_refln.attenuator_code which is stored with the intensities.
+;
+    _name.category_id             diffrn_attenuator
+    _name.object_id               code
+    _type.purpose                 Encode
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Word
+
+save_
+
+save_diffrn_attenuator.material
+
+    _definition.id                '_diffrn_attenuator.material'
+    _alias.definition_id          '_diffrn_attenuator_material'
+    _definition.update            2012-11-26
+    _description.text
+;
+    Description of the material from which the attenuator is made.
+;
+    _name.category_id             diffrn_attenuator
+    _name.object_id               material
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_diffrn_attenuator.scale
+
+    _definition.id                '_diffrn_attenuator.scale'
+    _alias.definition_id          '_diffrn_attenuator_scale'
+    _definition.update            2012-11-26
+    _description.text
+;
+    The scale factor applied to a measured intensity if it is reduced by
+    an attenuator identified by _diffrn_attenuator.code.
+;
+    _name.category_id             diffrn_attenuator
+    _name.object_id               scale
+    _type.purpose                 Number
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            1.0:
+    _units.code                   none
+
+save_
+
+save_DIFFRN_DETECTOR
+
+    _definition.id                DIFFRN_DETECTOR
+    _definition.scope             Category
+    _definition.class             Set
+    _definition.update            2023-01-13
+    _description.text
+;
+    The CATEGORY of data items which specify the detectors used
+    in the measurement of diffraction intensities.
+;
+    _name.category_id             DIFFRN
+    _name.object_id               DIFFRN_DETECTOR
+
+save_
+
+save_diffrn_detector.area_resol_mean
+
+    _definition.id                '_diffrn_detector.area_resol_mean'
+    _alias.definition_id          '_diffrn_detector_area_resol_mean'
+    _definition.update            2012-11-26
+    _description.text
+;
+    The resolution limit of an area diffraction radiation detector.
+;
+    _name.category_id             diffrn_detector
+    _name.object_id               area_resol_mean
+    _type.purpose                 Number
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   pixels_per_millimetre
+
+save_
+
+save_diffrn_detector.description
+
+    _definition.id                '_diffrn_detector.description'
+
+    loop_
+      _alias.definition_id
+      _alias.deprecation_date
+         '_diffrn_radiation_detector'                                1997-01-20
+         '_diffrn_detector'                                          .
+         '_diffrn_detector.detector'                                 .
+
+    _definition.update            2024-02-14
+    _description.text
+;
+    Description of the type of diffraction radiation detector.
+;
+    _name.category_id             diffrn_detector
+    _name.object_id               description
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+
+    loop_
+      _description_example.case
+         'photographic film'
+         'scintillation counter'
+         'CCD plate'
+         'BF~3~ counter'
+
+save_
+
+save_diffrn_detector.details
+
+    _definition.id                '_diffrn_detector.details'
+    _alias.definition_id          '_diffrn_detector_details'
+    _definition.update            2012-11-26
+    _description.text
+;
+    Description of special aspects of the radiation detector.
+;
+    _name.category_id             diffrn_detector
+    _name.object_id               details
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_diffrn_detector.dtime
+
+    _definition.id                '_diffrn_detector.dtime'
+
+    loop_
+      _alias.definition_id
+      _alias.deprecation_date
+         '_diffrn_detector_dtime'                                    .
+         '_diffrn_radiation.detector_dtime'                          .
+         '_diffrn_radiation_detector_dtime'                          1997-01-20
+
+    _definition.update            2024-02-14
+    _description.text
+;
+    The maximum time between two detector signals that cannot be resolved.
+;
+    _name.category_id             diffrn_detector
+    _name.object_id               dtime
+    _type.purpose                 Number
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   microseconds
+
+save_
+
+save_diffrn_detector.make
+
+    _definition.id                '_diffrn_detector.make'
+
+    loop_
+      _alias.definition_id
+         '_diffrn_detector_type'
+         '_diffrn_detector.type'
+
+    _definition.update            2012-11-26
+    _description.text
+;
+    The make, model or name of the diffraction radiation detector.
+;
+    _name.category_id             diffrn_detector
+    _name.object_id               make
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_DIFFRN_MEASUREMENT
+
+    _definition.id                DIFFRN_MEASUREMENT
+    _definition.scope             Category
+    _definition.class             Set
+    _definition.update            2012-11-26
+    _description.text
+;
+    The CATEGORY of data items which specify the details of the
+    diffraction measurement.
+;
+    _name.category_id             DIFFRN
+    _name.object_id               DIFFRN_MEASUREMENT
+
+save_
+
+save_diffrn_measurement.details
+
+    _definition.id                '_diffrn_measurement.details'
+
+    loop_
+      _alias.definition_id
+         '_diffrn_measurement_details'
+         '_diffrn.measurement_details'
+
+    _definition.update            2012-11-26
+    _description.text
+;
+    Description of special aspects of the diffraction measurement.
+;
+    _name.category_id             diffrn_measurement
+    _name.object_id               details
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+    _description_example.case     '440 frames of 0.25°'
+
+save_
+
+save_diffrn_measurement.device_class
+
+    _definition.id                '_diffrn_measurement.device_class'
+
+    loop_
+      _alias.definition_id
+         '_diffrn_measurement_device'
+         '_diffrn.measurement_device_class'
+         '_diffrn_measurement.device'
+
+    _definition.update            2012-11-26
+    _description.text
+;
+    Type of goniometer device used to mount and orient the specimen.
+;
+    _name.category_id             diffrn_measurement
+    _name.object_id               device_class
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+
+    loop_
+      _description_example.case
+         'three-circle diffractometer'
+         'four-circle diffractometer'
+         'κ-geometry diffractometer'
+         'oscillation camera'
+         'precession camera'
+
+save_
+
+save_diffrn_measurement.device_details
+
+    _definition.id                '_diffrn_measurement.device_details'
+
+    loop_
+      _alias.definition_id
+         '_diffrn_measurement_device_details'
+         '_diffrn.measurement_device_details'
+
+    _definition.update            2012-11-26
+    _description.text
+;
+    Details of the goniometer device used in the diffraction experiment.
+;
+    _name.category_id             diffrn_measurement
+    _name.object_id               device_details
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+    _description_example.case
+        'commercial goniometer modified locally to allow for 90° θ arc'
+
+save_
+
+save_diffrn_measurement.device_make
+
+    _definition.id                '_diffrn_measurement.device_make'
+
+    loop_
+      _alias.definition_id
+         '_diffrn_measurement_device_type'
+         '_diffrn.measurement_device_make'
+         '_diffrn_measurement.device_type'
+
+    _definition.update            2013-03-07
+    _description.text
+;
+    The make, model or name of the goniometer device used.
+;
+    _name.category_id             diffrn_measurement
+    _name.object_id               device_make
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+
+    loop_
+      _description_example.case
+         'Supper model q'
+         'Huber model r'
+         'Enraf-Nonius model s'
+         'home-made'
+
+save_
+
+save_diffrn_measurement.method
+
+    _definition.id                '_diffrn_measurement.method'
+
+    loop_
+      _alias.definition_id
+         '_diffrn_measurement_method'
+         '_diffrn.measurement_method'
+
+    _definition.update            2012-11-26
+    _description.text
+;
+    Description of scan method used to measure diffraction intensities.
+;
+    _name.category_id             diffrn_measurement
+    _name.object_id               method
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+    _description_example.case     'profile data from θ/2θ scans'
+
+save_
+
+save_diffrn_measurement.specimen_attachment_type
+
+    _definition.id                '_diffrn_measurement.specimen_attachment_type'
+    _definition.update            2023-02-06
+    _description.text
+;
+    The way in which the sample is attached to the sample holder,
+    including the type of adhesive material used if relevant. The sample
+    holder is usually wholly outside the beam, whereas the attachment
+    method may cause non-sample material to be illuminated. If the
+    attachment method is not included in the list below, 'other' should be
+    chosen and details provided in _diffrn_measurement.specimen_support.
+;
+    _name.category_id             diffrn_measurement
+    _name.object_id               specimen_attachment_type
+    _type.purpose                 State
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Word
+
+    loop_
+      _enumeration_set.state
+      _enumeration_set.detail
+         epoxy
+;
+         An epoxy glue.
+;
+         oil
+;
+         An oil.
+;
+         grease
+;
+         A type of grease, for example hydrocarbon or silicone grease.
+;
+         frozen_liquid
+;
+         A frozen liquid, not water or oil.
+;
+         other
+;
+         A method not listed here.
+;
+         ice
+;
+         The specimen is frozen in place using water ice.
+;
+         mechanical
+;
+         The specimen is held in place by mechanical forces, e.g. capillary or
+         pressure cell.
+;
+
+save_
+
+save_diffrn_measurement.specimen_support
+
+    _definition.id                '_diffrn_measurement.specimen_support'
+
+    loop_
+      _alias.definition_id
+         '_diffrn_measurement_specimen_support'
+         '_diffrn.measurement_specimen_support'
+
+    _definition.update            2013-01-23
+    _description.text
+;
+    Mounting method for the crystal specimen during data collection.
+;
+    _name.category_id             diffrn_measurement
+    _name.object_id               specimen_support
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+
+    loop_
+      _description_example.case
+         'glass capillary'
+         'quartz capillary'
+         'fiber'
+         'metal loop'
+
+save_
+
+save_DIFFRN_ORIENT
+
+    _definition.id                DIFFRN_ORIENT
+    _definition.scope             Category
+    _definition.class             Set
+    _definition.update            2012-11-26
+    _description.text
+;
+    The CATEGORY of data items which specify the orientation of the crystal
+    axes to the diffractometer goniometer.
+;
+    _name.category_id             DIFFRN
+    _name.object_id               DIFFRN_ORIENT
+
+save_
+
+save_DIFFRN_ORIENT_MATRIX
+
+    _definition.id                DIFFRN_ORIENT_MATRIX
+    _definition.scope             Category
+    _definition.class             Set
+    _definition.update            2012-11-26
+    _description.text
+;
+    The CATEGORY of data items which specify the matrix specifying the
+    orientation of the crystal axes to the diffractometer goniometer.
+;
+    _name.category_id             DIFFRN_ORIENT
+    _name.object_id               DIFFRN_ORIENT_MATRIX
+
+save_
+
+save_diffrn_orient_matrix.type
+
+    _definition.id                '_diffrn_orient_matrix.type'
+    _alias.definition_id          '_diffrn_orient_matrix_type'
+    _definition.update            2012-11-26
+    _description.text
+;
+    Description of orientation matrix and how it should be applied to define
+    the orientation of the crystal with respect to the diffractometer axes.
+;
+    _name.category_id             diffrn_orient_matrix
+    _name.object_id               type
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_diffrn_orient_matrix.ub_11
+
+    _definition.id                '_diffrn_orient_matrix.UB_11'
+
+    loop_
+      _alias.definition_id
+         '_diffrn_orient_matrix_UB_11'
+         '_diffrn_orient_matrix.UB[1][1]'
+
+    _name.category_id             diffrn_orient_matrix
+    _name.object_id               UB_11
+
+    _import.get
+        [{'file':templ_attr.cif  'save':orient_matrix}]
+
+save_
+
+save_diffrn_orient_matrix.ub_12
+
+    _definition.id                '_diffrn_orient_matrix.UB_12'
+
+    loop_
+      _alias.definition_id
+         '_diffrn_orient_matrix_UB_12'
+         '_diffrn_orient_matrix.UB[1][2]'
+
+    _name.category_id             diffrn_orient_matrix
+    _name.object_id               UB_12
+
+    _import.get
+        [{'file':templ_attr.cif  'save':orient_matrix}]
+
+save_
+
+save_diffrn_orient_matrix.ub_13
+
+    _definition.id                '_diffrn_orient_matrix.UB_13'
+
+    loop_
+      _alias.definition_id
+         '_diffrn_orient_matrix_UB_13'
+         '_diffrn_orient_matrix.UB[1][3]'
+
+    _name.category_id             diffrn_orient_matrix
+    _name.object_id               UB_13
+
+    _import.get
+        [{'file':templ_attr.cif  'save':orient_matrix}]
+
+save_
+
+save_diffrn_orient_matrix.ub_21
+
+    _definition.id                '_diffrn_orient_matrix.UB_21'
+
+    loop_
+      _alias.definition_id
+         '_diffrn_orient_matrix_UB_21'
+         '_diffrn_orient_matrix.UB[2][1]'
+
+    _name.category_id             diffrn_orient_matrix
+    _name.object_id               UB_21
+
+    _import.get
+        [{'file':templ_attr.cif  'save':orient_matrix}]
+
+save_
+
+save_diffrn_orient_matrix.ub_22
+
+    _definition.id                '_diffrn_orient_matrix.UB_22'
+
+    loop_
+      _alias.definition_id
+         '_diffrn_orient_matrix_UB_22'
+         '_diffrn_orient_matrix.UB[2][2]'
+
+    _name.category_id             diffrn_orient_matrix
+    _name.object_id               UB_22
+
+    _import.get
+        [{'file':templ_attr.cif  'save':orient_matrix}]
+
+save_
+
+save_diffrn_orient_matrix.ub_23
+
+    _definition.id                '_diffrn_orient_matrix.UB_23'
+
+    loop_
+      _alias.definition_id
+         '_diffrn_orient_matrix_UB_23'
+         '_diffrn_orient_matrix.UB[2][3]'
+
+    _name.category_id             diffrn_orient_matrix
+    _name.object_id               UB_23
+
+    _import.get
+        [{'file':templ_attr.cif  'save':orient_matrix}]
+
+save_
+
+save_diffrn_orient_matrix.ub_31
+
+    _definition.id                '_diffrn_orient_matrix.UB_31'
+
+    loop_
+      _alias.definition_id
+         '_diffrn_orient_matrix_UB_31'
+         '_diffrn_orient_matrix.UB[3][1]'
+
+    _name.category_id             diffrn_orient_matrix
+    _name.object_id               UB_31
+
+    _import.get
+        [{'file':templ_attr.cif  'save':orient_matrix}]
+
+save_
+
+save_diffrn_orient_matrix.ub_32
+
+    _definition.id                '_diffrn_orient_matrix.UB_32'
+
+    loop_
+      _alias.definition_id
+         '_diffrn_orient_matrix_UB_32'
+         '_diffrn_orient_matrix.UB[3][2]'
+
+    _name.category_id             diffrn_orient_matrix
+    _name.object_id               UB_32
+
+    _import.get
+        [{'file':templ_attr.cif  'save':orient_matrix}]
+
+save_
+
+save_diffrn_orient_matrix.ub_33
+
+    _definition.id                '_diffrn_orient_matrix.UB_33'
+
+    loop_
+      _alias.definition_id
+         '_diffrn_orient_matrix_UB_33'
+         '_diffrn_orient_matrix.UB[3][3]'
+
+    _name.category_id             diffrn_orient_matrix
+    _name.object_id               UB_33
+
+    _import.get
+        [{'file':templ_attr.cif  'save':orient_matrix}]
+
+save_
+
+save_diffrn_orient_matrix.ubij
+
+    _definition.id                '_diffrn_orient_matrix.UBij'
+    _definition.update            2021-03-01
+    _description.text
+;
+    The 3x3 matrix specifying the orientation of the crystal with
+    respect to the diffractometer axes.
+;
+    _name.category_id             diffrn_orient_matrix
+    _name.object_id               UBij
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Matrix
+    _type.dimension               '[3,3]'
+    _type.contents                Real
+    _units.code                   none
+    _method.purpose               Evaluation
+    _method.expression
+;
+    With  o  as  diffrn_orient_matrix
+
+     _diffrn_orient_matrix.UBIJ  =   [[ o.ub_11, o.ub_12, o.ub_13 ],
+                                      [ o.ub_21, o.ub_22, o.ub_23 ],
+                                      [ o.ub_31, o.ub_32, o.ub_33 ]]
+;
+
+save_
+
+save_DIFFRN_ORIENT_REFLN
+
+    _definition.id                DIFFRN_ORIENT_REFLN
+    _definition.scope             Category
+    _definition.class             Loop
+    _definition.update            2021-06-29
+    _description.text
+;
+    The CATEGORY of data items which specify the reflections used to
+    calculate the matrix which gives the orientation of the crystal
+    axes to the diffractometer goniometer.
+;
+    _name.category_id             DIFFRN_ORIENT
+    _name.object_id               DIFFRN_ORIENT_REFLN
+
+    loop_
+      _category_key.name
+         '_diffrn_orient_refln.index_h'
+         '_diffrn_orient_refln.index_k'
+         '_diffrn_orient_refln.index_l'
+
+save_
+
+save_diffrn_orient_refln.angle_chi
+
+    _definition.id                '_diffrn_orient_refln.angle_chi'
+    _alias.definition_id          '_diffrn_orient_refln_angle_chi'
+    _name.category_id             diffrn_orient_refln
+    _name.object_id               angle_chi
+
+    _import.get                   [{'file':templ_attr.cif  'save':orient_angle}]
+
+save_
+
+save_diffrn_orient_refln.angle_chi_su
+
+    _definition.id                '_diffrn_orient_refln.angle_chi_su'
+    _definition.update            2023-07-01
+    _description.text
+;
+    Standard uncertainty of _diffrn_orient_refln.angle_chi.
+;
+    _name.category_id             diffrn_orient_refln
+    _name.object_id               angle_chi_su
+    _name.linked_item_id          '_diffrn_orient_refln.angle_chi'
+    _units.code                   degrees
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+save_
+
+save_diffrn_orient_refln.angle_kappa
+
+    _definition.id                '_diffrn_orient_refln.angle_kappa'
+    _alias.definition_id          '_diffrn_orient_refln_angle_kappa'
+    _name.category_id             diffrn_orient_refln
+    _name.object_id               angle_kappa
+
+    _import.get                   [{'file':templ_attr.cif  'save':orient_angle}]
+
+save_
+
+save_diffrn_orient_refln.angle_kappa_su
+
+    _definition.id                '_diffrn_orient_refln.angle_kappa_su'
+    _definition.update            2023-07-01
+    _description.text
+;
+    Standard uncertainty of _diffrn_orient_refln.angle_kappa.
+;
+    _name.category_id             diffrn_orient_refln
+    _name.object_id               angle_kappa_su
+    _name.linked_item_id          '_diffrn_orient_refln.angle_kappa'
+    _units.code                   degrees
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+save_
+
+save_diffrn_orient_refln.angle_omega
+
+    _definition.id                '_diffrn_orient_refln.angle_omega'
+    _alias.definition_id          '_diffrn_orient_refln_angle_omega'
+    _name.category_id             diffrn_orient_refln
+    _name.object_id               angle_omega
+
+    _import.get                   [{'file':templ_attr.cif  'save':orient_angle}]
+
+save_
+
+save_diffrn_orient_refln.angle_omega_su
+
+    _definition.id                '_diffrn_orient_refln.angle_omega_su'
+    _definition.update            2023-07-01
+    _description.text
+;
+    Standard uncertainty of _diffrn_orient_refln.angle_omega.
+;
+    _name.category_id             diffrn_orient_refln
+    _name.object_id               angle_omega_su
+    _name.linked_item_id          '_diffrn_orient_refln.angle_omega'
+    _units.code                   degrees
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+save_
+
+save_diffrn_orient_refln.angle_phi
+
+    _definition.id                '_diffrn_orient_refln.angle_phi'
+    _alias.definition_id          '_diffrn_orient_refln_angle_phi'
+    _name.category_id             diffrn_orient_refln
+    _name.object_id               angle_phi
+
+    _import.get                   [{'file':templ_attr.cif  'save':orient_angle}]
+
+save_
+
+save_diffrn_orient_refln.angle_phi_su
+
+    _definition.id                '_diffrn_orient_refln.angle_phi_su'
+    _definition.update            2023-07-01
+    _description.text
+;
+    Standard uncertainty of _diffrn_orient_refln.angle_phi.
+;
+    _name.category_id             diffrn_orient_refln
+    _name.object_id               angle_phi_su
+    _name.linked_item_id          '_diffrn_orient_refln.angle_phi'
+    _units.code                   degrees
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+save_
+
+save_diffrn_orient_refln.angle_psi
+
+    _definition.id                '_diffrn_orient_refln.angle_psi'
+    _alias.definition_id          '_diffrn_orient_refln_angle_psi'
+    _name.category_id             diffrn_orient_refln
+    _name.object_id               angle_psi
+
+    _import.get                   [{'file':templ_attr.cif  'save':orient_angle}]
+
+save_
+
+save_diffrn_orient_refln.angle_psi_su
+
+    _definition.id                '_diffrn_orient_refln.angle_psi_su'
+    _definition.update            2023-07-01
+    _description.text
+;
+    Standard uncertainty of _diffrn_orient_refln.angle_psi.
+;
+    _name.category_id             diffrn_orient_refln
+    _name.object_id               angle_psi_su
+    _name.linked_item_id          '_diffrn_orient_refln.angle_psi'
+    _units.code                   degrees
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+save_
+
+save_diffrn_orient_refln.angle_theta
+
+    _definition.id                '_diffrn_orient_refln.angle_theta'
+    _alias.definition_id          '_diffrn_orient_refln_angle_theta'
+    _name.category_id             diffrn_orient_refln
+    _name.object_id               angle_theta
+
+    _import.get                   [{'file':templ_attr.cif  'save':orient_angle}]
+
+save_
+
+save_diffrn_orient_refln.angle_theta_su
+
+    _definition.id                '_diffrn_orient_refln.angle_theta_su'
+    _definition.update            2023-07-01
+    _description.text
+;
+    Standard uncertainty of _diffrn_orient_refln.angle_theta.
+;
+    _name.category_id             diffrn_orient_refln
+    _name.object_id               angle_theta_su
+    _name.linked_item_id          '_diffrn_orient_refln.angle_theta'
+    _units.code                   degrees
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+save_
+
+save_diffrn_orient_refln.hkl
+
+    _definition.id                '_diffrn_orient_refln.hkl'
+    _definition.update            2021-03-01
+    _description.text
+;
+    Miller indices of a reflection used to define the orientation matrix.
+;
+    _name.category_id             diffrn_orient_refln
+    _name.object_id               hkl
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Matrix
+    _type.dimension               '[3]'
+    _type.contents                Integer
+    _units.code                   none
+    _method.purpose               Evaluation
+    _method.expression
+;
+    With a as diffrn_orient_refln
+
+      _diffrn_orient_refln.hkl =  [a.index_h, a.index_k, a.index_l]
+;
+
+save_
+
+save_diffrn_orient_refln.index_h
+
+    _definition.id                '_diffrn_orient_refln.index_h'
+    _alias.definition_id          '_diffrn_orient_refln_index_h'
+    _name.category_id             diffrn_orient_refln
+    _name.object_id               index_h
+
+    _import.get                   [{'file':templ_attr.cif  'save':miller_index}]
+
+save_
+
+save_diffrn_orient_refln.index_k
+
+    _definition.id                '_diffrn_orient_refln.index_k'
+    _alias.definition_id          '_diffrn_orient_refln_index_k'
+    _name.category_id             diffrn_orient_refln
+    _name.object_id               index_k
+
+    _import.get                   [{'file':templ_attr.cif  'save':miller_index}]
+
+save_
+
+save_diffrn_orient_refln.index_l
+
+    _definition.id                '_diffrn_orient_refln.index_l'
+    _alias.definition_id          '_diffrn_orient_refln_index_l'
+    _name.category_id             diffrn_orient_refln
+    _name.object_id               index_l
+
+    _import.get                   [{'file':templ_attr.cif  'save':miller_index}]
+
+save_
+
+save_DIFFRN_RADIATION
+
+    _definition.id                DIFFRN_RADIATION
+    _definition.scope             Category
+    _definition.class             Set
+    _definition.update            2023-10-15
+    _description.text
+;
+    The CATEGORY of data items which specify the wavelength of the
+    radiation used in measuring diffraction intensities. To identify
+    and assign weights to distinct wavelength components from a
+    polychromatic beam, see DIFFRN_RADIATION_WAVELENGTH.
+;
+    _name.category_id             DIFFRN
+    _name.object_id               DIFFRN_RADIATION
+
+save_
+
+save_diffrn_radiation.collimation
+
+    _definition.id                '_diffrn_radiation.collimation'
+    _alias.definition_id          '_diffrn_radiation_collimation'
+    _definition.update            2012-11-26
+    _description.text
+;
+    Description of the collimation or focusing applied to the radiation.
+;
+    _name.category_id             diffrn_radiation
+    _name.object_id               collimation
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+
+    loop_
+      _description_example.case
+         '0.3 mm double-pinhole'
+         '0.5 mm'
+         'focusing mirrors'
+
+save_
+
+save_diffrn_radiation.filter_edge
+
+    _definition.id                '_diffrn_radiation.filter_edge'
+    _alias.definition_id          '_diffrn_radiation_filter_edge'
+    _definition.update            2012-11-26
+    _description.text
+;
+    Absorption edge of the radiation filter used.
+;
+    _name.category_id             diffrn_radiation
+    _name.object_id               filter_edge
+    _type.purpose                 Number
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   angstroms
+
+save_
+
+save_diffrn_radiation.inhomogeneity
+
+    _definition.id                '_diffrn_radiation.inhomogeneity'
+    _alias.definition_id          '_diffrn_radiation_inhomogeneity'
+    _definition.update            2012-11-26
+    _description.text
+;
+    Half-width of the incident beam perpendicular to the diffraction plane.
+;
+    _name.category_id             diffrn_radiation
+    _name.object_id               inhomogeneity
+    _type.purpose                 Number
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   millimetres
+
+save_
+
+save_diffrn_radiation.monochromator
+
+    _definition.id                '_diffrn_radiation.monochromator'
+    _alias.definition_id          '_diffrn_radiation_monochromator'
+    _definition.update            2012-11-26
+    _description.text
+;
+    Description of the method used to obtain monochromatic radiation.
+    If a monochromator crystal is used the material and the indices of
+    the Bragg reflection are specified.
+;
+    _name.category_id             diffrn_radiation
+    _name.object_id               monochromator
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+
+    loop_
+      _description_example.case
+         'Zr filter'
+         'Ge 220'
+         'none'
+         'equatorial mounted graphite'
+
+save_
+
+save_diffrn_radiation.polarisn_norm
+
+    _definition.id                '_diffrn_radiation.polarisn_norm'
+    _alias.definition_id          '_diffrn_radiation_polarisn_norm'
+    _definition.update            2012-11-26
+    _description.text
+;
+    The angle, as viewed from the specimen, between the perpendicular
+    component of the polarisation and the diffraction plane.
+;
+    _name.category_id             diffrn_radiation
+    _name.object_id               polarisn_norm
+    _type.purpose                 Number
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            -180.0:180.0
+    _units.code                   degrees
+
+save_
+
+save_diffrn_radiation.polarisn_ratio
+
+    _definition.id                '_diffrn_radiation.polarisn_ratio'
+    _alias.definition_id          '_diffrn_radiation_polarisn_ratio'
+    _definition.update            2012-11-26
+    _description.text
+;
+    Polarisation ratio of the diffraction beam incident on the crystal.
+    It is the ratio of the perpendicularly polarised to the parallel
+    polarised component of the radiation. The perpendicular component
+    forms an angle of _diffrn_radiation.polarisn_norm to the normal to
+    the diffraction plane of the sample (i.e. the plane containing the
+    incident and reflected beams).
+;
+    _name.category_id             diffrn_radiation
+    _name.object_id               polarisn_ratio
+    _type.purpose                 Number
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   none
+
+save_
+
+save_diffrn_radiation.probe
+
+    _definition.id                '_diffrn_radiation.probe'
+    _alias.definition_id          '_diffrn_radiation_probe'
+    _definition.update            2012-11-26
+    _description.text
+;
+    Enumerated code for the nature of radiation used (i.e. name of
+    subatomic particle or region of the electromagnetic spectrum).
+;
+    _name.category_id             diffrn_radiation
+    _name.object_id               probe
+    _type.purpose                 State
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Text
+
+    loop_
+      _enumeration_set.state
+         x-ray
+         neutron
+         electron
+         gamma
+
+save_
+
+save_diffrn_radiation.type
+
+    _definition.id                '_diffrn_radiation.type'
+    _definition_replaced.id       1
+    _definition_replaced.by       '_diffrn_radiation_wavelength.type'
+    _alias.definition_id          '_diffrn_radiation_type'
+    _definition.update            2022-10-04
+    _description.text
+;
+    DEPRECATED. Use _diffrn_radiation_wavelength.type. Details of the
+    radiation source or energy spectrum.
+;
+    _name.category_id             diffrn_radiation
+    _name.object_id               type
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+
+    loop_
+      _description_example.case
+         'Mo Kα'
+         'Cu Kα'
+         'Cu Kα~1~'
+         'Cu K-L~2,3~'
+         'white-beam'
+
+save_
+
+save_diffrn_radiation.xray_symbol
+
+    _definition.id                '_diffrn_radiation.xray_symbol'
+    _definition_replaced.id       1
+    _definition_replaced.by       '_diffrn_radiation_wavelength.xray_symbol'
+    _alias.definition_id          '_diffrn_radiation_xray_symbol'
+    _definition.update            2022-10-04
+    _description.text
+;
+    DEPRECATED. Use _diffrn_radiation_wavelength.xray_symbol. IUPAC
+    symbol for the X-ray wavelength for probe radiation.
+;
+    _name.category_id             diffrn_radiation
+    _name.object_id               xray_symbol
+    _type.purpose                 State
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Text
+
+    loop_
+      _enumeration_set.state
+      _enumeration_set.detail
+         K-L~3~                 'Kα~1~ in older Siegbahn notation.'
+         K-L~2~                 'Kα~2~ in older Siegbahn notation.'
+         K-M~3~                 'Kβ~1~ in older Siegbahn notation.'
+         K-L~2,3~               'Use where K-L~3~ and K-L~2~ are not resolved.'
+
+save_
+
+save_DIFFRN_RADIATION_WAVELENGTH
+
+    _definition.id                DIFFRN_RADIATION_WAVELENGTH
+    _definition.scope             Category
+    _definition.class             Loop
+    _definition.update            2021-06-29
+    _description.text
+;
+    The CATEGORY of data items which specify the wavelength of the
+    radiation used in measuring diffraction intensities. Items may be
+    looped to identify and assign weights to distinct wavelength
+    components from a polychromatic beam.
+;
+    _name.category_id             DIFFRN_RADIATION
+    _name.object_id               DIFFRN_RADIATION_WAVELENGTH
+    _category_key.name            '_diffrn_radiation_wavelength.id'
+
+save_
+
+save_diffrn_radiation_wavelength.details
+
+    _definition.id                '_diffrn_radiation_wavelength.details'
+
+    loop_
+      _alias.definition_id
+         '_diffrn_radiation_wavelength_details'
+         '_diffrn_radiation.wavelength_details'
+
+    _definition.update            2012-11-26
+    _description.text
+;
+    Information about the determination of the radiation
+    diffrn_radiation_wavelength that is not conveyed completely by an
+    enumerated value of _diffrn_radiation_wavelength.determination.
+;
+    _name.category_id             diffrn_radiation_wavelength
+    _name.object_id               details
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_diffrn_radiation_wavelength.determination
+
+    _definition.id                '_diffrn_radiation_wavelength.determination'
+
+    loop_
+      _alias.definition_id
+         '_diffrn_radiation_wavelength_determination'
+         '_diffrn_radiation.wavelength_determination'
+
+    _definition.update            2023-01-13
+    _description.text
+;
+    Method by which the radiation wavelength was determined.
+;
+    _name.category_id             diffrn_radiation_wavelength
+    _name.object_id               determination
+    _type.purpose                 State
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Text
+
+    loop_
+      _enumeration_set.state
+      _enumeration_set.detail
+         fundamental
+             'Fundamental property of matter, e.g. MoKα.'
+         estimated
+             'Estimated, e.g. from monochromator angle or time of flight.'
+         refined
+             'Refined using a standard crystal with known cell parameters.'
+
+save_
+
+save_diffrn_radiation_wavelength.id
+
+    _definition.id                '_diffrn_radiation_wavelength.id'
+
+    loop_
+      _alias.definition_id
+         '_diffrn_radiation_wavelength_id'
+         '_diffrn_radiation.wavelength_id'
+
+    _definition.update            2023-04-04
+    _description.text
+;
+    Code identifying the radiation used in the diffraction measurements.
+    This is linked to _diffrn_refln.wavelength_id and _refln.wavelength_id
+;
+    _name.category_id             diffrn_radiation_wavelength
+    _name.object_id               id
+    _type.purpose                 Key
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Word
+    _description_example.case     x2
+
+save_
+
+save_diffrn_radiation_wavelength.type
+
+    _definition.id                '_diffrn_radiation_wavelength.type'
+    _definition.update            2022-10-04
+    _description.text
+;
+    Details of the radiation source or energy spectrum.
+;
+    _name.category_id             diffrn_radiation_wavelength
+    _name.object_id               type
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+
+    loop_
+      _description_example.case
+         'Mo Kα'
+         'Cu Kα'
+         'Cu Kα~1~'
+         'Cu K-L~2,3~'
+         'white-beam'
+
+save_
+
+save_diffrn_radiation_wavelength.value
+
+    _definition.id                '_diffrn_radiation_wavelength.value'
+
+    loop_
+      _alias.definition_id
+         '_diffrn_radiation_wavelength'
+         '_diffrn_radiation_wavelength.wavelength'
+
+    _definition.update            2012-11-26
+    _description.text
+;
+    Wavelength of radiation used in diffraction measurements.
+;
+    _name.category_id             diffrn_radiation_wavelength
+    _name.object_id               value
+    _type.purpose                 Measurand
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   angstroms
+
+save_
+
+save_diffrn_radiation_wavelength.value_su
+
+    _definition.id                '_diffrn_radiation_wavelength.value_su'
+
+    loop_
+      _alias.definition_id
+         '_diffrn_radiation_wavelength_su'
+         '_diffrn_radiation_wavelength.wavelength_su'
+
+    _definition.update            2021-08-03
+    _description.text
+;
+    Standard uncertainty of _diffrn_radiation_wavelength.value.
+;
+    _name.category_id             diffrn_radiation_wavelength
+    _name.object_id               value_su
+    _name.linked_item_id          '_diffrn_radiation_wavelength.value'
+    _units.code                   angstroms
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+save_
+
+save_diffrn_radiation_wavelength.wt
+
+    _definition.id                '_diffrn_radiation_wavelength.wt'
+    _alias.definition_id          '_diffrn_radiation_wavelength_wt'
+    _definition.update            2012-11-26
+    _description.text
+;
+    Relative intensity of a radiation used in the diffraction measurements.
+;
+    _name.category_id             diffrn_radiation_wavelength
+    _name.object_id               wt
+    _type.purpose                 Number
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:1.0
+    _units.code                   none
+
+save_
+
+save_diffrn_radiation_wavelength.xray_symbol
+
+    _definition.id                '_diffrn_radiation_wavelength.xray_symbol'
+    _definition.update            2022-10-04
+    _description.text
+;
+    IUPAC symbol for the X-ray wavelength for probe radiation.
+;
+    _name.category_id             diffrn_radiation_wavelength
+    _name.object_id               xray_symbol
+    _type.purpose                 State
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Text
+
+    loop_
+      _enumeration_set.state
+      _enumeration_set.detail
+         K-L~3~                 'Kα~1~ in older Siegbahn notation.'
+         K-L~2~                 'Kα~2~ in older Siegbahn notation.'
+         K-M~3~                 'Kβ~1~ in older Siegbahn notation.'
+         K-L~2,3~               'Use where K-L~3~ and K-L~2~ are not resolved.'
+
+save_
+
+save_DIFFRN_REFLN
+
+    _definition.id                DIFFRN_REFLN
+    _definition.scope             Category
+    _definition.class             Loop
+    _definition.update            2021-06-29
+    _description.text
+;
+    The CATEGORY of data items which specify the reflection measurements,
+    prior to data reduction and merging.
+;
+    _name.category_id             DIFFRN
+    _name.object_id               DIFFRN_REFLN
+    _category_key.name            '_diffrn_refln.id'
+
+save_
+
+save_diffrn_refln.angle_chi
+
+    _definition.id                '_diffrn_refln.angle_chi'
+    _alias.definition_id          '_diffrn_refln_angle_chi'
+    _name.category_id             diffrn_refln
+    _name.object_id               angle_chi
+
+    _import.get                   [{'file':templ_attr.cif  'save':diffr_angle}]
+
+save_
+
+save_diffrn_refln.angle_kappa
+
+    _definition.id                '_diffrn_refln.angle_kappa'
+    _alias.definition_id          '_diffrn_refln_angle_kappa'
+    _name.category_id             diffrn_refln
+    _name.object_id               angle_kappa
+
+    _import.get                   [{'file':templ_attr.cif  'save':diffr_angle}]
+
+save_
+
+save_diffrn_refln.angle_omega
+
+    _definition.id                '_diffrn_refln.angle_omega'
+    _alias.definition_id          '_diffrn_refln_angle_omega'
+    _name.category_id             diffrn_refln
+    _name.object_id               angle_omega
+
+    _import.get                   [{'file':templ_attr.cif  'save':diffr_angle}]
+
+save_
+
+save_diffrn_refln.angle_phi
+
+    _definition.id                '_diffrn_refln.angle_phi'
+    _alias.definition_id          '_diffrn_refln_angle_phi'
+    _name.category_id             diffrn_refln
+    _name.object_id               angle_phi
+
+    _import.get                   [{'file':templ_attr.cif  'save':diffr_angle}]
+
+save_
+
+save_diffrn_refln.angle_psi
+
+    _definition.id                '_diffrn_refln.angle_psi'
+    _alias.definition_id          '_diffrn_refln_angle_psi'
+    _name.category_id             diffrn_refln
+    _name.object_id               angle_psi
+
+    _import.get                   [{'file':templ_attr.cif  'save':diffr_angle}]
+
+save_
+
+save_diffrn_refln.angle_theta
+
+    _definition.id                '_diffrn_refln.angle_theta'
+    _alias.definition_id          '_diffrn_refln_angle_theta'
+    _name.category_id             diffrn_refln
+    _name.object_id               angle_theta
+
+    _import.get                   [{'file':templ_attr.cif  'save':diffr_angle}]
+
+save_
+
+save_diffrn_refln.attenuator_code
+
+    _definition.id                '_diffrn_refln.attenuator_code'
+    _alias.definition_id          '_diffrn_refln_attenuator_code'
+    _definition.update            2021-10-27
+    _description.text
+;
+    Code identifying any attenuator setting for this reflection.
+;
+    _name.category_id             diffrn_refln
+    _name.object_id               attenuator_code
+    _name.linked_item_id          '_diffrn_attenuator.code'
+    _type.purpose                 Link
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Word
+
+save_
+
+save_diffrn_refln.class_code
+
+    _definition.id                '_diffrn_refln.class_code'
+    _alias.definition_id          '_diffrn_refln_class_code'
+    _definition.update            2021-10-27
+    _description.text
+;
+    Code for reflection class, if assigned. e.g. modulated structures
+;
+    _name.category_id             diffrn_refln
+    _name.object_id               class_code
+    _name.linked_item_id          '_diffrn_reflns_class.code'
+    _type.purpose                 Link
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Word
+
+save_
+
+save_diffrn_refln.counts_bg_1
+
+    _definition.id                '_diffrn_refln.counts_bg_1'
+    _alias.definition_id          '_diffrn_refln_counts_bg_1'
+    _definition.update            2022-11-22
+    _description.text
+;
+    The measured background scattering on one side of a diffraction
+    peak when measuring using a point detector.
+
+    Note that counts-per-second values should be converted to
+    total counts.
+
+    Standard uncertainties should not be quoted for these values.
+    If the standard uncertainties differ from the square root of
+    the number of counts, _diffrn_refln.intensity_* should be used.
+;
+    _name.category_id             diffrn_refln
+    _name.object_id               counts_bg_1
+    _type.purpose                 Number
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Integer
+    _enumeration.range            0:
+    _units.code                   counts
+
+save_
+
+save_diffrn_refln.counts_bg_2
+
+    _definition.id                '_diffrn_refln.counts_bg_2'
+    _alias.definition_id          '_diffrn_refln_counts_bg_2'
+    _definition.update            2022-11-22
+    _description.text
+;
+    The measured background counts on the other side of the
+    peak to the measurement of _diffrn_refln.counts_bg_1
+    when measuring using a point detector.
+
+    Note that counts-per-second values should be converted to
+    total counts.
+
+    Standard uncertainties should not be quoted for these values.
+    If the standard uncertainties differ from the square root of
+    the number of counts, _diffrn_refln.intensity_* should be used.
+;
+    _name.category_id             diffrn_refln
+    _name.object_id               counts_bg_2
+    _type.purpose                 Number
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Integer
+    _enumeration.range            0:
+    _units.code                   counts
+
+save_
+
+save_diffrn_refln.counts_net
+
+    _definition.id                '_diffrn_refln.counts_net'
+    _alias.definition_id          '_diffrn_refln_counts_net'
+    _definition.update            2022-12-12
+    _description.text
+;
+    Counts measured in the reflection peak after background
+    subtraction. If background and peak counts were collected
+    for different times, the background counts must be scaled to
+    the peak counts prior to subtraction.
+
+    Note that counts-per-second values should be converted to
+    total counts.
+
+    The value for this data item must be derived from count values.
+    If not, _diffrn_refln.intensity_* should be used.
+;
+    _name.category_id             diffrn_refln
+    _name.object_id               counts_net
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _units.code                   counts
+
+save_
+
+save_diffrn_refln.counts_net_su
+
+    _definition.id                '_diffrn_refln.counts_net_su'
+    _definition.update            2023-07-01
+    _description.text
+;
+    Standard uncertainty of _diffrn_refln.counts_net.
+;
+    _name.category_id             diffrn_refln
+    _name.object_id               counts_net_su
+    _name.linked_item_id          '_diffrn_refln.counts_net'
+    _units.code                   counts
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+save_
+
+save_diffrn_refln.counts_peak
+
+    _definition.id                '_diffrn_refln.counts_peak'
+    _alias.definition_id          '_diffrn_refln_counts_peak'
+    _definition.update            2022-11-22
+    _description.text
+;
+    Counts measured in the reflection peak before background
+    subtraction. That is, the region of interest consists of
+    only the diffraction peak.
+
+    Note that counts-per-second values should be converted to
+    total counts.
+
+    Standard uncertainties should not be quoted for these values.
+    If the standard uncertainties differ from the square root of
+    the number of counts, _diffrn_refln.intensity_* should be used.
+;
+    _name.category_id             diffrn_refln
+    _name.object_id               counts_peak
+    _type.purpose                 Number
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Integer
+    _enumeration.range            0:
+    _units.code                   counts
+
+save_
+
+save_diffrn_refln.counts_total
+
+    _definition.id                '_diffrn_refln.counts_total'
+    _alias.definition_id          '_diffrn_refln_counts_total'
+    _definition.update            2022-11-22
+    _description.text
+;
+    Counts measured in the total reflection including background
+    and peak regions. That is, the region of interest consists of the
+    diffraction peak and an area of background immediately surrounding
+    the peak of interest.
+
+    Note that counts-per-second values should be converted to
+    total counts.
+
+    Standard uncertainties should not be quoted for these values.
+    If the standard uncertainties differ from the square root of
+    the number of counts, _diffrn_refln.intensity_* should be used.
+;
+    _name.category_id             diffrn_refln
+    _name.object_id               counts_total
+    _type.purpose                 Number
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Integer
+    _enumeration.range            0:
+    _units.code                   counts
+
+save_
+
+save_diffrn_refln.detect_slit_horiz
+
+    _definition.id                '_diffrn_refln.detect_slit_horiz'
+    _alias.definition_id          '_diffrn_refln_detect_slit_horiz'
+    _definition.update            2012-11-26
+    _description.text
+;
+    Total slit aperture angle in the diffraction plane.
+;
+    _name.category_id             diffrn_refln
+    _name.object_id               detect_slit_horiz
+    _type.purpose                 Number
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:90.0
+    _units.code                   degrees
+
+save_
+
+save_diffrn_refln.detect_slit_vert
+
+    _definition.id                '_diffrn_refln.detect_slit_vert'
+    _alias.definition_id          '_diffrn_refln_detect_slit_vert'
+    _definition.update            2012-11-26
+    _description.text
+;
+    Total slit aperture angle perpendicular to the diffraction plane.
+;
+    _name.category_id             diffrn_refln
+    _name.object_id               detect_slit_vert
+    _type.purpose                 Number
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:90.0
+    _units.code                   degrees
+
+save_
+
+save_diffrn_refln.elapsed_time
+
+    _definition.id                '_diffrn_refln.elapsed_time'
+    _alias.definition_id          '_diffrn_refln_elapsed_time'
+    _definition.update            2012-11-26
+    _description.text
+;
+    Elapsed time from the start to the end of the intensity measurement.
+;
+    _name.category_id             diffrn_refln
+    _name.object_id               elapsed_time
+    _type.purpose                 Number
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   minutes
+
+save_
+
+save_diffrn_refln.hkl
+
+    _definition.id                '_diffrn_refln.hkl'
+    _definition.update            2021-03-01
+    _description.text
+;
+    Miller indices of a measured reflection. These need not match the
+    _refln.hkl values if a transformation of the original measured
+    cell has taken place.
+;
+    _name.category_id             diffrn_refln
+    _name.object_id               hkl
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Matrix
+    _type.dimension               '[3]'
+    _type.contents                Integer
+    _units.code                   none
+    _method.purpose               Evaluation
+    _method.expression
+;
+    With a as diffrn_refln
+
+          _diffrn_refln.hkl =   [a.index_h, a.index_h, a.index_l]
+;
+
+save_
+
+save_diffrn_refln.id
+
+    _definition.id                '_diffrn_refln.id'
+    _definition.update            2024-11-12
+    _description.text
+;
+    _diffrn_refln.id must uniquely identify the reflection.
+
+    Note that this item need not be a number; it can be any unique
+    identifier.
+;
+    _name.category_id             diffrn_refln
+    _name.object_id               id
+    _type.purpose                 Key
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Word
+
+save_
+
+save_diffrn_refln.index_h
+
+    _definition.id                '_diffrn_refln.index_h'
+    _alias.definition_id          '_diffrn_refln_index_h'
+    _name.category_id             diffrn_refln
+    _name.object_id               index_h
+
+    _import.get                   [{'file':templ_attr.cif  'save':miller_index}]
+
+save_
+
+save_diffrn_refln.index_k
+
+    _definition.id                '_diffrn_refln.index_k'
+    _alias.definition_id          '_diffrn_refln_index_k'
+    _name.category_id             diffrn_refln
+    _name.object_id               index_k
+
+    _import.get                   [{'file':templ_attr.cif  'save':miller_index}]
+
+save_
+
+save_diffrn_refln.index_l
+
+    _definition.id                '_diffrn_refln.index_l'
+    _alias.definition_id          '_diffrn_refln_index_l'
+    _name.category_id             diffrn_refln
+    _name.object_id               index_l
+
+    _import.get                   [{'file':templ_attr.cif  'save':miller_index}]
+
+save_
+
+save_diffrn_refln.intensity_bg_1
+
+    _definition.id                '_diffrn_refln.intensity_bg_1'
+    _definition.update            2022-11-22
+    _description.text
+;
+    The measured background intensity on one side of a diffraction
+    peak when measuring using a point detector.
+
+    Use these entries for measurements where intensity values are not
+    counts (use _diffrn_refln.counts_* for event-counting measurements
+    where the standard uncertainty is estimated as the square root of
+    the number of counts).
+;
+    _name.category_id             diffrn_refln
+    _name.object_id               intensity_bg_1
+    _type.purpose                 Measurand
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Real
+    _units.code                   none
+
+save_
+
+save_diffrn_refln.intensity_bg_1_su
+
+    _definition.id                '_diffrn_refln.intensity_bg_1_su'
+    _definition.update            2023-07-01
+    _description.text
+;
+    Standard uncertainty of _diffrn_refln.intensity_bg_1.
+;
+    _name.category_id             diffrn_refln
+    _name.object_id               intensity_bg_1_su
+    _name.linked_item_id          '_diffrn_refln.intensity_bg_1'
+    _units.code                   none
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+save_
+
+save_diffrn_refln.intensity_bg_2
+
+    _definition.id                '_diffrn_refln.intensity_bg_2'
+    _definition.update            2022-11-22
+    _description.text
+;
+    The measured background counts on the other side of the
+    peak to the measurement of _diffrn_refln.intensity_bg_1
+    when measuring using a point detector.
+
+    Use these entries for measurements where intensity values are not
+    counts (use _diffrn_refln.counts_* for event-counting measurements
+    where the standard uncertainty is estimated as the square root of
+    the number of counts).
+;
+    _name.category_id             diffrn_refln
+    _name.object_id               intensity_bg_2
+    _type.purpose                 Measurand
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Real
+    _units.code                   none
+
+save_
+
+save_diffrn_refln.intensity_bg_2_su
+
+    _definition.id                '_diffrn_refln.intensity_bg_2_su'
+    _definition.update            2023-07-01
+    _description.text
+;
+    Standard uncertainty of _diffrn_refln.intensity_bg_2.
+;
+    _name.category_id             diffrn_refln
+    _name.object_id               intensity_bg_2_su
+    _name.linked_item_id          '_diffrn_refln.intensity_bg_2'
+    _units.code                   none
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+save_
+
+save_diffrn_refln.intensity_net
+
+    _definition.id                '_diffrn_refln.intensity_net'
+    _alias.definition_id          '_diffrn_refln_intensity_net'
+    _definition.update            2022-11-22
+    _description.text
+;
+    Net intensity in the reflection peak calculated from the
+    diffraction counts after the attenuator and standard scales
+    have been applied.
+;
+    _name.category_id             diffrn_refln
+    _name.object_id               intensity_net
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _units.code                   none
+
+save_
+
+save_diffrn_refln.intensity_net_su
+
+    _definition.id                '_diffrn_refln.intensity_net_su'
+
+    loop_
+      _alias.definition_id
+      _alias.deprecation_date
+         '_diffrn_refln_intensity_u'                                 .
+         '_diffrn_refln_intensity_sigma'                             1999-03-24
+         '_diffrn_refln.intensity_sigma'                             .
+         '_diffrn_refln.intensity_u'                                 .
+
+    _definition.update            2024-02-14
+    _description.text
+;
+    Standard uncertainty of _diffrn_refln.intensity_net.
+;
+    _name.category_id             diffrn_refln
+    _name.object_id               intensity_net_su
+    _name.linked_item_id          '_diffrn_refln.intensity_net'
+    _units.code                   none
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+save_
+
+save_diffrn_refln.intensity_peak
+
+    _definition.id                '_diffrn_refln.intensity_peak'
+    _definition.update            2022-11-22
+    _description.text
+;
+    Intensity measured in the reflection peak before background
+    subtraction. That is, the region of interest consists of
+    only the diffraction peak.
+
+    Use these entries for measurements where intensity values are not
+    counts (use _diffrn_refln.counts_* for event-counting measurements
+    where the standard uncertainty is estimated as the square root of
+    the number of counts).
+;
+    _name.category_id             diffrn_refln
+    _name.object_id               intensity_peak
+    _type.purpose                 Measurand
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Real
+    _units.code                   none
+
+save_
+
+save_diffrn_refln.intensity_peak_su
+
+    _definition.id                '_diffrn_refln.intensity_peak_su'
+    _definition.update            2023-07-01
+    _description.text
+;
+    Standard uncertainty of _diffrn_refln.intensity_peak.
+;
+    _name.category_id             diffrn_refln
+    _name.object_id               intensity_peak_su
+    _name.linked_item_id          '_diffrn_refln.intensity_peak'
+    _units.code                   none
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+save_
+
+save_diffrn_refln.intensity_total
+
+    _definition.id                '_diffrn_refln.intensity_total'
+    _definition.update            2022-11-22
+    _description.text
+;
+    Intensity measured in the total reflection including background
+    and peak regions. That is, the region of interest consists of the
+    diffraction peak and an area of background immediately surrounding
+    the peak of interest.
+
+    Use these entries for measurements where intensity values are not
+    counts (use _diffrn_refln.counts_* for event-counting measurements
+    where the standard uncertainty is estimated as the square root of
+    the number of counts).
+;
+    _name.category_id             diffrn_refln
+    _name.object_id               intensity_total
+    _type.purpose                 Measurand
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Real
+    _units.code                   none
+
+save_
+
+save_diffrn_refln.intensity_total_su
+
+    _definition.id                '_diffrn_refln.intensity_total_su'
+    _definition.update            2023-07-01
+    _description.text
+;
+    Standard uncertainty of _diffrn_refln.intensity_total.
+;
+    _name.category_id             diffrn_refln
+    _name.object_id               intensity_total_su
+    _name.linked_item_id          '_diffrn_refln.intensity_total'
+    _units.code                   none
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+save_
+
+save_diffrn_refln.scale_group_code
+
+    _definition.id                '_diffrn_refln.scale_group_code'
+    _alias.definition_id          '_diffrn_refln_scale_group_code'
+    _definition.update            2023-11-14
+    _description.text
+;
+    Code identifying the scale applying to this reflection. The code must match
+    a _diffrn_scale_group.code in the DIFFRN_SCALE_GROUP list.
+;
+    _name.category_id             diffrn_refln
+    _name.object_id               scale_group_code
+    _name.linked_item_id          '_diffrn_scale_group.code'
+    _type.purpose                 Link
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Word
+
+save_
+
+save_diffrn_refln.scan_mode
+
+    _definition.id                '_diffrn_refln.scan_mode'
+    _alias.definition_id          '_diffrn_refln_scan_mode'
+    _definition.update            2023-01-13
+    _description.text
+;
+    Code identifying the mode of scanning with a diffractometer.
+    See also _diffrn_refln.scan_width and _diffrn_refln.scan_mode_backgd.
+;
+    _name.category_id             diffrn_refln
+    _name.object_id               scan_mode
+    _type.purpose                 State
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Text
+
+    loop_
+      _enumeration_set.state
+      _enumeration_set.detail
+         om                       'ω-scan.'
+         ot                       'ω/2θ-scan.'
+         q                        'Q-scans (arbitrary reciprocal directions).'
+
+save_
+
+save_diffrn_refln.scan_mode_backgd
+
+    _definition.id                '_diffrn_refln.scan_mode_backgd'
+    _alias.definition_id          '_diffrn_refln_scan_mode_backgd'
+    _definition.update            2012-11-26
+    _description.text
+;
+    Code identifying mode of scanning to measure the background intensity.
+;
+    _name.category_id             diffrn_refln
+    _name.object_id               scan_mode_backgd
+    _type.purpose                 State
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Text
+
+    loop_
+      _enumeration_set.state
+      _enumeration_set.detail
+         st                       'Stationary counter background.'
+         mo                       'Moving counter background.'
+
+save_
+
+save_diffrn_refln.scan_rate
+
+    _definition.id                '_diffrn_refln.scan_rate'
+    _alias.definition_id          '_diffrn_refln_scan_rate'
+    _definition.update            2013-03-07
+    _description.text
+;
+    Angular rate of scanning a reflection to measure the intensity.
+;
+    _name.category_id             diffrn_refln
+    _name.object_id               scan_rate
+    _type.purpose                 Number
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   degree_per_minute
+
+save_
+
+save_diffrn_refln.scan_time_backgd
+
+    _definition.id                '_diffrn_refln.scan_time_backgd'
+    _alias.definition_id          '_diffrn_refln_scan_time_backgd'
+    _definition.update            2012-11-26
+    _description.text
+;
+    Time spent measuring background counts.
+;
+    _name.category_id             diffrn_refln
+    _name.object_id               scan_time_backgd
+    _type.purpose                 Number
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   seconds
+
+save_
+
+save_diffrn_refln.scan_width
+
+    _definition.id                '_diffrn_refln.scan_width'
+    _alias.definition_id          '_diffrn_refln_scan_width'
+    _definition.update            2012-11-26
+    _description.text
+;
+    Angular scan width when measuring the peak intensity.
+;
+    _name.category_id             diffrn_refln
+    _name.object_id               scan_width
+    _type.purpose                 Number
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:90.0
+    _units.code                   degrees
+
+save_
+
+save_diffrn_refln.sin_theta_over_lambda
+
+    _definition.id                '_diffrn_refln.sin_theta_over_lambda'
+
+    loop_
+      _alias.definition_id
+         '_diffrn_refln_sint/lambda'
+         '_diffrn_refln_sint_over_lambda'
+         '_diffrn_refln.sint_over_lambda'
+
+    _definition.update            2012-11-26
+    _description.text
+;
+    sin(θ)/λ value for this reflection.
+;
+    _name.category_id             diffrn_refln
+    _name.object_id               sin_theta_over_lambda
+    _type.purpose                 Number
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   reciprocal_angstroms
+
+save_
+
+save_diffrn_refln.standard_code
+
+    _definition.id                '_diffrn_refln.standard_code'
+    _alias.definition_id          '_diffrn_refln_standard_code'
+    _definition.update            2023-11-14
+    _description.text
+;
+    Code identifying reflections measured repeated as standard intensity.
+    Must match a _diffrn_standard_refln.code value or set to '.' if
+    it was not used as an intensity standard.
+;
+    _name.category_id             diffrn_refln
+    _name.object_id               standard_code
+    _name.linked_item_id          '_diffrn_standard_refln.code'
+    _type.purpose                 Link
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Word
+
+save_
+
+save_diffrn_refln.wavelength
+
+    _definition.id                '_diffrn_refln.wavelength'
+    _alias.definition_id          '_diffrn_refln_wavelength'
+    _definition.update            2012-11-26
+    _description.text
+;
+    Mean wavelength of radiation used to measure this intensity.
+;
+    _name.category_id             diffrn_refln
+    _name.object_id               wavelength
+    _type.purpose                 Number
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   angstroms
+
+save_
+
+save_diffrn_refln.wavelength_id
+
+    _definition.id                '_diffrn_refln.wavelength_id'
+    _alias.definition_id          '_diffrn_refln_wavelength_id'
+    _definition.update            2021-10-27
+    _description.text
+;
+    Code identifying the wavelength in the diffrn_radiation_wavelength list.
+;
+    _name.category_id             diffrn_refln
+    _name.object_id               wavelength_id
+    _name.linked_item_id          '_diffrn_radiation_wavelength.id'
+    _type.purpose                 Link
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Word
+
+save_
+
+save_DIFFRN_REFLNS
+
+    _definition.id                DIFFRN_REFLNS
+    _definition.scope             Category
+    _definition.class             Set
+    _definition.update            2012-11-26
+    _description.text
+;
+    The CATEGORY of data items which specify the overall reflection
+    measurement information.
+;
+    _name.category_id             DIFFRN
+    _name.object_id               DIFFRN_REFLNS
+
+save_
+
+save_diffrn_reflns.av_r_equivalents
+
+    _definition.id                '_diffrn_reflns.av_R_equivalents'
+    _alias.definition_id          '_diffrn_reflns_av_R_equivalents'
+    _definition.update            2012-11-26
+    _description.text
+;
+    The residual [sum av|del(I)| / sum |av(I)|] for symmetry-equivalent
+    reflections used to calculate the average intensity av(I). The
+    av|del(I)| term is the average absolute difference between av(I) and
+    the individual symmetry-equivalent intensities.
+;
+    _name.category_id             diffrn_reflns
+    _name.object_id               av_R_equivalents
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   none
+
+save_
+
+save_diffrn_reflns.av_suneti_over_neti
+
+    _definition.id                '_diffrn_reflns.av_sunetI_over_netI'
+
+    loop_
+      _alias.definition_id
+      _alias.deprecation_date
+         '_diffrn_reflns_av_sigmaI/netI'                             1999-03-24
+         '_diffrn_reflns.av_unetI/netI'                              .
+         '_diffrn_reflns_av_unetI/netI'                              .
+         '_diffrn_reflns.av_sigmaI_over_netI'                        .
+
+    _definition.update            2024-02-14
+    _description.text
+;
+    Recorded [sum |su(netI)| / sum |netI|] for all measured reflections.
+;
+    _name.category_id             diffrn_reflns
+    _name.object_id               av_sunetI_over_netI
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   none
+
+save_
+
+save_diffrn_reflns.laue_measured_fraction_full
+
+    _definition.id                '_diffrn_reflns.Laue_measured_fraction_full'
+    _alias.definition_id          '_diffrn_reflns_Laue_measured_fraction_full'
+    _definition.update            2019-01-09
+    _description.text
+;
+    Fraction of Laue group unique reflections (symmetry-independent in
+    the Laue group) measured out to the resolution given in
+    _diffrn_reflns.resolution_full or _diffrn_reflns.theta_full.
+    The Laue group always contains a centre of symmetry so that
+    the reflection h,k,l is always equivalent to the reflection
+    -h,-k,-l even in space groups without a centre of symmetry.
+    This number should not be less than 0.95, since it represents
+    the fraction of reflections measured in the part of the
+    diffraction pattern that is essentially complete.
+;
+    _name.category_id             diffrn_reflns
+    _name.object_id               Laue_measured_fraction_full
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.95:1.0
+    _units.code                   none
+
+save_
+
+save_diffrn_reflns.laue_measured_fraction_max
+
+    _definition.id                '_diffrn_reflns.Laue_measured_fraction_max'
+    _alias.definition_id          '_diffrn_reflns_Laue_measured_fraction_max'
+    _definition.update            2021-03-03
+    _description.text
+;
+    Fraction of Laue group unique reflections (symmetry-independent in
+    the Laue group) measured out to the resolution given in
+    _diffrn_reflns.resolution_max or _diffrn_reflns.theta_max.
+    The Laue group always contains a centre of symmetry so that the
+    reflection h,k,l is always equivalent to the reflection -h,-k,-l
+    even in space groups without a centre of symmetry.
+;
+    _name.category_id             diffrn_reflns
+    _name.object_id               Laue_measured_fraction_max
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:1.0
+    _units.code                   none
+
+save_
+
+save_diffrn_reflns.limit_h_max
+
+    _definition.id                '_diffrn_reflns.limit_h_max'
+    _alias.definition_id          '_diffrn_reflns_limit_h_max'
+    _name.category_id             diffrn_reflns
+    _name.object_id               limit_h_max
+
+    _import.get                   [{'file':templ_attr.cif  'save':miller_index}]
+
+save_
+
+save_diffrn_reflns.limit_h_min
+
+    _definition.id                '_diffrn_reflns.limit_h_min'
+    _alias.definition_id          '_diffrn_reflns_limit_h_min'
+    _name.category_id             diffrn_reflns
+    _name.object_id               limit_h_min
+
+    _import.get                   [{'file':templ_attr.cif  'save':miller_index}]
+
+save_
+
+save_diffrn_reflns.limit_k_max
+
+    _definition.id                '_diffrn_reflns.limit_k_max'
+    _alias.definition_id          '_diffrn_reflns_limit_k_max'
+    _name.category_id             diffrn_reflns
+    _name.object_id               limit_k_max
+
+    _import.get                   [{'file':templ_attr.cif  'save':miller_index}]
+
+save_
+
+save_diffrn_reflns.limit_k_min
+
+    _definition.id                '_diffrn_reflns.limit_k_min'
+    _alias.definition_id          '_diffrn_reflns_limit_k_min'
+    _name.category_id             diffrn_reflns
+    _name.object_id               limit_k_min
+
+    _import.get                   [{'file':templ_attr.cif  'save':miller_index}]
+
+save_
+
+save_diffrn_reflns.limit_l_max
+
+    _definition.id                '_diffrn_reflns.limit_l_max'
+    _alias.definition_id          '_diffrn_reflns_limit_l_max'
+    _name.category_id             diffrn_reflns
+    _name.object_id               limit_l_max
+
+    _import.get                   [{'file':templ_attr.cif  'save':miller_index}]
+
+save_
+
+save_diffrn_reflns.limit_l_min
+
+    _definition.id                '_diffrn_reflns.limit_l_min'
+    _alias.definition_id          '_diffrn_reflns_limit_l_min'
+    _name.category_id             diffrn_reflns
+    _name.object_id               limit_l_min
+
+    _import.get                   [{'file':templ_attr.cif  'save':miller_index}]
+
+save_
+
+save_diffrn_reflns.limit_max
+
+    _definition.id                '_diffrn_reflns.limit_max'
+    _definition.update            2023-01-06
+    _description.text
+;
+    Maximum Miller indices of measured diffraction reflections.
+;
+    _name.category_id             diffrn_reflns
+    _name.object_id               limit_max
+    _type.purpose                 Number
+    _type.source                  Assigned
+    _type.container               Matrix
+    _type.dimension               '[3]'
+    _type.contents                Integer
+    _units.code                   none
+    _method.purpose               Evaluation
+    _method.expression
+;
+    With t as diffrn_reflns
+
+    _diffrn_reflns.limit_max = [t.limit_h_max,t.limit_k_max,t.limit_l_max]
+;
+
+save_
+
+save_diffrn_reflns.limit_min
+
+    _definition.id                '_diffrn_reflns.limit_min'
+    _definition.update            2023-01-06
+    _description.text
+;
+    Minimum Miller indices of measured diffraction reflections.
+;
+    _name.category_id             diffrn_reflns
+    _name.object_id               limit_min
+    _type.purpose                 Number
+    _type.source                  Assigned
+    _type.container               Matrix
+    _type.dimension               '[3]'
+    _type.contents                Integer
+    _units.code                   none
+    _method.purpose               Evaluation
+    _method.expression
+;
+    With t as diffrn_reflns
+
+    _diffrn_reflns.limit_min = [t.limit_h_min,t.limit_k_min,t.limit_l_min]
+;
+
+save_
+
+save_diffrn_reflns.number
+
+    _definition.id                '_diffrn_reflns.number'
+    _alias.definition_id          '_diffrn_reflns_number'
+    _definition.update            2021-03-01
+    _description.text
+;
+    Total number of measured intensities, excluding reflections that are
+    classed as systematically absent arising from translational symmetry
+    in the crystal unit cell.
+;
+    _name.category_id             diffrn_reflns
+    _name.object_id               number
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Integer
+    _enumeration.range            0:
+    _units.code                   none
+
+save_
+
+save_diffrn_reflns.point_measured_fraction_full
+
+    _definition.id                '_diffrn_reflns.point_measured_fraction_full'
+    _alias.definition_id
+        '_diffrn_reflns_point_group_measured_fraction_full'
+    _definition.update            2013-01-20
+    _description.text
+;
+    Fraction of crystal point-group unique reflections (i.e.
+    symmetry-independent in the crystal point group) measured
+    out to the resolution given in _diffrn_reflns.resolution_full
+    or _diffrn_reflns.theta_full. For space groups that do not
+    contain a centre of symmetry the reflections h,k,l and
+    -h,-k,-l are independent. This number should not be less
+    than 0.95, since it represents the fraction of reflections
+    measured in the part of the diffraction pattern that is
+    essentially complete.
+;
+    _name.category_id             diffrn_reflns
+    _name.object_id               point_measured_fraction_full
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.95:1.0
+    _units.code                   none
+
+save_
+
+save_diffrn_reflns.point_measured_fraction_max
+
+    _definition.id                '_diffrn_reflns.point_measured_fraction_max'
+    _alias.definition_id
+        '_diffrn_reflns_point_group_measured_fraction_max'
+    _definition.update            2013-01-20
+    _description.text
+;
+    Fraction of crystal point-group unique reflections (i.e.
+    symmetry-independent in the crystal point group) measured
+    out to the resolution given in _diffrn_reflns.resolution_max
+    or _diffrn_reflns.theta_max. For space groups that do not
+    contain a centre of symmetry the reflections h,k,l and
+    -h,-k,-l are independent.
+;
+    _name.category_id             diffrn_reflns
+    _name.object_id               point_measured_fraction_max
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:1.0
+    _units.code                   none
+
+save_
+
+save_diffrn_reflns.reduction_process
+
+    _definition.id                '_diffrn_reflns.reduction_process'
+    _alias.definition_id          '_diffrn_reflns_reduction_process'
+    _definition.update            2012-11-26
+    _description.text
+;
+    How intensities were reduced to structure-factor magnitudes.
+;
+    _name.category_id             diffrn_reflns
+    _name.object_id               reduction_process
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+    _description_example.case     'data averaged using Fisher test'
+
+save_
+
+save_diffrn_reflns.resolution_full
+
+    _definition.id                '_diffrn_reflns.resolution_full'
+    _alias.definition_id          '_diffrn_reflns_resolution_full'
+    _definition.update            2012-11-26
+    _description.text
+;
+    The resolution at which the measured reflection count is close
+    to complete. The fraction of unique reflections measured out
+    to this angle is given by _diffrn.measured_fraction_theta_full.
+;
+    _name.category_id             diffrn_reflns
+    _name.object_id               resolution_full
+    _type.purpose                 Number
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   reciprocal_angstroms
+
+save_
+
+save_diffrn_reflns.resolution_max
+
+    _definition.id                '_diffrn_reflns.resolution_max'
+    _alias.definition_id          '_diffrn_reflns_resolution_max'
+    _definition.update            2013-02-22
+    _description.text
+;
+    Maximum resolution of the measured diffraction pattern.
+    The fraction of unique reflections measured out to this angle
+    is given by _diffrn.measured_fraction_theta_max.
+;
+    _name.category_id             diffrn_reflns
+    _name.object_id               resolution_max
+    _type.purpose                 Number
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   reciprocal_angstroms
+
+save_
+
+save_diffrn_reflns.theta_full
+
+    _definition.id                '_diffrn_reflns.theta_full'
+    _alias.definition_id          '_diffrn_reflns_theta_full'
+    _definition.update            2023-01-13
+    _description.text
+;
+    Theta angle at which the count of measured reflections is almost
+    complete. The fraction of unique reflections measured out to
+    this angle is given by _diffrn.measured_fraction_theta_full.
+;
+    _name.category_id             diffrn_reflns
+    _name.object_id               theta_full
+    _type.purpose                 Number
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:90.0
+    _units.code                   degrees
+
+save_
+
+save_diffrn_reflns.theta_max
+
+    _definition.id                '_diffrn_reflns.theta_max'
+    _alias.definition_id          '_diffrn_reflns_theta_max'
+    _definition.update            2012-11-26
+    _description.text
+;
+    Maximum θ angle of the measured reflections.
+;
+    _name.category_id             diffrn_reflns
+    _name.object_id               theta_max
+    _type.purpose                 Number
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:90.0
+    _units.code                   degrees
+
+save_
+
+save_diffrn_reflns.theta_min
+
+    _definition.id                '_diffrn_reflns.theta_min'
+    _alias.definition_id          '_diffrn_reflns_theta_min'
+    _definition.update            2012-11-26
+    _description.text
+;
+    Minimum θ angle of the measured reflections.
+;
+    _name.category_id             diffrn_reflns
+    _name.object_id               theta_min
+    _type.purpose                 Number
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:90.0
+    _units.code                   degrees
+
+save_
+
+save_DIFFRN_REFLNS_CLASS
+
+    _definition.id                DIFFRN_REFLNS_CLASS
+    _definition.scope             Category
+    _definition.class             Loop
+    _definition.update            2021-06-29
+    _description.text
+;
+    The CATEGORY of data items which specify different classes of
+    reflections in the raw measured diffraction data.
+;
+    _name.category_id             DIFFRN_REFLNS
+    _name.object_id               DIFFRN_REFLNS_CLASS
+    _category_key.name            '_diffrn_reflns_class.code'
+
+save_
+
+save_diffrn_reflns_class.av_r_eq
+
+    _definition.id                '_diffrn_reflns_class.av_R_eq'
+    _alias.definition_id          '_diffrn_reflns_class_av_R_eq'
+    _definition.update            2012-11-26
+    _description.text
+;
+    Residual [sum av|del(I)|/sum|av(I)|] for symmetry-equivalent
+    reflections used to calculate the average intensity av(I).
+    The av|del(I)| term is the average absolute difference
+    between av(I) and the individual intensities.
+;
+    _name.category_id             diffrn_reflns_class
+    _name.object_id               av_R_eq
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   none
+
+save_
+
+save_diffrn_reflns_class.av_sui_over_i
+
+    _definition.id                '_diffrn_reflns_class.av_suI_over_I'
+
+    loop_
+      _alias.definition_id
+      _alias.deprecation_date
+         '_diffrn_reflns_class_av_uI_over_I'                         .
+         '_diffrn_reflns_class.av_uI/I'                              .
+         '_diffrn_reflns_class_av_uI/I'                              .
+         '_diffrn_reflns_class.av_sgI/I'                             .
+         '_diffrn_reflns_class_av_sgI/I'                             1999-03-24
+
+    _definition.update            2024-02-14
+    _description.text
+;
+    Recorded [sum|su(net I)|/sum|net I|] in a reflection class.
+;
+    _name.category_id             diffrn_reflns_class
+    _name.object_id               av_suI_over_I
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   none
+
+save_
+
+save_diffrn_reflns_class.code
+
+    _definition.id                '_diffrn_reflns_class.code'
+    _alias.definition_id          '_diffrn_reflns_class_code'
+    _definition.update            2021-10-27
+    _description.text
+;
+    Code identifying a reflection class.
+;
+    _name.category_id             diffrn_reflns_class
+    _name.object_id               code
+    _type.purpose                 Encode
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Word
+    _description_example.case     m2
+
+save_
+
+save_diffrn_reflns_class.d_res_high
+
+    _definition.id                '_diffrn_reflns_class.d_res_high'
+    _alias.definition_id          '_diffrn_reflns_class_d_res_high'
+    _definition.update            2012-11-26
+    _description.text
+;
+    Highest resolution in reflection class i.e. smallest d value in class.
+;
+    _name.category_id             diffrn_reflns_class
+    _name.object_id               d_res_high
+    _type.purpose                 Number
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   angstroms
+
+save_
+
+save_diffrn_reflns_class.d_res_low
+
+    _definition.id                '_diffrn_reflns_class.d_res_low'
+    _alias.definition_id          '_diffrn_reflns_class_d_res_low'
+    _definition.update            2012-11-26
+    _description.text
+;
+    Lowest resolution in reflection class i.e. largest d value in class.
+;
+    _name.category_id             diffrn_reflns_class
+    _name.object_id               d_res_low
+    _type.purpose                 Number
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   angstroms
+
+save_
+
+save_diffrn_reflns_class.description
+
+    _definition.id                '_diffrn_reflns_class.description'
+    _alias.definition_id          '_diffrn_reflns_class_description'
+    _definition.update            2012-11-26
+    _description.text
+;
+    Description of a reflection class.
+;
+    _name.category_id             diffrn_reflns_class
+    _name.object_id               description
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+    _description_example.case     'm=1 first order satellites'
+
+save_
+
+save_diffrn_reflns_class.number
+
+    _definition.id                '_diffrn_reflns_class.number'
+    _alias.definition_id          '_diffrn_reflns_class_number'
+    _definition.update            2021-03-01
+    _description.text
+;
+    Number of measured intensities for a reflection class, excluding
+    the systematic absences arising from centring translations.
+;
+    _name.category_id             diffrn_reflns_class
+    _name.object_id               number
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Integer
+    _enumeration.range            0:
+    _units.code                   none
+
+save_
+
+save_DIFFRN_REFLNS_TRANSF_MATRIX
+
+    _definition.id                DIFFRN_REFLNS_TRANSF_MATRIX
+    _definition.scope             Category
+    _definition.class             Set
+    _definition.update            2012-11-26
+    _description.text
+;
+    The CATEGORY of data items which specify the elements of the matrix
+    used to transform the reflection indices _diffrn_refln.hkl
+    into _refln.hkl.
+                                |11 12 13|
+           (h k l) diffraction  |21 22 23|  =  (h' k' l')
+                                |31 32 33|
+;
+    _name.category_id             DIFFRN_REFLNS
+    _name.object_id               DIFFRN_REFLNS_TRANSF_MATRIX
+
+save_
+
+save_diffrn_reflns_transf_matrix.11
+
+    _definition.id                '_diffrn_reflns_transf_matrix.11'
+
+    loop_
+      _alias.definition_id
+         '_diffrn_reflns_transf_matrix_11'
+         '_diffrn_reflns.transf_matrix[1][1]'
+
+    _name.category_id             diffrn_reflns_transf_matrix
+    _name.object_id               11
+
+    _import.get
+        [{'file':templ_attr.cif  'save':transf_matrix}]
+
+save_
+
+save_diffrn_reflns_transf_matrix.12
+
+    _definition.id                '_diffrn_reflns_transf_matrix.12'
+
+    loop_
+      _alias.definition_id
+         '_diffrn_reflns_transf_matrix_12'
+         '_diffrn_reflns.transf_matrix[1][2]'
+
+    _name.category_id             diffrn_reflns_transf_matrix
+    _name.object_id               12
+
+    _import.get
+        [{'file':templ_attr.cif  'save':transf_matrix}]
+
+save_
+
+save_diffrn_reflns_transf_matrix.13
+
+    _definition.id                '_diffrn_reflns_transf_matrix.13'
+
+    loop_
+      _alias.definition_id
+         '_diffrn_reflns_transf_matrix_13'
+         '_diffrn_reflns.transf_matrix[1][3]'
+
+    _name.category_id             diffrn_reflns_transf_matrix
+    _name.object_id               13
+
+    _import.get
+        [{'file':templ_attr.cif  'save':transf_matrix}]
+
+save_
+
+save_diffrn_reflns_transf_matrix.21
+
+    _definition.id                '_diffrn_reflns_transf_matrix.21'
+
+    loop_
+      _alias.definition_id
+         '_diffrn_reflns_transf_matrix_21'
+         '_diffrn_reflns.transf_matrix[2][1]'
+
+    _name.category_id             diffrn_reflns_transf_matrix
+    _name.object_id               21
+
+    _import.get
+        [{'file':templ_attr.cif  'save':transf_matrix}]
+
+save_
+
+save_diffrn_reflns_transf_matrix.22
+
+    _definition.id                '_diffrn_reflns_transf_matrix.22'
+
+    loop_
+      _alias.definition_id
+         '_diffrn_reflns_transf_matrix_22'
+         '_diffrn_reflns.transf_matrix[2][2]'
+
+    _name.category_id             diffrn_reflns_transf_matrix
+    _name.object_id               22
+
+    _import.get
+        [{'file':templ_attr.cif  'save':transf_matrix}]
+
+save_
+
+save_diffrn_reflns_transf_matrix.23
+
+    _definition.id                '_diffrn_reflns_transf_matrix.23'
+
+    loop_
+      _alias.definition_id
+         '_diffrn_reflns_transf_matrix_23'
+         '_diffrn_reflns.transf_matrix[2][3]'
+
+    _name.category_id             diffrn_reflns_transf_matrix
+    _name.object_id               23
+
+    _import.get
+        [{'file':templ_attr.cif  'save':transf_matrix}]
+
+save_
+
+save_diffrn_reflns_transf_matrix.31
+
+    _definition.id                '_diffrn_reflns_transf_matrix.31'
+
+    loop_
+      _alias.definition_id
+         '_diffrn_reflns_transf_matrix_31'
+         '_diffrn_reflns.transf_matrix[3][1]'
+
+    _name.category_id             diffrn_reflns_transf_matrix
+    _name.object_id               31
+
+    _import.get
+        [{'file':templ_attr.cif  'save':transf_matrix}]
+
+save_
+
+save_diffrn_reflns_transf_matrix.32
+
+    _definition.id                '_diffrn_reflns_transf_matrix.32'
+
+    loop_
+      _alias.definition_id
+         '_diffrn_reflns_transf_matrix_32'
+         '_diffrn_reflns.transf_matrix[3][2]'
+
+    _name.category_id             diffrn_reflns_transf_matrix
+    _name.object_id               32
+
+    _import.get
+        [{'file':templ_attr.cif  'save':transf_matrix}]
+
+save_
+
+save_diffrn_reflns_transf_matrix.33
+
+    _definition.id                '_diffrn_reflns_transf_matrix.33'
+
+    loop_
+      _alias.definition_id
+         '_diffrn_reflns_transf_matrix_33'
+         '_diffrn_reflns.transf_matrix[3][3]'
+
+    _name.category_id             diffrn_reflns_transf_matrix
+    _name.object_id               33
+
+    _import.get
+        [{'file':templ_attr.cif  'save':transf_matrix}]
+
+save_
+
+save_diffrn_reflns_transf_matrix.tij
+
+    _definition.id                '_diffrn_reflns_transf_matrix.TIJ'
+    _definition.update            2021-03-01
+    _description.text
+;
+    Elements of the matrix used to transform the diffraction reflection
+    indices _diffrn_refln.hkl into the _refln.hkl indices.
+                                 |11 12 13|
+            (h k l) diffraction  |21 22 23|  =  (h' k' l')
+                                 |31 32 33|
+;
+    _name.category_id             diffrn_reflns_transf_matrix
+    _name.object_id               TIJ
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Matrix
+    _type.dimension               '[3,3]'
+    _type.contents                Real
+    _units.code                   none
+    _method.purpose               Evaluation
+    _method.expression
+;
+    With t as diffrn_reflns_transf_matrix
+
+         _diffrn_reflns_transf_matrix.TIJ =  [[t.11, t.12, t.13],
+                                              [t.21, t.22, t.23],
+                                              [t.31, t.32, t.33]]
+;
+
+save_
+
+save_DIFFRN_SCALE_GROUP
+
+    _definition.id                DIFFRN_SCALE_GROUP
+    _definition.scope             Category
+    _definition.class             Loop
+    _definition.update            2021-06-29
+    _description.text
+;
+    The CATEGORY of data items which specify the groups of reflections in
+    the raw measured diffraction data with different relative scales.
+;
+    _name.category_id             DIFFRN
+    _name.object_id               DIFFRN_SCALE_GROUP
+    _category_key.name            '_diffrn_scale_group.code'
+
+save_
+
+save_diffrn_scale_group.code
+
+    _definition.id                '_diffrn_scale_group.code'
+    _alias.definition_id          '_diffrn_scale_group_code'
+    _definition.update            2023-11-14
+    _description.text
+;
+    Code identifying a specific scale group of reflections (e.g. for
+    multi-film or multi-crystal data).
+;
+    _name.category_id             diffrn_scale_group
+    _name.object_id               code
+    _type.purpose                 Encode
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Word
+
+    loop_
+      _description_example.case
+         1
+         2
+         3
+         s1
+         A
+         B
+         c1
+         c2
+         c3
+
+save_
+
+save_diffrn_scale_group.i_net
+
+    _definition.id                '_diffrn_scale_group.I_net'
+    _alias.definition_id          '_diffrn_scale_group_I_net'
+    _definition.update            2021-03-03
+    _description.text
+;
+    Scale for a specific measurement group of reflections. Is multiplied
+    with the net intensity to place all intensities on a common scale.
+;
+    _name.category_id             diffrn_scale_group
+    _name.object_id               I_net
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   none
+
+save_
+
+save_diffrn_scale_group.i_net_su
+
+    _definition.id                '_diffrn_scale_group.I_net_su'
+    _definition.update            2023-07-01
+    _description.text
+;
+    Standard uncertainty of _diffrn_scale_group.I_net.
+;
+    _name.category_id             diffrn_scale_group
+    _name.object_id               I_net_su
+    _name.linked_item_id          '_diffrn_scale_group.I_net'
+    _units.code                   none
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+save_
+
+save_DIFFRN_SOURCE
+
+    _definition.id                DIFFRN_SOURCE
+    _definition.scope             Category
+    _definition.class             Set
+    _definition.update            2012-11-26
+    _description.text
+;
+    The CATEGORY of data items which specify information about the
+    radiation source.
+;
+    _name.category_id             DIFFRN
+    _name.object_id               DIFFRN_SOURCE
+
+save_
+
+save_diffrn_source.beamline
+
+    _definition.id                '_diffrn_source.beamline'
+    _definition.update            2021-03-01
+    _description.text
+;
+    The name of the beamline at the synchrotron or other
+    large-scale experimental facility at which the experiment
+    was conducted.
+;
+    _name.category_id             diffrn_source
+    _name.object_id               beamline
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+    _description_example.case     I19
+
+save_
+
+save_diffrn_source.current
+
+    _definition.id                '_diffrn_source.current'
+    _alias.definition_id          '_diffrn_source_current'
+    _definition.update            2012-11-26
+    _description.text
+;
+    Generator current at which the radiation source device was operated.
+;
+    _name.category_id             diffrn_source
+    _name.object_id               current
+    _type.purpose                 Number
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   milliamperes
+
+save_
+
+save_diffrn_source.description
+
+    _definition.id                '_diffrn_source.description'
+
+    loop_
+      _definition_replaced.id
+      _definition_replaced.by
+         1                        '_diffrn_source.device'
+         2                        '_diffrn_source.details'
+
+    loop_
+      _alias.definition_id
+      _alias.deprecation_date
+         '_diffrn_source'                                            .
+         '_diffrn_radiation_source'                                  1997-01-20
+         '_diffrn_source.source'                                     .
+
+    _definition.update            2024-02-14
+    _description.text
+;
+    The general class of the source of radiation. This is deprecated.
+    Use _diffrn_source.device and _diffrn_source.details.
+;
+    _name.category_id             diffrn_source
+    _name.object_id               description
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_diffrn_source.details
+
+    _definition.id                '_diffrn_source.details'
+    _alias.definition_id          '_diffrn_source_details'
+    _definition.update            2021-08-18
+    _description.text
+;
+    A description of special aspects of the source not covered by
+    other data items.
+;
+    _name.category_id             diffrn_source
+    _name.object_id               details
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_diffrn_source.device
+
+    _definition.id                '_diffrn_source.device'
+    _definition.update            2018-02-26
+    _description.text
+;
+    Enumerated code for the device providing the source of radiation.
+;
+    _name.category_id             diffrn_source
+    _name.object_id               device
+    _type.purpose                 State
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Text
+
+    loop_
+      _enumeration_set.state
+      _enumeration_set.detail
+         tube                     'Sealed X-ray tube.'
+         nuclear                  'Nuclear reactor.'
+         spallation               'Spallation source.'
+         elect-micro              'Electron microscope.'
+         rot_anode                'Rotating-anode X-ray tube.'
+         synch                    'Synchrotron.'
+
+save_
+
+save_diffrn_source.facility
+
+    _definition.id                '_diffrn_source.facility'
+    _definition.update            2020-09-18
+    _description.text
+;
+    The name of the synchrotron or other large-scale
+    experimental facility at which the experiment was
+    conducted. Names should conform to the spelling and
+    format used in the 'Light Sources of the World' listing
+    of lightsources.org
+    (https://lightsources.org/lightsources-of-the-world/)
+;
+    _name.category_id             diffrn_source
+    _name.object_id               facility
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+    _description_example.case     'Diamond Light Source'
+
+save_
+
+save_diffrn_source.make
+
+    _definition.id                '_diffrn_source.make'
+
+    loop_
+      _alias.definition_id
+         '_diffrn_source_make'
+         '_diffrn_source.type'
+         '_diffrn_source_type'
+
+    _definition.update            2021-07-26
+    _description.text
+;
+    Description of the make, model or name of the source device.
+    Large scale facilities should use _diffrn_source.facility and
+    _diffrn_source.beamline to identify the source of radiation.
+;
+    _name.category_id             diffrn_source
+    _name.object_id               make
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+    _description_example.case     'Rigaku RU2012-05-07'
+
+save_
+
+save_diffrn_source.power
+
+    _definition.id                '_diffrn_source.power'
+    _alias.definition_id          '_diffrn_source_power'
+    _definition.update            2012-11-26
+    _description.text
+;
+    Generator power at which the radiation source device was operated.
+;
+    _name.category_id             diffrn_source
+    _name.object_id               power
+    _type.purpose                 Number
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   kilowatts
+
+save_
+
+save_diffrn_source.size
+
+    _definition.id                '_diffrn_source.size'
+    _alias.definition_id          '_diffrn_source_size'
+    _definition.update            2012-11-26
+    _description.text
+;
+    Description of the collimated source beam as viewed from the sample.
+;
+    _name.category_id             diffrn_source
+    _name.object_id               size
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+
+    loop_
+      _description_example.case
+         '8 mm x 0.4 mm fine-focus'
+         'broad focus'
+
+save_
+
+save_diffrn_source.take_off_angle
+
+    _definition.id                '_diffrn_source.take_off_angle'
+
+    loop_
+      _alias.definition_id
+         '_diffrn_source_take-off_angle'
+         '_diffrn_source.take-off_angle'
+
+    _definition.update            2013-02-22
+    _description.text
+;
+    The complement of the angle in degrees between the normal
+    to the surface of the X-ray tube target and the primary
+    X-ray beam for beams generated by traditional X-ray tubes.
+;
+    _name.category_id             diffrn_source
+    _name.object_id               take_off_angle
+    _type.purpose                 Number
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:90.0
+    _units.code                   degrees
+
+save_
+
+save_diffrn_source.target
+
+    _definition.id                '_diffrn_source.target'
+    _alias.definition_id          '_diffrn_source_target'
+    _definition.update            2021-10-27
+    _description.text
+;
+    Chemical element symbol for the radiation source target (usually
+    the anode). This can be used also for spallation sources.
+;
+    _name.category_id             diffrn_source
+    _name.object_id               target
+    _type.purpose                 State
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Word
+
+    _import.get
+        [{'file':templ_enum.cif  'save':element_symbol}]
+
+save_
+
+save_diffrn_source.voltage
+
+    _definition.id                '_diffrn_source.voltage'
+    _alias.definition_id          '_diffrn_source_voltage'
+    _definition.update            2012-11-26
+    _description.text
+;
+    Generator voltage at which the radiation source device was operated.
+;
+    _name.category_id             diffrn_source
+    _name.object_id               voltage
+    _type.purpose                 Number
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   kilovolts
+
+save_
+
+save_DIFFRN_STANDARDS
+
+    _definition.id                DIFFRN_STANDARDS
+    _definition.scope             Category
+    _definition.class             Set
+    _definition.update            2023-01-10
+    _description.text
+;
+    The CATEGORY of data items which specify information about the
+    standard reflections used in the diffraction measurement process.
+;
+    _name.category_id             DIFFRN
+    _name.object_id               DIFFRN_STANDARDS
+
+save_
+
+save_diffrn_standards.decay_percent
+
+    _definition.id                '_diffrn_standards.decay_percent'
+
+    loop_
+      _alias.definition_id
+         '_diffrn_standards_decay_%'
+         '_diffrn_standards.decay_%'
+         '_diffrn_standards_decay_percent'
+
+    _definition.update            2023-01-13
+    _description.text
+;
+    The percentage decrease in the mean of the intensities for the
+    standard reflections at the start to the finish of the measurement
+    process. This value affords a measure of the overall decay in
+    crystal quality during measurement. Negative values only occur in
+    exceptional instances where the final intensities are greater than
+    the initial ones. If no measurable decay has occurred, the
+    standard uncertainty should be quoted to indicate the maximum
+    possible value the decay might have. A range of 3 standard
+    uncertainties is considered possible. Thus 0.0(1) would indicate
+    a decay of less than 0.3% or an enhancement of less than 0.3%.
+;
+    _name.category_id             diffrn_standards
+    _name.object_id               decay_percent
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            :100.0
+    _units.code                   none
+
+    loop_
+      _description_example.case
+      _description_example.detail
+         0.5(1)         'Represents a decay between 0.2% and 0.8%.'
+         -1(1)          'Change in standards between 2% decay and 4% rise.'
+         0.0(2)         'Change in standards between 0.6% decay and 0.6% rise.'
+
+save_
+
+save_diffrn_standards.decay_percent_su
+
+    _definition.id                '_diffrn_standards.decay_percent_su'
+    _definition.update            2023-07-01
+    _description.text
+;
+    Standard uncertainty of _diffrn_standards.decay_percent.
+;
+    _name.category_id             diffrn_standards
+    _name.object_id               decay_percent_su
+    _name.linked_item_id          '_diffrn_standards.decay_percent'
+    _units.code                   none
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+save_
+
+save_diffrn_standards.interval_count
+
+    _definition.id                '_diffrn_standards.interval_count'
+    _alias.definition_id          '_diffrn_standards_interval_count'
+    _definition.update            2023-01-10
+    _description.text
+;
+    Reflection count between the standard reflection measurements.
+;
+    _name.category_id             diffrn_standards
+    _name.object_id               interval_count
+    _type.purpose                 Number
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Integer
+    _enumeration.range            0:
+    _units.code                   none
+
+save_
+
+save_diffrn_standards.interval_time
+
+    _definition.id                '_diffrn_standards.interval_time'
+    _alias.definition_id          '_diffrn_standards_interval_time'
+    _definition.update            2023-01-10
+    _description.text
+;
+    Time between the standard reflection measurements.
+;
+    _name.category_id             diffrn_standards
+    _name.object_id               interval_time
+    _type.purpose                 Number
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   minutes
+
+save_
+
+save_diffrn_standards.number
+
+    _definition.id                '_diffrn_standards.number'
+    _alias.definition_id          '_diffrn_standards_number'
+    _definition.update            2023-01-10
+    _description.text
+;
+    Number of unique standard reflections used in measurements.
+;
+    _name.category_id             diffrn_standards
+    _name.object_id               number
+    _type.purpose                 Number
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Integer
+    _enumeration.range            0:
+    _units.code                   none
+
+save_
+
+save_diffrn_standards.scale_su_average
+
+    _definition.id                '_diffrn_standards.scale_su_average'
+
+    loop_
+      _alias.definition_id
+      _alias.deprecation_date
+         '_diffrn_standards_scale_sigma'                             1999-03-24
+         '_diffrn_standards.scale_sigma'                             .
+         '_diffrn_standards.scale_u'                                 .
+         '_diffrn_standards_scale_u'                                 .
+
+    _definition.update            2024-02-14
+    _description.text
+;
+    The average standard uncertainty of the individual standard scales
+    applied to the intensity data.
+;
+    _name.category_id             diffrn_standards
+    _name.object_id               scale_su_average
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   none
+
+save_
+
+save_diffrn_standards.scale_su_average_su
+
+    _definition.id                '_diffrn_standards.scale_su_average_su'
+    _definition.update            2023-07-01
+    _description.text
+;
+    Standard uncertainty of _diffrn_standards.scale_su_average.
+;
+    _name.category_id             diffrn_standards
+    _name.object_id               scale_su_average_su
+    _name.linked_item_id          '_diffrn_standards.scale_su_average'
+    _units.code                   none
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+save_
+
+save_DIFFRN_STANDARD_REFLN
+
+    _definition.id                DIFFRN_STANDARD_REFLN
+    _definition.scope             Category
+    _definition.class             Loop
+    _definition.update            2021-06-29
+    _description.text
+;
+    The CATEGORY of data items which specify the "standard" reflections
+    measured repeatedly to monitor variations in intensity due to source
+    flux, environment conditions or crystal quality.
+;
+    _name.category_id             DIFFRN_STANDARDS
+    _name.object_id               DIFFRN_STANDARD_REFLN
+
+    loop_
+      _category_key.name
+         '_diffrn_standard_refln.index_h'
+         '_diffrn_standard_refln.index_k'
+         '_diffrn_standard_refln.index_l'
+
+save_
+
+save_diffrn_standard_refln.code
+
+    _definition.id                '_diffrn_standard_refln.code'
+
+    loop_
+      _alias.definition_id
+         '_diffrn_standard_refln_code'
+         '_diffrn_standard_refln.diffrn_id'
+
+    _definition.update            2021-10-27
+    _description.text
+;
+    Code identifying a standard reflection used to monitor source
+    intensity variations or crystal degradation or movement during
+    data collection.
+;
+    _name.category_id             diffrn_standard_refln
+    _name.object_id               code
+    _type.purpose                 Encode
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Word
+    _description_example.case     s1
+
+save_
+
+save_diffrn_standard_refln.hkl
+
+    _definition.id                '_diffrn_standard_refln.hkl'
+    _definition.update            2021-03-01
+    _description.text
+;
+    Miller indices of a standard reflection.
+;
+    _name.category_id             diffrn_standard_refln
+    _name.object_id               hkl
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Matrix
+    _type.dimension               '[3]'
+    _type.contents                Integer
+    _units.code                   none
+    _method.purpose               Evaluation
+    _method.expression
+;
+    With d as diffrn_standard_refln
+
+     _diffrn_standard_refln.hkl =  [d.index_h, d.index_h, d.index_l]
+;
+
+save_
+
+save_diffrn_standard_refln.index_h
+
+    _definition.id                '_diffrn_standard_refln.index_h'
+    _alias.definition_id          '_diffrn_standard_refln_index_h'
+    _name.category_id             diffrn_standard_refln
+    _name.object_id               index_h
+
+    _import.get                   [{'file':templ_attr.cif  'save':miller_index}]
+
+save_
+
+save_diffrn_standard_refln.index_k
+
+    _definition.id                '_diffrn_standard_refln.index_k'
+    _alias.definition_id          '_diffrn_standard_refln_index_k'
+    _name.category_id             diffrn_standard_refln
+    _name.object_id               index_k
+
+    _import.get                   [{'file':templ_attr.cif  'save':miller_index}]
+
+save_
+
+save_diffrn_standard_refln.index_l
+
+    _definition.id                '_diffrn_standard_refln.index_l'
+    _alias.definition_id          '_diffrn_standard_refln_index_l'
+    _name.category_id             diffrn_standard_refln
+    _name.object_id               index_l
+
+    _import.get                   [{'file':templ_attr.cif  'save':miller_index}]
+
+save_
+
+save_REFLN
+
+    _definition.id                REFLN
+    _definition.scope             Category
+    _definition.class             Loop
+    _definition.update            2024-11-12
+    _description.text
+;
+    The CATEGORY of data items used to describe the reflection data
+    used in the refinement of a crystallographic structure model.
+;
+    _name.category_id             DIFFRACTION
+    _name.object_id               REFLN
+    _category_key.name            '_refln.id'
+
+save_
+
+save_refln.a_calc
+
+    _definition.id                '_refln.A_calc'
+    _alias.definition_id          '_refln_A_calc'
+    _definition.update            2012-11-26
+    _description.text
+;
+    The calculated real structure-factor component A =|Fcalc|cos(phase)
+;
+    _name.category_id             refln
+    _name.object_id               A_calc
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+
+    loop_
+      _method.purpose
+      _method.expression
+         Definition
+;
+              If (_diffrn_radiation.probe == "neutron")  _units.code =
+         "femtometres" Else If (_diffrn_radiation.probe == "electron")
+         _units.code =  "volts" Else
+         _units.code =  "electrons"
+;
+         Evaluation
+;
+         _refln.A_calc =  Real ( _refln.F_complex )
+;
+
+save_
+
+save_refln.a_calc_su
+
+    _definition.id                '_refln.A_calc_su'
+    _definition.update            2023-07-01
+    _description.text
+;
+    Standard uncertainty of _refln.A_calc.
+;
+    _name.category_id             refln
+    _name.object_id               A_calc_su
+    _name.linked_item_id          '_refln.A_calc'
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+    _method.purpose               Definition
+    _method.expression
+;
+         If (_diffrn_radiation.probe == "neutron")  _units.code =
+    "femtometres" Else If (_diffrn_radiation.probe == "electron")
+    _units.code =  "volts" Else
+    _units.code =  "electrons"
+;
+
+save_
+
+save_refln.a_meas
+
+    _definition.id                '_refln.A_meas'
+    _alias.definition_id          '_refln_A_meas'
+    _definition.update            2012-11-26
+    _description.text
+;
+    The measured real structure-factor component A =|Fmeas|cos(phase)
+;
+    _name.category_id             refln
+    _name.object_id               A_meas
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _method.purpose               Definition
+    _method.expression
+;
+         If (_diffrn_radiation.probe == "neutron")  _units.code =  "femtometres"
+    Else If (_diffrn_radiation.probe == "electron") _units.code =  "volts"
+    Else                                            _units.code =  "electrons"
+;
+
+save_
+
+save_refln.a_meas_su
+
+    _definition.id                '_refln.A_meas_su'
+    _definition.update            2023-07-01
+    _description.text
+;
+    Standard uncertainty of _refln.A_meas.
+;
+    _name.category_id             refln
+    _name.object_id               A_meas_su
+    _name.linked_item_id          '_refln.A_meas'
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+    _method.purpose               Definition
+    _method.expression
+;
+         If (_diffrn_radiation.probe == "neutron")  _units.code =  "femtometres"
+    Else If (_diffrn_radiation.probe == "electron") _units.code =  "volts"
+    Else                                            _units.code =  "electrons"
+;
+
+save_
+
+save_refln.b_calc
+
+    _definition.id                '_refln.B_calc'
+    _alias.definition_id          '_refln_B_calc'
+    _definition.update            2012-11-26
+    _description.text
+;
+    The calculated imaginary structure-factor component B =|Fcalc|sin(phase)
+;
+    _name.category_id             refln
+    _name.object_id               B_calc
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+
+    loop_
+      _method.purpose
+      _method.expression
+         Definition
+;
+              If (_diffrn_radiation.probe == "neutron")  _units.code =
+         "femtometres" Else If (_diffrn_radiation.probe == "electron")
+         _units.code =  "volts" Else
+         _units.code =  "electrons"
+;
+         Evaluation
+;
+         _refln.B_calc =  Imag ( _refln.F_complex )
+;
+
+save_
+
+save_refln.b_calc_su
+
+    _definition.id                '_refln.B_calc_su'
+    _definition.update            2023-07-01
+    _description.text
+;
+    Standard uncertainty of _refln.B_calc.
+;
+    _name.category_id             refln
+    _name.object_id               B_calc_su
+    _name.linked_item_id          '_refln.B_calc'
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+    _method.purpose               Definition
+    _method.expression
+;
+         If (_diffrn_radiation.probe == "neutron")  _units.code =
+    "femtometres" Else If (_diffrn_radiation.probe == "electron")
+    _units.code =  "volts" Else
+    _units.code =  "electrons"
+;
+
+save_
+
+save_refln.b_meas
+
+    _definition.id                '_refln.B_meas'
+    _alias.definition_id          '_refln_B_meas'
+    _definition.update            2012-11-26
+    _description.text
+;
+    The measured imaginary structure-factor component B =|Fmeas|sin(phase)
+;
+    _name.category_id             refln
+    _name.object_id               B_meas
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _method.purpose               Definition
+    _method.expression
+;
+         If (_diffrn_radiation.probe == "neutron")  _units.code =  "femtometres"
+    Else If (_diffrn_radiation.probe == "electron") _units.code =  "volts"
+    Else                                            _units.code =  "electrons"
+;
+
+save_
+
+save_refln.b_meas_su
+
+    _definition.id                '_refln.B_meas_su'
+    _definition.update            2023-07-01
+    _description.text
+;
+    Standard uncertainty of _refln.B_meas.
+;
+    _name.category_id             refln
+    _name.object_id               B_meas_su
+    _name.linked_item_id          '_refln.B_meas'
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+    _method.purpose               Definition
+    _method.expression
+;
+         If (_diffrn_radiation.probe == "neutron")  _units.code =  "femtometres"
+    Else If (_diffrn_radiation.probe == "electron") _units.code =  "volts"
+    Else                                            _units.code =  "electrons"
+;
+
+save_
+
+save_refln.class_code
+
+    _definition.id                '_refln.class_code'
+    _alias.definition_id          '_refln_class_code'
+    _definition.update            2021-10-27
+    _description.text
+;
+    Code identifying the class to which this reflection has been
+    assigned. This code must match a value of _reflns_class.code.
+    Reflections may be grouped into classes for a variety of
+    purposes. For example, for modulated structures each reflection
+    class may be defined by the number m=sum|m~i~|, where the m~i~
+    are the integer coefficients that, in addition to h,k,l, index
+    the corresponding diffraction vector in the basis defined
+    for the reciprocal lattice.
+;
+    _name.category_id             refln
+    _name.object_id               class_code
+    _name.linked_item_id          '_reflns_class.code'
+    _type.purpose                 Link
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Word
+
+save_
+
+save_refln.d_spacing
+
+    _definition.id                '_refln.d_spacing'
+    _alias.definition_id          '_refln_d_spacing'
+    _definition.update            2012-11-26
+    _description.text
+;
+    The distance in angstroms between lattice planes in the crystal
+    with the indices _refln.hkl for this reflection.
+;
+    _name.category_id             refln
+    _name.object_id               d_spacing
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   angstroms
+    _method.purpose               Evaluation
+    _method.expression
+;
+    _refln.d_spacing = 1 / (2 * _refln.sin_theta_over_lambda)
+;
+
+save_
+
+save_refln.f_calc
+
+    _definition.id                '_refln.F_calc'
+    _alias.definition_id          '_refln_F_calc'
+    _definition.update            2013-02-21
+    _description.text
+;
+    The structure factor amplitude for the reflection calculated from
+    the atom site data.
+;
+    _name.category_id             refln
+    _name.object_id               F_calc
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+
+    loop_
+      _method.purpose
+      _method.expression
+         Definition
+;
+              If (_diffrn_radiation.probe == "neutron")  _units.code =
+         "femtometres" Else If (_diffrn_radiation.probe == "electron")
+         _units.code =  "volts" Else
+         _units.code =  "electrons"
+;
+         Evaluation
+;
+         _refln.F_calc  =   Magn ( _refln.F_complex )
+;
+
+save_
+
+save_refln.f_calc_su
+
+    _definition.id                '_refln.F_calc_su'
+    _definition.update            2023-07-01
+    _description.text
+;
+    Standard uncertainty of _refln.F_calc.
+;
+    _name.category_id             refln
+    _name.object_id               F_calc_su
+    _name.linked_item_id          '_refln.F_calc'
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+    _method.purpose               Definition
+    _method.expression
+;
+         If (_diffrn_radiation.probe == "neutron")  _units.code =
+    "femtometres" Else If (_diffrn_radiation.probe == "electron")
+    _units.code =  "volts" Else
+    _units.code =  "electrons"
+;
+
+save_
+
+save_refln.f_complex
+
+    _definition.id                '_refln.F_complex'
+    _alias.definition_id          '_refln_F_complex'
+    _definition.update            2016-05-13
+    _description.text
+;
+    The structure factor vector for the reflection calculated from
+    the atom site data.
+;
+    _name.category_id             refln
+    _name.object_id               F_complex
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Complex
+
+    loop_
+      _method.purpose
+      _method.expression
+         Definition
+;
+              If (_diffrn_radiation.probe == "neutron")  _units.code =
+         "femtometres" Else If (_diffrn_radiation.probe == "electron")
+         _units.code =  "volts" Else
+         _units.code =  "electrons"
+;
+         Evaluation
+;
+         With r  as  refln
+
+            fc  =   Complex (0., 0.)
+            h   =   r.hkl
+
+         Loop a  as  atom_site  {
+
+                f  =   a.site_symmetry_multiplicity * a.occupancy * (
+                               r.form_factor_table [a.type_symbol]      +
+                              _atom_type_scat[a.type_symbol].dispersion  )
+
+            Loop s  as  space_group_symop  {
+
+                t   =  Exp(-h * s.R * a.matrix_beta * s.RT * h)
+
+                fc +=  f * t * ExpImag(TwoPi *( h *( s.R * a.fract_xyz + s.T)))
+         }  }
+                _refln.F_complex  =   fc / _space_group.multiplicity
+;
+
+save_
+
+save_refln.f_complex_su
+
+    _definition.id                '_refln.F_complex_su'
+    _definition.update            2023-07-01
+    _description.text
+;
+    Standard uncertainty of _refln.F_complex.
+;
+    _name.category_id             refln
+    _name.object_id               F_complex_su
+    _name.linked_item_id          '_refln.F_complex'
+    _type.purpose                 SU
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Complex
+    _method.purpose               Definition
+    _method.expression
+;
+         If (_diffrn_radiation.probe == "neutron")  _units.code =
+    "femtometres" Else If (_diffrn_radiation.probe == "electron")
+    _units.code =  "volts" Else
+    _units.code =  "electrons"
+;
+
+save_
+
+save_refln.f_meas
+
+    _definition.id                '_refln.F_meas'
+    _alias.definition_id          '_refln_F_meas'
+    _definition.update            2013-02-21
+    _description.text
+;
+    The structure factor amplitude for the reflection derived from the
+    measured intensities.
+;
+    _name.category_id             refln
+    _name.object_id               F_meas
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _method.purpose               Definition
+    _method.expression
+;
+         If (_diffrn_radiation.probe == "neutron")  _units.code =  "femtometres"
+    Else If (_diffrn_radiation.probe == "electron") _units.code =  "volts"
+    Else                                            _units.code =  "electrons"
+;
+
+save_
+
+save_refln.f_meas_su
+
+    _definition.id                '_refln.F_meas_su'
+
+    loop_
+      _alias.definition_id
+         '_refln_F_sigma'
+         '_refln.F_meas_sigma'
+         '_refln_F_meas_su'
+
+    _definition.update            2021-03-03
+    _description.text
+;
+    Standard uncertainty of _refln.F_meas.
+;
+    _name.category_id             refln
+    _name.object_id               F_meas_su
+    _name.linked_item_id          '_refln.F_meas'
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+    _method.purpose               Definition
+    _method.expression
+;
+         If (_diffrn_radiation.probe == "neutron")  _units.code =  "femtometres"
+    Else If (_diffrn_radiation.probe == "electron") _units.code =  "volts"
+    Else                                            _units.code =  "electrons"
+;
+
+save_
+
+save_refln.f_squared_calc
+
+    _definition.id                '_refln.F_squared_calc'
+    _alias.definition_id          '_refln_F_squared_calc'
+    _definition.update            2012-11-26
+    _description.text
+;
+    The structure factor amplitude squared for the reflection calculated from
+    the atom site data.
+;
+    _name.category_id             refln
+    _name.object_id               F_squared_calc
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _method.purpose               Definition
+    _method.expression
+;
+    If      (_diffrn_radiation.probe == "neutron")
+                                         _units.code =  "femtometre_squared"
+    Else If (_diffrn_radiation.probe == "electron")
+                                         _units.code =  "volt_squared"
+    Else                                 _units.code =  "electron_squared"
+;
+
+save_
+
+save_refln.f_squared_calc_su
+
+    _definition.id                '_refln.F_squared_calc_su'
+    _definition.update            2023-07-01
+    _description.text
+;
+    Standard uncertainty of _refln.F_squared_calc.
+;
+    _name.category_id             refln
+    _name.object_id               F_squared_calc_su
+    _name.linked_item_id          '_refln.F_squared_calc'
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+    _method.purpose               Definition
+    _method.expression
+;
+    If      (_diffrn_radiation.probe == "neutron")
+                                         _units.code =  "femtometre_squared"
+    Else If (_diffrn_radiation.probe == "electron")
+                                         _units.code =  "volt_squared"
+    Else                                 _units.code =  "electron_squared"
+;
+
+save_
+
+save_refln.f_squared_meas
+
+    _definition.id                '_refln.F_squared_meas'
+    _alias.definition_id          '_refln_F_squared_meas'
+    _definition.update            2013-02-21
+    _description.text
+;
+    The structure factor amplitude for the reflection derived from the
+    measured intensities.
+;
+    _name.category_id             refln
+    _name.object_id               F_squared_meas
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _method.purpose               Definition
+    _method.expression
+;
+    If      (_diffrn_radiation.probe == "neutron")
+                                         _units.code =  "femtometre_squared"
+    Else If (_diffrn_radiation.probe == "electron")
+                                         _units.code =  "volt_squared"
+    Else                                 _units.code =  "electron_squared"
+;
+
+save_
+
+save_refln.f_squared_meas_su
+
+    _definition.id                '_refln.F_squared_meas_su'
+
+    loop_
+      _alias.definition_id
+         '_refln_F_squared_sigma'
+         '_refln.F_squared_sigma'
+         '_refln_F_squared_meas_su'
+
+    _definition.update            2021-03-03
+    _description.text
+;
+    Standard uncertainty of _refln.F_squared_meas.
+;
+    _name.category_id             refln
+    _name.object_id               F_squared_meas_su
+    _name.linked_item_id          '_refln.F_squared_meas'
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+    _method.purpose               Definition
+    _method.expression
+;
+    If      (_diffrn_radiation.probe == "neutron")
+                                         _units.code =  "femtometre_squared"
+    Else If (_diffrn_radiation.probe == "electron")
+                                         _units.code =  "volt_squared"
+    Else                                 _units.code =  "electron_squared"
+;
+
+save_
+
+save_refln.fom
+
+    _definition.id                '_refln.fom'
+    _definition.update            2021-03-01
+    _description.text
+;
+    The figure of merit m for this reflection.
+
+        int P~α~ exp(i*α) dα
+    m = --------------------
+            int P~α~ dα
+
+    P~α~ = the probability that the phase angle α is correct
+
+    int is taken over the range α = 0 to 2 π.
+;
+    _name.category_id             refln
+    _name.object_id               fom
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _units.code                   none
+
+save_
+
+save_refln.form_factor_table
+
+    _definition.id                '_refln.form_factor_table'
+    _definition.update            2023-06-16
+    _description.text
+;
+    Atomic scattering factor table for the scattering angle
+    of this diffraction vector and atom types in structure.
+;
+    _name.category_id             refln
+    _name.object_id               form_factor_table
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Table
+    _type.contents                Real
+
+    loop_
+      _method.purpose
+      _method.expression
+         Definition
+;
+         _units.code = "none"
+
+         If (_diffrn_radiation.probe == "neutron")
+             _units.code = "femtometres"
+;
+         Evaluation
+;
+         With r  as  refln
+
+           table = Table ()
+           s  =    r.sin_theta_over_lambda
+
+           Loop t  as  atom_type  {
+
+             If (_diffrn_radiation.probe == 'neutron') {
+
+               f  =   t.length_neutron
+
+             } Else If (s < 2.0 ) {
+
+               c  =   t.Cromer_Mann_coeffs
+
+               f  =  (c[0] + c[1] * Exp (-c[2] * s*s)
+                           + c[3] * Exp (-c[4] * s*s)
+                           + c[5] * Exp (-c[6] * s*s)
+                           + c[7] * Exp (-c[8] * s*s))
+             } Else {
+
+               c  =   t.hi_ang_Fox_coeffs
+
+               f  =   Exp ( c[0] + c[1]*s + c[2]*s*s + c[3]*s*s*s )
+             }
+
+             table [ t.symbol ]  =   f
+
+           }
+         _refln.form_factor_table  =   table
+;
+
+save_
+
+save_refln.hkl
+
+    _definition.id                '_refln.hkl'
+    _definition.update            2021-03-01
+    _description.text
+;
+    The Miller indices as a reciprocal space vector.
+;
+    _name.category_id             refln
+    _name.object_id               hkl
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Matrix
+    _type.dimension               '[3]'
+    _type.contents                Integer
+    _units.code                   none
+    _method.purpose               Evaluation
+    _method.expression
+;
+    With r  as  refln
+
+           _refln.hkl =  [r.index_h, r.index_k, r.index_l]
+;
+
+save_
+
+save_refln.id
+
+    _definition.id                '_refln.id'
+    _definition.update            2024-11-12
+    _description.text
+;
+    _refln.id must uniquely identify the reflection.
+
+    Note that this item need not be a number; it can be any unique
+    identifier.
+;
+    _name.category_id             refln
+    _name.object_id               id
+    _type.purpose                 Key
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Word
+
+save_
+
+save_refln.include_status
+
+    _definition.id                '_refln.include_status'
+
+    loop_
+      _alias.definition_id
+      _alias.deprecation_date
+         '_refln_include_status'                                     .
+         '_refln_observed_status'                                    1999-03-24
+         '_refln.observed_status'                                    .
+         '_refln.status'                                             .
+
+    _definition.update            2024-02-14
+    _description.text
+;
+    Code indicating how the reflection was included in the refinement
+    and R-factor calculations.
+;
+    _name.category_id             refln
+    _name.object_id               include_status
+    _type.purpose                 State
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Text
+
+    loop_
+      _enumeration_set.state
+      _enumeration_set.detail
+         o    'ob : within _reflns.threshold_expression; within d-res limits.'
+         <    'lt : without _reflns.threshold_expression; within d-res limits.'
+         -    'sa : systematically absent reflection due to symmetry.'
+         x    'du : deemed unreliable measurement -- not used.'
+         h    'hd : above _refine_ls.d_res_high.'
+         l    'ld : below _refine_ls.d_res_low.'
+
+save_
+
+save_refln.index_h
+
+    _definition.id                '_refln.index_h'
+    _alias.definition_id          '_refln_index_h'
+    _name.category_id             refln
+    _name.object_id               index_h
+
+    _import.get                   [{'file':templ_attr.cif  'save':miller_index}]
+
+save_
+
+save_refln.index_k
+
+    _definition.id                '_refln.index_k'
+    _alias.definition_id          '_refln_index_k'
+    _name.category_id             refln
+    _name.object_id               index_k
+
+    _import.get                   [{'file':templ_attr.cif  'save':miller_index}]
+
+save_
+
+save_refln.index_l
+
+    _definition.id                '_refln.index_l'
+    _alias.definition_id          '_refln_index_l'
+    _name.category_id             refln
+    _name.object_id               index_l
+
+    _import.get                   [{'file':templ_attr.cif  'save':miller_index}]
+
+save_
+
+save_refln.intensity_calc
+
+    _definition.id                '_refln.intensity_calc'
+    _alias.definition_id          '_refln_intensity_calc'
+    _definition.update            2012-11-26
+    _description.text
+;
+    The intensity of the reflection calculated from the atom site data.
+;
+    _name.category_id             refln
+    _name.object_id               intensity_calc
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   none
+    _method.purpose               Evaluation
+    _method.expression
+;
+    _refln.intensity_calc  =   _refln.F_squared_calc / _refln.Lp_factor
+;
+
+save_
+
+save_refln.intensity_calc_su
+
+    _definition.id                '_refln.intensity_calc_su'
+    _definition.update            2023-07-01
+    _description.text
+;
+    Standard uncertainty of _refln.intensity_calc.
+;
+    _name.category_id             refln
+    _name.object_id               intensity_calc_su
+    _name.linked_item_id          '_refln.intensity_calc'
+    _units.code                   none
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+save_
+
+save_refln.intensity_meas
+
+    _definition.id                '_refln.intensity_meas'
+    _alias.definition_id          '_refln_intensity_meas'
+    _definition.update            2013-04-11
+    _description.text
+;
+    The intensity of the reflection derived from the diffraction measurements.
+;
+    _name.category_id             refln
+    _name.object_id               intensity_meas
+    _type.purpose                 Measurand
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   none
+
+save_
+
+save_refln.intensity_meas_su
+
+    _definition.id                '_refln.intensity_meas_su'
+
+    loop_
+      _alias.definition_id
+         '_refln_intensity_meas_su'
+         '_refln.intensity_sigma'
+         '_refln_intensity_sigma'
+
+    _definition.update            2021-03-03
+    _description.text
+;
+    Standard uncertainty of _refln.intensity_meas.
+;
+    _name.category_id             refln
+    _name.object_id               intensity_meas_su
+    _name.linked_item_id          '_refln.intensity_meas'
+    _units.code                   none
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+save_
+
+save_refln.lp_factor
+
+    _definition.id                '_refln.Lp_factor'
+    _alias.definition_id          '_refln_Lp_factor'
+    _definition.update            2012-11-26
+    _description.text
+;
+    The Lorentz-polarization factor appropriate for the instrument
+    used to measure the diffraction intensity. This is applied to
+    convert the net intensity into the measured F squared.
+;
+    _name.category_id             refln
+    _name.object_id               Lp_factor
+    _type.purpose                 Number
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   none
+
+save_
+
+save_refln.mean_path_length_tbar
+
+    _definition.id                '_refln.mean_path_length_tbar'
+    _alias.definition_id          '_refln_mean_path_length_tbar'
+    _definition.update            2012-11-26
+    _description.text
+;
+    Mean path length through the crystal for this diffraction vector.
+;
+    _name.category_id             refln
+    _name.object_id               mean_path_length_tbar
+    _type.purpose                 Number
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   millimetres
+
+save_
+
+save_refln.phase_calc
+
+    _definition.id                '_refln.phase_calc'
+    _alias.definition_id          '_refln_phase_calc'
+    _definition.update            2013-04-27
+    _description.text
+;
+    The phase of the calculated structure-factor.
+;
+    _name.category_id             refln
+    _name.object_id               phase_calc
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:360.0
+    _units.code                   degrees
+    _method.purpose               Evaluation
+    _method.expression
+;
+    phase  = Atan2d ( _refln.B_calc, _refln.A_calc )
+      If(phase < 0.) _refln.phase_calc = phase + 360.
+      Else           _refln.phase_calc = phase
+;
+
+save_
+
+save_refln.phase_calc_su
+
+    _definition.id                '_refln.phase_calc_su'
+    _definition.update            2023-07-01
+    _description.text
+;
+    Standard uncertainty of _refln.phase_calc.
+;
+    _name.category_id             refln
+    _name.object_id               phase_calc_su
+    _name.linked_item_id          '_refln.phase_calc'
+    _units.code                   degrees
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+save_
+
+save_refln.phase_meas
+
+    _definition.id                '_refln.phase_meas'
+    _alias.definition_id          '_refln_phase_meas'
+    _definition.update            2012-11-26
+    _description.text
+;
+    The phase of the measured structure-factor. This may be derived from
+    the atom site data if available or from the phase solution process
+    prior to determination of the structure.
+;
+    _name.category_id             refln
+    _name.object_id               phase_meas
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:360.0
+    _units.code                   degrees
+
+save_
+
+save_refln.phase_meas_su
+
+    _definition.id                '_refln.phase_meas_su'
+    _definition.update            2023-07-01
+    _description.text
+;
+    Standard uncertainty of _refln.phase_meas.
+;
+    _name.category_id             refln
+    _name.object_id               phase_meas_su
+    _name.linked_item_id          '_refln.phase_meas'
+    _units.code                   degrees
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+save_
+
+save_refln.refinement_status
+
+    _definition.id                '_refln.refinement_status'
+    _alias.definition_id          '_refln_refinement_status'
+    _definition.update            2012-11-26
+    _description.text
+;
+    Status code of reflection in the structure refinement process.
+;
+    _name.category_id             refln
+    _name.object_id               refinement_status
+    _type.purpose                 State
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Text
+
+    loop_
+      _enumeration_set.state
+      _enumeration_set.detail
+         incl                     'Included in ls process.'
+         excl                     'Excluded from ls process.'
+         extn                     'Excluded due to extinction.'
+
+save_
+
+save_refln.scale_group_code
+
+    _definition.id                '_refln.scale_group_code'
+    _alias.definition_id          '_refln_scale_group_code'
+    _definition.update            2021-11-04
+    _description.text
+;
+    Code identifying the scale (if there is more than one scale) used
+    convert the measured structure factor to a common absolute value.
+;
+    _name.category_id             refln
+    _name.object_id               scale_group_code
+    _name.linked_item_id          '_reflns_scale.group_code'
+    _type.purpose                 Link
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Word
+
+save_
+
+save_refln.sin_theta_over_lambda
+
+    _definition.id                '_refln.sin_theta_over_lambda'
+
+    loop_
+      _alias.definition_id
+         '_refln_sint/lambda'
+         '_refln_sin_theta_over_lambda'
+         '_refln.sint_over_lambda'
+
+    _definition.update            2013-03-07
+    _description.text
+;
+    The sin(θ)/λ value for this reflection.
+;
+    _name.category_id             refln
+    _name.object_id               sin_theta_over_lambda
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   reciprocal_angstroms
+    _method.purpose               Evaluation
+    _method.expression
+;
+    With r  as  refln
+                           h =  r.hkl
+                           G =  _cell.reciprocal_metric_tensor
+
+    r.sin_theta_over_lambda  =   Sqrt ( h * G * h ) / 2.
+;
+
+save_
+
+save_refln.symmetry_epsilon
+
+    _definition.id                '_refln.symmetry_epsilon'
+    _alias.definition_id          '_refln_symmetry_epsilon'
+    _definition.update            2021-03-01
+    _description.text
+;
+    The symmetry reinforcement factor corresponding to the number of
+    times the reflection indices are generated identically from the
+    space-group symmetry operations.
+;
+    _name.category_id             refln
+    _name.object_id               symmetry_epsilon
+    _type.purpose                 Number
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Integer
+    _enumeration.range            1:48
+    _units.code                   none
+
+save_
+
+save_refln.symmetry_multiplicity
+
+    _definition.id                '_refln.symmetry_multiplicity'
+    _alias.definition_id          '_refln_symmetry_multiplicity'
+    _definition.update            2021-03-01
+    _description.text
+;
+    The number of reflections symmetry-equivalent under the Laue
+    symmetry to the present reflection. In the Laue symmetry, Friedel
+    opposites (h k l and -h -k -l) are equivalent. Tables of
+    symmetry-equivalent reflections are available in International
+    Tables for Crystallography, Volume A (1987), section 10.2.
+;
+    _name.category_id             refln
+    _name.object_id               symmetry_multiplicity
+    _type.purpose                 Number
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Integer
+    _enumeration.range            1:48
+    _units.code                   none
+
+save_
+
+save_refln.wavelength
+
+    _definition.id                '_refln.wavelength'
+    _alias.definition_id          '_refln_wavelength'
+    _definition.update            2012-11-26
+    _description.text
+;
+    The mean wavelength in angstroms of radiation used to measure
+    this reflection. This is an important parameter for data
+    collected using energy-dispersive detectors or the Laue method.
+;
+    _name.category_id             refln
+    _name.object_id               wavelength
+    _type.purpose                 Number
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   angstroms
+
+save_
+
+save_refln.wavelength_id
+
+    _definition.id                '_refln.wavelength_id'
+    _alias.definition_id          '_refln_wavelength_id'
+    _definition.update            2021-10-27
+    _description.text
+;
+    Code identifying the wavelength in DIFFRN_RADIATION_WAVELENGTH list.
+;
+    _name.category_id             refln
+    _name.object_id               wavelength_id
+    _name.linked_item_id          '_diffrn_radiation_wavelength.id'
+    _type.purpose                 Link
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Word
+
+save_
+
+save_REFLNS
+
+    _definition.id                REFLNS
+    _definition.scope             Category
+    _definition.class             Set
+    _definition.update            2012-11-26
+    _description.text
+;
+    The CATEGORY of data items used to specify parameters for the complete
+    set of reflections used in the structure refinement process. Note that
+    these parameters are often similar measures to those defined in the
+    DIFFRN categories, but differ in that the parameters refer to the
+    reduced/transformed reflections which have been used to refine the
+    atom site data in the ATOM_SITE category. The DIFFRN definitions refer
+    to the diffraction measurements and the raw reflection data.
+;
+    _name.category_id             DIFFRACTION
+    _name.object_id               REFLNS
+
+save_
+
+save_reflns.apply_dispersion_to_fcalc
+
+    _definition.id                '_reflns.apply_dispersion_to_Fcalc'
+    _definition.update            2019-01-09
+    _description.text
+;
+    Yes or No flag on whether the anomalous dispersion scattering
+    components will be applied in the F complex calculation.
+    See _refln.F_complex
+;
+    _name.category_id             reflns
+    _name.object_id               apply_dispersion_to_Fcalc
+    _type.purpose                 State
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Text
+
+    loop_
+      _enumeration_set.state
+      _enumeration_set.detail
+         yes                      'Apply dispersion.'
+         y                        'Abbreviation for "yes".'
+         no                       'Do not apply dispersion.'
+         n                        'Abbreviation for "no".'
+
+save_
+
+save_reflns.d_resolution_high
+
+    _definition.id                '_reflns.d_resolution_high'
+    _alias.definition_id          '_reflns_d_resolution_high'
+    _definition.update            2021-03-03
+    _description.text
+;
+    Highest resolution for the final REFLN data set.
+    This corresponds to the smallest interplanar d value.
+;
+    _name.category_id             reflns
+    _name.object_id               d_resolution_high
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   angstroms
+
+save_
+
+save_reflns.d_resolution_low
+
+    _definition.id                '_reflns.d_resolution_low'
+    _alias.definition_id          '_reflns_d_resolution_low'
+    _definition.update            2021-03-03
+    _description.text
+;
+    Lowest resolution for the final REFLN data set.
+    This corresponds to the largest interplanar d value.
+;
+    _name.category_id             reflns
+    _name.object_id               d_resolution_low
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   angstroms
+
+save_
+
+save_reflns.friedel_coverage
+
+    _definition.id                '_reflns.Friedel_coverage'
+    _alias.definition_id          '_reflns_Friedel_coverage'
+    _definition.update            2019-01-09
+    _description.text
+;
+    The proportion of Friedel related reflections present in the number of
+    the 'independent reflections' specified by the item _reflns.number_total.
+
+    This proportion is calculated as the ratio:
+
+          [N(Crystal class) - N(Laue symmetry)] / N(Laue symmetry)
+
+    where, working from the DIFFRN_REFLN list,
+
+        N(Crystal class) is the number of reflections obtained on
+            averaging under the symmetry of the crystal class
+        N(Laue symmetry) is the number of reflections obtained on
+            averaging under the Laue symmetry.
+
+      (a) For centrosymmetric structures its value is
+          necessarily equal to 0.0 as the crystal class
+          is identical to the Laue symmetry.
+      (b) For whole-sphere data for a crystal in the space
+          group P1, _reflns.Friedel_coverage is equal to 1.0,
+          as no reflection h k l is equivalent to -h -k -l
+          in the crystal class and all Friedel pairs
+          {h k l; -h -k -l} have been measured.
+      (c) For whole-sphere data in space group Pmm2, the value
+          will be < 1.0 because although reflections h k l and
+          -h -k -l are not equivalent when h k l indices are
+          non-zero, they are when l=0.
+      (d) For a crystal in the group Pmm2 measurements of the
+          two inequivalent octants h >= 0, k >=0, l lead to the
+          same value as in (c), whereas measurements of the
+          two equivalent octants h >= 0, k, l >= 0 will lead to
+          a zero value for _reflns.Friedel_coverage.
+;
+    _name.category_id             reflns
+    _name.object_id               Friedel_coverage
+    _type.purpose                 Number
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:1.0
+    _units.code                   none
+
+save_
+
+save_reflns.friedel_fraction_full
+
+    _definition.id                '_reflns.Friedel_fraction_full'
+    _alias.definition_id          '_reflns_Friedel_fraction_full'
+    _definition.update            2013-01-20
+    _description.text
+;
+    The ratio of Friedel pairs measured to _diffrn_reflns.theta_full
+    to the number theoretically possible (ignoring reflections in
+    centric projections and systematic absences throughout).
+    In contrast to _reflns.Friedel_coverage this can take values in
+    the full range 0 to 1 for any non-centrosymmetric space group,
+    and so one can see at a glance how completely the Friedel pairs
+    have been measured. For centrosymmetric space groups the value
+    would be given as not-applicable '.'
+;
+    _name.category_id             reflns
+    _name.object_id               Friedel_fraction_full
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:1.0
+    _units.code                   none
+
+save_
+
+save_reflns.friedel_fraction_max
+
+    _definition.id                '_reflns.Friedel_fraction_max'
+    _alias.definition_id          '_reflns_Friedel_fraction_max'
+    _definition.update            2013-01-20
+    _description.text
+;
+    The ratio of Friedel pairs measured to _diffrn_reflns.theta_max
+    to the number theoretically possible (ignoring reflections in
+    centric projections and systematic absences throughout).
+    In contrast to _reflns.Friedel_coverage this can take values in
+    the full range 0 to 1 for any non-centrosymmetric space group,
+    and so one can see at a glance how completely the Friedel pairs
+    have been measured. For centrosymmetric space groups the value
+    would be given as not-applicable '.'
+;
+    _name.category_id             reflns
+    _name.object_id               Friedel_fraction_max
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:1.0
+    _units.code                   none
+
+save_
+
+save_reflns.limit_h_max
+
+    _definition.id                '_reflns.limit_h_max'
+    _alias.definition_id          '_reflns_limit_h_max'
+    _name.category_id             reflns
+    _name.object_id               limit_h_max
+
+    _import.get                   [{'file':templ_attr.cif  'save':miller_index}]
+
+save_
+
+save_reflns.limit_h_min
+
+    _definition.id                '_reflns.limit_h_min'
+    _alias.definition_id          '_reflns_limit_h_min'
+    _name.category_id             reflns
+    _name.object_id               limit_h_min
+
+    _import.get                   [{'file':templ_attr.cif  'save':miller_index}]
+
+save_
+
+save_reflns.limit_k_max
+
+    _definition.id                '_reflns.limit_k_max'
+    _alias.definition_id          '_reflns_limit_k_max'
+    _name.category_id             reflns
+    _name.object_id               limit_k_max
+
+    _import.get                   [{'file':templ_attr.cif  'save':miller_index}]
+
+save_
+
+save_reflns.limit_k_min
+
+    _definition.id                '_reflns.limit_k_min'
+    _alias.definition_id          '_reflns_limit_k_min'
+    _name.category_id             reflns
+    _name.object_id               limit_k_min
+
+    _import.get                   [{'file':templ_attr.cif  'save':miller_index}]
+
+save_
+
+save_reflns.limit_l_max
+
+    _definition.id                '_reflns.limit_l_max'
+    _alias.definition_id          '_reflns_limit_l_max'
+    _name.category_id             reflns
+    _name.object_id               limit_l_max
+
+    _import.get                   [{'file':templ_attr.cif  'save':miller_index}]
+
+save_
+
+save_reflns.limit_l_min
+
+    _definition.id                '_reflns.limit_l_min'
+    _alias.definition_id          '_reflns_limit_l_min'
+    _name.category_id             reflns
+    _name.object_id               limit_l_min
+
+    _import.get                   [{'file':templ_attr.cif  'save':miller_index}]
+
+save_
+
+save_reflns.limit_max
+
+    _definition.id                '_reflns.limit_max'
+    _definition.update            2013-01-15
+    _description.text
+;
+    Maximum Miller indices of refined diffraction reflections.
+;
+    _name.category_id             reflns
+    _name.object_id               limit_max
+    _type.purpose                 Number
+    _type.source                  Assigned
+    _type.container               Matrix
+    _type.dimension               '[3]'
+    _type.contents                Real
+    _units.code                   none
+    _method.purpose               Evaluation
+    _method.expression
+;
+    With t as reflns
+
+    _reflns.limit_max = [t.limit_h_max,t.limit_k_max,t.limit_l_max]
+;
+
+save_
+
+save_reflns.limit_min
+
+    _definition.id                '_reflns.limit_min'
+    _definition.update            2013-01-15
+    _description.text
+;
+    Minimum Miller indices of refined diffraction reflections.
+;
+    _name.category_id             reflns
+    _name.object_id               limit_min
+    _type.purpose                 Number
+    _type.source                  Assigned
+    _type.container               Matrix
+    _type.dimension               '[3]'
+    _type.contents                Integer
+    _units.code                   none
+    _method.purpose               Evaluation
+    _method.expression
+;
+    With t as reflns
+
+    _reflns.limit_min = [t.limit_h_min,t.limit_k_min,t.limit_l_min]
+;
+
+save_
+
+save_reflns.number_gt
+
+    _definition.id                '_reflns.number_gt'
+
+    loop_
+      _alias.definition_id
+      _alias.deprecation_date
+         '_reflns_number_gt'                                         .
+         '_reflns_number_observed'                                   1999-03-24
+         '_reflns.number_obs'                                        .
+
+    _definition.update            2024-02-14
+    _description.text
+;
+    Count of reflections in the REFLN set (not the DIFFRN_REFLN set) which
+    are significantly intense (see _reflns.threshold_expression). It may
+    include Friedel equivalent reflections (i.e. those which are equivalent
+    under the Laue symmetry but inequivalent under the crystal class),
+    depending on the nature of the structure and the procedures used.
+;
+    _name.category_id             reflns
+    _name.object_id               number_gt
+    _type.purpose                 Number
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Integer
+    _enumeration.range            0:
+    _units.code                   none
+
+save_
+
+save_reflns.number_total
+
+    _definition.id                '_reflns.number_total'
+
+    loop_
+      _alias.definition_id
+         '_reflns_number_total'
+         '_reflns_number_all'
+         '_reflns.number_all'
+
+    _definition.update            2023-01-13
+    _description.text
+;
+    Number of reflections in the REFLN set (not the DIFFRN_REFLN set). It may
+    include Friedel equivalent reflections (i.e. those which are equivalent
+    under the Laue symmetry but inequivalent under the crystal class),
+    depending on the nature of the structure and the procedures used.
+;
+    _name.category_id             reflns
+    _name.object_id               number_total
+    _type.purpose                 Number
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Integer
+    _enumeration.range            0:
+    _units.code                   none
+
+save_
+
+save_reflns.special_details
+
+    _definition.id                '_reflns.special_details'
+
+    loop_
+      _alias.definition_id
+         '_reflns_special_details'
+         '_reflns.details'
+
+    _definition.update            2012-11-26
+    _description.text
+;
+    Description of the properties of the REFLN reflection list that is not
+    given in other data items. Should include details about the averaging
+    of symmetry-equivalent reflections including Friedel pairs.
+;
+    _name.category_id             reflns
+    _name.object_id               special_details
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_reflns.threshold_expression
+
+    _definition.id                '_reflns.threshold_expression'
+
+    loop_
+      _alias.definition_id
+      _alias.deprecation_date
+         '_reflns_threshold_expression'                              .
+         '_reflns_observed_criterion'                                1999-03-24
+         '_reflns.observed_criterion'                                .
+
+    _definition.update            2024-02-14
+    _description.text
+;
+    Description of the criterion used to classify a reflection as having a
+    "significant intensity". This criterion is usually expressed in terms
+    of a u(I) or u(F) threshold. "u" is the standard uncertainty.
+;
+    _name.category_id             reflns
+    _name.object_id               threshold_expression
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+    _description_example.case     I>2u(I)
+
+save_
+
+save_REFLNS_CLASS
+
+    _definition.id                REFLNS_CLASS
+    _definition.scope             Category
+    _definition.class             Loop
+    _definition.update            2021-06-29
+    _description.text
+;
+    The CATEGORY of data items which specify the properties of reflections
+    in specific classes of reflections.
+;
+    _name.category_id             REFLNS
+    _name.object_id               REFLNS_CLASS
+    _category_key.name            '_reflns_class.code'
+
+save_
+
+save_reflns_class.code
+
+    _definition.id                '_reflns_class.code'
+    _alias.definition_id          '_reflns_class_code'
+    _definition.update            2021-10-27
+    _description.text
+;
+    Code identifying a reflection class.
+;
+    _name.category_id             reflns_class
+    _name.object_id               code
+    _type.purpose                 Encode
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Word
+    _description_example.case     c1
+
+save_
+
+save_reflns_class.d_res_high
+
+    _definition.id                '_reflns_class.d_res_high'
+    _alias.definition_id          '_reflns_class_d_res_high'
+    _definition.update            2021-03-03
+    _description.text
+;
+    Highest resolution for the reflections in this class.
+    This corresponds to the smallest interplanar d value.
+;
+    _name.category_id             reflns_class
+    _name.object_id               d_res_high
+    _type.purpose                 Number
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   angstroms
+
+save_
+
+save_reflns_class.d_res_low
+
+    _definition.id                '_reflns_class.d_res_low'
+    _alias.definition_id          '_reflns_class_d_res_low'
+    _definition.update            2021-03-03
+    _description.text
+;
+    Lowest resolution for the reflections in this class.
+    This corresponds to the largest interplanar d value.
+;
+    _name.category_id             reflns_class
+    _name.object_id               d_res_low
+    _type.purpose                 Number
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   angstroms
+
+save_
+
+save_reflns_class.description
+
+    _definition.id                '_reflns_class.description'
+    _alias.definition_id          '_reflns_class_description'
+    _definition.update            2012-11-26
+    _description.text
+;
+    Description of a reflection class.
+;
+    _name.category_id             reflns_class
+    _name.object_id               description
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+    _description_example.case     'H0L0 common projection reflections'
+
+save_
+
+save_reflns_class.number_gt
+
+    _definition.id                '_reflns_class.number_gt'
+
+    loop_
+      _alias.definition_id
+         '_reflns_class_number_observed'
+         '_reflns_class_number_gt'
+
+    _definition.update            2023-01-13
+    _description.text
+;
+    Count of reflections in this REFLN class (not the DIFFRN_REFLN set)
+    which are significantly intense (see _reflns.threshold_expression). It may
+    include Friedel equivalent reflections (i.e. those which are equivalent
+    under the Laue symmetry but inequivalent under the crystal class),
+    depending on the nature of the structure and the procedures used.
+;
+    _name.category_id             reflns_class
+    _name.object_id               number_gt
+    _type.purpose                 Number
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Integer
+    _enumeration.range            0:
+    _units.code                   none
+
+save_
+
+save_reflns_class.number_total
+
+    _definition.id                '_reflns_class.number_total'
+    _alias.definition_id          '_reflns_class_number_total'
+    _definition.update            2023-01-13
+    _description.text
+;
+    Count of reflections in this REFLN class (not the DIFFRN_REFLN set). It
+    may include Friedel equivalent reflections (those which are equivalent
+    under the Laue symmetry but inequivalent under the crystal class),
+    depending on the nature of the structure and the procedures used.
+;
+    _name.category_id             reflns_class
+    _name.object_id               number_total
+    _type.purpose                 Number
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Integer
+    _enumeration.range            0:
+    _units.code                   none
+
+save_
+
+save_reflns_class.r_factor_all
+
+    _definition.id                '_reflns_class.R_factor_all'
+    _alias.definition_id          '_reflns_class_R_factor_all'
+    _definition.update            2012-11-26
+    _description.text
+;
+    Residual factor for reflections in this class used in refinement.
+
+                  sum | F(meas) - F(calc) |
+       R(F all) = ------------------------
+                        sum | F(meas) |
+
+              F(meas) = the measured structure-factor amplitudes
+              F(calc) = the calculated structure-factor amplitudes
+
+              and the sum is taken over the specified reflections
+;
+    _name.category_id             reflns_class
+    _name.object_id               R_factor_all
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   none
+
+save_
+
+save_reflns_class.r_factor_gt
+
+    _definition.id                '_reflns_class.R_factor_gt'
+
+    loop_
+      _alias.definition_id
+         '_reflns_class_R_factor_gt'
+         '_reflns_class_R_factor_observed'
+
+    _definition.update            2012-11-26
+    _description.text
+;
+    Residual factor for the reflections in this class judged
+    significantly intense (i.e. greater than required by the
+    _reflns.threshold_expression) and included in the refinement.
+
+                  sum | F(meas_gt) - F(calc) |
+       R(F gt) = --------------------------------
+                        sum | F(meas_gt) |
+
+              F(meas) = the measured structure-factor amplitudes
+              F(calc) = the calculated structure-factor amplitudes
+
+              and the sum is taken over the specified reflections
+;
+    _name.category_id             reflns_class
+    _name.object_id               R_factor_gt
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   none
+
+save_
+
+save_reflns_class.r_fsqd_factor
+
+    _definition.id                '_reflns_class.R_Fsqd_factor'
+    _alias.definition_id          '_reflns_class_R_Fsqd_factor'
+    _definition.update            2012-11-26
+    _description.text
+;
+    Residual factor R(F^2^) for reflections in this class judged
+    significantly intense (i.e. greater than required by the
+    _reflns.threshold_expression) and included in the refinement.
+
+                         sum | F(meas_gt)^2^ - F(calc)^2^ |
+           R(Fsqd gt) = ------------------------------------
+                                 sum F(meas_gt)^2^
+
+         F(meas_gt)^2^ = square of the 'observed' structure-factor
+         F(calc   )^2^ = square of the calculated structure-factor
+
+              and the sum is taken over the specified reflections
+;
+    _name.category_id             reflns_class
+    _name.object_id               R_Fsqd_factor
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   none
+
+save_
+
+save_reflns_class.r_i_factor
+
+    _definition.id                '_reflns_class.R_I_factor'
+    _alias.definition_id          '_reflns_class_R_I_factor'
+    _definition.update            2012-11-26
+    _description.text
+;
+    Residual factor R(I) for reflections in this class judged
+    significantly intense (i.e. greater than required by the
+    _reflns.threshold_expression) and included in the refinement.
+
+                      sum | I(meas_gt) - I(calc) |
+           R(I gt) =  ----------------------------
+                             sum | I(meas_gt) |
+
+              I(meas_gt) = the net 'observed' intensity
+              I(calc   ) = the net calculated intensity
+
+              and the sum is taken over the specified reflections
+;
+    _name.category_id             reflns_class
+    _name.object_id               R_I_factor
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   none
+
+save_
+
+save_reflns_class.wr_factor_all
+
+    _definition.id                '_reflns_class.wR_factor_all'
+    _alias.definition_id          '_reflns_class_wR_factor_all'
+    _definition.update            2012-11-26
+    _description.text
+;
+    For each reflection class, the weighted residual factors for all
+    reflections included in the refinement. The reflections also
+    satisfy the resolution limits established by
+    _reflns_class.d_res_high and _reflns_class.d_res_low.
+
+         ( sum w [ Y(meas) - Y(calc) ]^2^  )^1/2^
+    wR = ( ------------------------------- )
+         (         sum w Y(meas)^2^        )
+
+        Y(meas) = the measured amplitudes specified by
+                  _refine_ls.structure_factor_coef
+        Y(calc) = the calculated amplitudes specified by
+                  _refine_ls.structure_factor_coef
+        w       = the least-squares weights
+
+    and the sum is taken over the reflections of this class.
+;
+    _name.category_id             reflns_class
+    _name.object_id               wR_factor_all
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   none
+
+save_
+
+save_REFLNS_SCALE
+
+    _definition.id                REFLNS_SCALE
+    _definition.scope             Category
+    _definition.class             Loop
+    _definition.update            2021-06-29
+    _description.text
+;
+    The CATEGORY of data items which specify the scales needed to place
+    measured structure factor coefficients on the same absolute scale.
+;
+    _name.category_id             REFLNS
+    _name.object_id               REFLNS_SCALE
+    _category_key.name            '_reflns_scale.group_code'
+
+save_
+
+save_reflns_scale.group_code
+
+    _definition.id                '_reflns_scale.group_code'
+    _alias.definition_id          '_reflns_scale_group_code'
+    _definition.update            2021-11-04
+    _description.text
+;
+    Code identifying a reflection scale group. These names need not
+    correspond to _diffrn_scale_group.code names.
+;
+    _name.category_id             reflns_scale
+    _name.object_id               group_code
+    _type.purpose                 Encode
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Word
+
+save_
+
+save_reflns_scale.meas_f
+
+    _definition.id                '_reflns_scale.meas_F'
+    _alias.definition_id          '_reflns_scale_meas_F'
+    _definition.update            2012-11-26
+    _description.text
+;
+    Structure factor scale for this scale group.
+;
+    _name.category_id             reflns_scale
+    _name.object_id               meas_F
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   none
+
+save_
+
+save_reflns_scale.meas_f_su
+
+    _definition.id                '_reflns_scale.meas_F_su'
+    _definition.update            2023-07-01
+    _description.text
+;
+    Standard uncertainty of _reflns_scale.meas_F.
+;
+    _name.category_id             reflns_scale
+    _name.object_id               meas_F_su
+    _name.linked_item_id          '_reflns_scale.meas_F'
+    _units.code                   none
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+save_
+
+save_reflns_scale.meas_f_squared
+
+    _definition.id                '_reflns_scale.meas_F_squared'
+    _alias.definition_id          '_reflns_scale_meas_F_squared'
+    _definition.update            2012-11-26
+    _description.text
+;
+    Structure factor squared scale for this scale group.
+;
+    _name.category_id             reflns_scale
+    _name.object_id               meas_F_squared
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   none
+
+save_
+
+save_reflns_scale.meas_f_squared_su
+
+    _definition.id                '_reflns_scale.meas_F_squared_su'
+    _definition.update            2023-07-01
+    _description.text
+;
+    Standard uncertainty of _reflns_scale.meas_F_squared.
+;
+    _name.category_id             reflns_scale
+    _name.object_id               meas_F_squared_su
+    _name.linked_item_id          '_reflns_scale.meas_F_squared'
+    _units.code                   none
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+save_
+
+save_reflns_scale.meas_intensity
+
+    _definition.id                '_reflns_scale.meas_intensity'
+    _alias.definition_id          '_reflns_scale_meas_intensity'
+    _definition.update            2012-11-26
+    _description.text
+;
+    Net intensity scale for this scale group.
+;
+    _name.category_id             reflns_scale
+    _name.object_id               meas_intensity
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   none
+
+save_
+
+save_reflns_scale.meas_intensity_su
+
+    _definition.id                '_reflns_scale.meas_intensity_su'
+    _definition.update            2023-07-01
+    _description.text
+;
+    Standard uncertainty of _reflns_scale.meas_intensity.
+;
+    _name.category_id             reflns_scale
+    _name.object_id               meas_intensity_su
+    _name.linked_item_id          '_reflns_scale.meas_intensity'
+    _units.code                   none
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+save_
+
+save_REFLNS_SHELL
+
+    _definition.id                REFLNS_SHELL
+    _definition.scope             Category
+    _definition.class             Loop
+    _definition.update            2021-06-29
+    _description.text
+;
+    The CATEGORY of data items which specify the information about
+    reflections divided into shells bounded by d resolution limits.
+;
+    _name.category_id             REFLNS
+    _name.object_id               REFLNS_SHELL
+
+    loop_
+      _category_key.name
+         '_reflns_shell.d_res_low'
+         '_reflns_shell.d_res_high'
+
+save_
+
+save_reflns_shell.d_res_high
+
+    _definition.id                '_reflns_shell.d_res_high'
+    _alias.definition_id          '_reflns_shell_d_res_high'
+    _definition.update            2021-03-03
+    _description.text
+;
+    Highest resolution for the reflections in this shell.
+    This corresponds to the smallest interplanar d value.
+;
+    _name.category_id             reflns_shell
+    _name.object_id               d_res_high
+    _type.purpose                 Number
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   angstroms
+
+save_
+
+save_reflns_shell.d_res_limits
+
+    _definition.id                '_reflns_shell.d_res_limits'
+    _definition.update            2012-11-26
+    _description.text
+;
+    Resolution for the reflections in this shell stored as
+    the list of lowest and highest values. This is the
+    category key.
+;
+    _name.category_id             reflns_shell
+    _name.object_id               d_res_limits
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               List
+    _type.dimension               '[2]'
+    _type.contents                Real
+    _units.code                   angstroms
+    _method.purpose               Evaluation
+    _method.expression
+;
+    With s as reflns_shell
+
+       _reflns_shell.d_res_limits =  [ s.d_res_low, s.d_res_high ]
+;
+
+save_
+
+save_reflns_shell.d_res_low
+
+    _definition.id                '_reflns_shell.d_res_low'
+    _alias.definition_id          '_reflns_shell_d_res_low'
+    _definition.update            2021-03-03
+    _description.text
+;
+    Lowest resolution for the reflections in this shell.
+    This corresponds to the largest interplanar d value.
+;
+    _name.category_id             reflns_shell
+    _name.object_id               d_res_low
+    _type.purpose                 Number
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   angstroms
+
+save_
+
+save_reflns_shell.meani_over_sui_all
+
+    _definition.id                '_reflns_shell.meanI_over_suI_all'
+
+    loop_
+      _alias.definition_id
+      _alias.deprecation_date
+         '_reflns_shell_meanI_over_uI_all'                           .
+         '_reflns_shell_meanI_over_sigI_all'                         1999-03-24
+         '_reflns_shell.meanI_over_sigI_all'                         .
+         '_reflns_shell.meanI_over_uI_all'                           .
+
+    _definition.update            2024-02-14
+    _description.text
+;
+    Ratio of the mean intensity in a shell to the mean standard uncertainty
+    of the intensities in the shell.
+;
+    _name.category_id             reflns_shell
+    _name.object_id               meanI_over_suI_all
+    _type.purpose                 Number
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   none
+
+save_
+
+save_reflns_shell.meani_over_sui_gt
+
+    _definition.id                '_reflns_shell.meanI_over_suI_gt'
+
+    loop_
+      _alias.definition_id
+      _alias.deprecation_date
+         '_reflns_shell_meanI_over_sigI_obs'                         1999-03-24
+         '_reflns_shell.meanI_over_sigI_obs'                         .
+         '_reflns_shell.meanI_over_sigI_gt'                          .
+         '_reflns_shell_meanI_over_sigI_gt'                          1999-03-24
+         '_reflns_shell.meanI_over_uI_gt'                            .
+         '_reflns_shell_meanI_over_uI_gt'                            .
+
+    _definition.update            2024-02-14
+    _description.text
+;
+    Ratio of the mean intensity of significantly intense reflections (see
+    _reflns.threshold_expression) in this shell to the mean standard
+    uncertainty of the intensities in the shell.
+;
+    _name.category_id             reflns_shell
+    _name.object_id               meanI_over_suI_gt
+    _type.purpose                 Number
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   none
+
+save_
+
+save_reflns_shell.number_measured_all
+
+    _definition.id                '_reflns_shell.number_measured_all'
+    _alias.definition_id          '_reflns_shell_number_measured_all'
+    _definition.update            2021-03-01
+    _description.text
+;
+    Total count of reflections measured for this resolution shell.
+;
+    _name.category_id             reflns_shell
+    _name.object_id               number_measured_all
+    _type.purpose                 Number
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Integer
+    _enumeration.range            0:
+    _units.code                   none
+
+save_
+
+save_reflns_shell.number_measured_gt
+
+    _definition.id                '_reflns_shell.number_measured_gt'
+
+    loop_
+      _alias.definition_id
+      _alias.deprecation_date
+         '_reflns_shell_number_measured_obs'                         1999-03-24
+         '_reflns_shell.number_measured_obs'                         .
+         '_reflns_shell_number_measured_gt'                          .
+
+    _definition.update            2024-02-14
+    _description.text
+;
+    Number of reflections measured for this resolution shell which are
+    significantly intense (see _reflns.threshold_expression).
+;
+    _name.category_id             reflns_shell
+    _name.object_id               number_measured_gt
+    _type.purpose                 Number
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Integer
+    _enumeration.range            0:
+    _units.code                   none
+
+save_
+
+save_reflns_shell.number_possible
+
+    _definition.id                '_reflns_shell.number_possible'
+
+    loop_
+      _alias.definition_id
+         '_reflns_shell_number_possible'
+         '_reflns_shell.number_possible_all'
+
+    _definition.update            2021-03-01
+    _description.text
+;
+    Count of symmetry-unique reflections possible in this reflection shell.
+;
+    _name.category_id             reflns_shell
+    _name.object_id               number_possible
+    _type.purpose                 Number
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Integer
+    _enumeration.range            0:
+    _units.code                   none
+
+save_
+
+save_reflns_shell.number_unique_all
+
+    _definition.id                '_reflns_shell.number_unique_all'
+    _alias.definition_id          '_reflns_shell_number_unique_all'
+    _definition.update            2021-03-01
+    _description.text
+;
+    Count of symmetry-unique reflections present in this reflection shell.
+;
+    _name.category_id             reflns_shell
+    _name.object_id               number_unique_all
+    _type.purpose                 Number
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Integer
+    _enumeration.range            0:
+    _units.code                   none
+
+save_
+
+save_reflns_shell.number_unique_gt
+
+    _definition.id                '_reflns_shell.number_unique_gt'
+
+    loop_
+      _alias.definition_id
+      _alias.deprecation_date
+         '_reflns_shell_number_unique_gt'                            .
+         '_reflns_shell_number_unique_obs'                           1999-03-24
+         '_reflns_shell.number_unique_obs'                           .
+
+    _definition.update            2024-02-14
+    _description.text
+;
+    Number of symmetry-unique reflections present in this reflection shell
+    which are significantly intense (see _reflns.threshold_expression).
+;
+    _name.category_id             reflns_shell
+    _name.object_id               number_unique_gt
+    _type.purpose                 Number
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Integer
+    _enumeration.range            0:
+    _units.code                   none
+
+save_
+
+save_reflns_shell.percent_possible_all
+
+    _definition.id                '_reflns_shell.percent_possible_all'
+    _alias.definition_id          '_reflns_shell_percent_possible_all'
+    _definition.update            2012-11-26
+    _description.text
+;
+    Percentage of reflections present in this shell over that possible.
+;
+    _name.category_id             reflns_shell
+    _name.object_id               percent_possible_all
+    _type.purpose                 Number
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:100.0
+    _units.code                   none
+
+save_
+
+save_reflns_shell.percent_possible_gt
+
+    _definition.id                '_reflns_shell.percent_possible_gt'
+
+    loop_
+      _alias.definition_id
+      _alias.deprecation_date
+         '_reflns_shell_percent_possible_gt'                         .
+         '_reflns_shell_percent_possible_obs'                        1999-03-24
+         '_reflns_shell.percent_possible_obs'                        .
+
+    _definition.update            2024-02-14
+    _description.text
+;
+    Percentage of reflections present in this shell which are significantly
+    intense (see _reflns.threshold_expression), over that possible.
+;
+    _name.category_id             reflns_shell
+    _name.object_id               percent_possible_gt
+    _type.purpose                 Number
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:100.0
+    _units.code                   none
+
+save_
+
+save_reflns_shell.rmerge_f_all
+
+    _definition.id                '_reflns_shell.Rmerge_F_all'
+    _alias.definition_id          '_reflns_shell_Rmerge_F_all'
+    _definition.update            2012-11-26
+    _description.text
+;
+    Rmerge(F) for all reflections in a given shell.
+
+                    sum~i~ ( sum~j~ | F~j~ - <F> | )
+        Rmerge(F) = --------------------------------
+                        sum~i~ ( sum~j~ <F> )
+
+        F~j~  = the amplitude of the jth observation of reflection i
+        <F> = the mean of the amplitudes of all observations of
+               reflection i
+
+        sum~i~ is taken over all reflections
+        sum~j~ is taken over all observations of each reflection.
+;
+    _name.category_id             reflns_shell
+    _name.object_id               Rmerge_F_all
+    _type.purpose                 Number
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   none
+
+save_
+
+save_reflns_shell.rmerge_f_gt
+
+    _definition.id                '_reflns_shell.Rmerge_F_gt'
+
+    loop_
+      _alias.definition_id
+      _alias.deprecation_date
+         '_reflns_shell_Rmerge_F_obs'                                1999-03-24
+         '_reflns_shell.Rmerge_F_obs'                                .
+         '_reflns_shell_Rmerge_F_gt'                                 .
+
+    _definition.update            2024-02-14
+    _description.text
+;
+    Rmerge(F) for reflections in a shell which are significantly intense
+    (see _reflns.threshold_expression). The residual merge expression is
+    shown in the _reflns_shell.Rmerge_F_all definition.
+;
+    _name.category_id             reflns_shell
+    _name.object_id               Rmerge_F_gt
+    _type.purpose                 Number
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   none
+
+save_
+
+save_reflns_shell.rmerge_i_all
+
+    _definition.id                '_reflns_shell.Rmerge_I_all'
+    _alias.definition_id          '_reflns_shell_Rmerge_I_all'
+    _definition.update            2012-11-26
+    _description.text
+;
+    Rmerge(I) for all reflections in a given shell.
+
+                    sum~i~ ( sum~j~ | I~j~ - <I> | )
+        Rmerge(I) = --------------------------------
+                        sum~i~ ( sum~j~ <I> )
+
+        I~j~  = the intensity of the jth observation of reflection i
+        <I> = the mean of the intensities of all observations of
+               reflection i
+
+        sum~i~ is taken over all reflections
+        sum~j~ is taken over all observations of each reflection.
+;
+    _name.category_id             reflns_shell
+    _name.object_id               Rmerge_I_all
+    _type.purpose                 Number
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   none
+
+save_
+
+save_reflns_shell.rmerge_i_gt
+
+    _definition.id                '_reflns_shell.Rmerge_I_gt'
+
+    loop_
+      _alias.definition_id
+      _alias.deprecation_date
+         '_reflns_shell_Rmerge_I_obs'                                1999-03-24
+         '_reflns_shell.Rmerge_I_obs'                                .
+         '_reflns_shell_Rmerge_I_gt'                                 .
+
+    _definition.update            2024-02-14
+    _description.text
+;
+    Rmerge(I) for reflections in a shell which are significantly intense
+    (see _reflns.threshold_expression). The residual merge expression is
+    shown in the _reflns_shell.Rmerge_I_all definition.
+;
+    _name.category_id             reflns_shell
+    _name.object_id               Rmerge_I_gt
+    _type.purpose                 Number
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   none
+
+save_
+
+save_EXPTL
+
+    _definition.id                EXPTL
+    _definition.scope             Category
+    _definition.class             Set
+    _definition.update            2024-05-15
+    _description.text
+;
+    The CATEGORY of data items used to specify the experimental work
+    prior to diffraction measurements. These include crystallization
+    crystal measurements and absorption-correction techniques used.
+;
+    _name.category_id             CIF_CORE_HEAD
+    _name.object_id               EXPTL
+
+save_
+
+save_exptl.crystals_number
+
+    _definition.id                '_exptl.crystals_number'
+    _alias.definition_id          '_exptl_crystals_number'
+    _definition.update            2021-03-01
+    _description.text
+;
+    Total number of crystals used in the measurement of intensities.
+;
+    _name.category_id             exptl
+    _name.object_id               crystals_number
+    _type.purpose                 Number
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Integer
+    _enumeration.range            1:
+    _units.code                   none
+
+save_
+
+save_exptl.method
+
+    _definition.id                '_exptl.method'
+    _definition.update            2014-06-12
+    _description.text
+;
+    The method used in the experiment.
+;
+    _name.category_id             exptl
+    _name.object_id               method
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+
+    loop_
+      _description_example.case
+         'single-crystal x-ray diffraction'
+         'single-crystal neutron diffraction'
+         'single-crystal electron diffraction'
+         'fiber x-ray diffraction'
+         'fiber neutron diffraction'
+         'fiber electron diffraction'
+         'single-crystal joint x-ray and neutron diffraction'
+         'single-crystal joint x-ray and electron diffraction'
+         'solution nmr'
+         'solid-state nmr'
+         'theoretical model'
+         'other'
+
+save_
+
+save_exptl.method_details
+
+    _definition.id                '_exptl.method_details'
+    _definition.update            2014-06-12
+    _description.text
+;
+    A description of special aspects of the experimental method.
+;
+    _name.category_id             exptl
+    _name.object_id               method_details
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+
+    loop_
+      _description_example.case
+         '29 structures'
+         'minimized average structure'
+
+save_
+
+save_exptl.special_details
+
+    _definition.id                '_exptl.special_details'
+
+    loop_
+      _alias.definition_id
+         '_exptl_special_details'
+         '_exptl.details'
+
+    _definition.update            2012-11-22
+    _description.text
+;
+    Details of the experiment prior to intensity measurement.
+    See also _exptl_crystal.preparation
+;
+    _name.category_id             exptl
+    _name.object_id               special_details
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_exptl.transmission_factor_max
+
+    _definition.id                '_exptl.transmission_factor_max'
+    _alias.definition_id          '_exptl_transmission_factor_max'
+    _definition.update            2013-04-11
+    _description.text
+;
+    The calculated maximum value of the transmission factor for
+    the specimen. Its value does not include the effects of
+    absorption in the specimen mount. The presence of this
+    item does not imply that the structure factors have been
+    corrected for absorption. For the applied correction see
+    _exptl_absorpt.correction_T_max.
+;
+    _name.category_id             exptl
+    _name.object_id               transmission_factor_max
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:1.0
+    _units.code                   none
+
+save_
+
+save_exptl.transmission_factor_max_su
+
+    _definition.id                '_exptl.transmission_factor_max_su'
+    _definition.update            2023-07-01
+    _description.text
+;
+    Standard uncertainty of _exptl.transmission_factor_max.
+;
+    _name.category_id             exptl
+    _name.object_id               transmission_factor_max_su
+    _name.linked_item_id          '_exptl.transmission_factor_max'
+    _units.code                   none
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+save_
+
+save_exptl.transmission_factor_min
+
+    _definition.id                '_exptl.transmission_factor_min'
+    _alias.definition_id          '_exptl_transmission_factor_min'
+    _definition.update            2013-04-11
+    _description.text
+;
+    The calculated minimum value of the transmission factor for
+    the specimen. Its value does not include the effects of
+    absorption in the specimen mount. The presence of this
+    item does not imply that the structure factors have been
+    corrected for absorption. For the applied correction see
+    _exptl_absorpt.correction_T_min.
+;
+    _name.category_id             exptl
+    _name.object_id               transmission_factor_min
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:1.0
+    _units.code                   none
+
+save_
+
+save_exptl.transmission_factor_min_su
+
+    _definition.id                '_exptl.transmission_factor_min_su'
+    _definition.update            2023-07-01
+    _description.text
+;
+    Standard uncertainty of _exptl.transmission_factor_min.
+;
+    _name.category_id             exptl
+    _name.object_id               transmission_factor_min_su
+    _name.linked_item_id          '_exptl.transmission_factor_min'
+    _units.code                   none
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+save_
+
+save_CHEMICAL
+
+    _definition.id                CHEMICAL
+    _definition.scope             Category
+    _definition.class             Set
+    _definition.update            2012-11-22
+    _description.text
+;
+    The CATEGORY of data items which describe the composition and
+    chemical properties of the compound under study. The formula data
+    items must be consistent with the density, unit-cell and Z values.
+;
+    _name.category_id             EXPTL
+    _name.object_id               CHEMICAL
+
+save_
+
+save_chemical.absolute_configuration
+
+    _definition.id                '_chemical.absolute_configuration'
+    _alias.definition_id          '_chemical_absolute_configuration'
+    _definition.update            2023-02-02
+    _description.text
+;
+    Necessary conditions for this assignment are given by
+         Flack, H. D. & Bernardinelli, G. (1999). Acta Cryst. A55, 908-915.
+                https://doi.org/10.1107/S0108767399004262
+                https://www.iucr.org/paper?sh0129
+         Flack, H. D. & Bernardinelli, G. (2000). J. Appl. Cryst. 33, 1143-1148.
+                https://doi.org/10.1107/S0021889800007184
+                https://www.iucr.org/paper?ks0021
+;
+    _name.category_id             chemical
+    _name.object_id               absolute_configuration
+    _type.purpose                 State
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Text
+
+    loop_
+      _enumeration_set.state
+      _enumeration_set.detail
+         rm
+;
+         'reference molecule' Absolute configuration established by the
+         structure determination of a compound containing a chiral reference
+         molecule of known absolute configuration.
+;
+         ad
+;
+         'anomalous dispersion' Absolute configuration established by a-d
+         effects in diffraction measurements on the crystal.
+;
+         rmad
+;
+         'rm + ad' Absolute configuration established by the structure
+         determination of a compound containing a chiral reference molecule of
+         known absolute configuration and confirmed by a-d effects in
+         diffraction measurements on the crystal.
+;
+         syn
+;
+         'synthetic' Absolute configuration has not been established by
+         anomalous-dispersion effects in diffraction measurements on the
+         crystal. The enantiomer has been assigned by reference to an
+         unchanging chiral centre in the synthetic procedure.
+;
+         unk
+;
+         'unknown' No firm chemical or a-d evidence for an assignment is
+         available. An arbitrary choice of enantiomer has been made.
+;
+         .
+;
+         Inapplicable.
+;
+
+save_
+
+save_chemical.compound_source
+
+    _definition.id                '_chemical.compound_source'
+    _alias.definition_id          '_chemical_compound_source'
+    _definition.update            2023-01-13
+    _description.text
+;
+    Description of the source of the compound under study, or of the
+    parent molecule if a simple derivative is studied. This includes
+    the place of discovery for minerals or the actual source of a
+    natural product.
+;
+    _name.category_id             chemical
+    _name.object_id               compound_source
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_chemical.enantioexcess_bulk
+
+    _definition.id                '_chemical.enantioexcess_bulk'
+    _alias.definition_id          '_chemical_enantioexcess_bulk'
+    _definition.update            2023-02-02
+    _description.text
+;
+    The enantioexcess of the bulk material from which the crystals
+    were grown. A value of 0.0 indicates the racemate. A value of
+    1.0 indicates that the compound is enantiomerically pure.
+    Enantioexcess is defined in the IUPAC Recommendations
+    (Moss et al., 1996). The composition of the crystal
+    and bulk must be the same.
+    Ref: Moss G. P. et al. (1996). Basic Terminology of Stereochemistry.
+         Pure Appl. Chem., 68, 2193-2222.
+         https://doi.org/10.1351/pac199668122193
+         https://iupac.qmul.ac.uk/stereo/
+;
+    _name.category_id             chemical
+    _name.object_id               enantioexcess_bulk
+    _type.purpose                 Measurand
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:1.0
+    _units.code                   none
+
+save_
+
+save_chemical.enantioexcess_bulk_su
+
+    _definition.id                '_chemical.enantioexcess_bulk_su'
+    _definition.update            2023-07-01
+    _description.text
+;
+    Standard uncertainty of _chemical.enantioexcess_bulk.
+;
+    _name.category_id             chemical
+    _name.object_id               enantioexcess_bulk_su
+    _name.linked_item_id          '_chemical.enantioexcess_bulk'
+    _units.code                   none
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+save_
+
+save_chemical.enantioexcess_bulk_technique
+
+    _definition.id                '_chemical.enantioexcess_bulk_technique'
+    _alias.definition_id          '_chemical_enantioexcess_bulk_technique'
+    _definition.update            2013-01-18
+    _description.text
+;
+    Technique used to determine the enantioexcess of the bulk compound.
+;
+    _name.category_id             chemical
+    _name.object_id               enantioexcess_bulk_technique
+    _type.purpose                 State
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Text
+
+    loop_
+      _enumeration_set.state
+      _enumeration_set.detail
+         OA
+;
+         Enantioexcess determined by measurement of the specific rotation of
+         the optical activity of the bulk compound in solution.
+;
+         CD
+;
+         Enantioexcess determined by measurement of the visible/near UV
+         circular dichroism spectrum of the bulk compound in solution.
+;
+         EC
+;
+         Enantioexcess determined by enantioselective chromatography of the
+         bulk compound in solution.
+;
+         other
+;
+         Enantioexcess determined by a technique not in this list.
+;
+
+save_
+
+save_chemical.enantioexcess_crystal
+
+    _definition.id                '_chemical.enantioexcess_crystal'
+    _alias.definition_id          '_chemical_enantioexcess_crystal'
+    _definition.update            2023-02-02
+    _description.text
+;
+    The enantioexcess of the crystal used for the diffraction
+    study. A value of 0.0 indicates the racemate. A value of
+    1.0 indicates that the crystal is enantiomerically pure.
+    Enantioexcess is defined in the IUPAC Recommendations
+    (Moss et al., 1996).
+    Ref: Moss G. P. et al. (1996). Basic Terminology of Stereochemistry.
+         Pure Appl. Chem., 68, 2193-2222.
+         https://doi.org/10.1351/pac199668122193
+         https://iupac.qmul.ac.uk/stereo/
+;
+    _name.category_id             chemical
+    _name.object_id               enantioexcess_crystal
+    _type.purpose                 Measurand
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:1.0
+    _units.code                   none
+
+save_
+
+save_chemical.enantioexcess_crystal_su
+
+    _definition.id                '_chemical.enantioexcess_crystal_su'
+    _definition.update            2023-07-01
+    _description.text
+;
+    Standard uncertainty of _chemical.enantioexcess_crystal.
+;
+    _name.category_id             chemical
+    _name.object_id               enantioexcess_crystal_su
+    _name.linked_item_id          '_chemical.enantioexcess_crystal'
+    _units.code                   none
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+save_
+
+save_chemical.enantioexcess_crystal_technique
+
+    _definition.id                '_chemical.enantioexcess_crystal_technique'
+    _alias.definition_id          '_chemical_enantioexcess_crystal_technique'
+    _definition.update            2013-01-18
+    _description.text
+;
+    Technique used to determine the enantioexcess of the crystal.
+;
+    _name.category_id             chemical
+    _name.object_id               enantioexcess_crystal_technique
+    _type.purpose                 State
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Text
+
+    loop_
+      _enumeration_set.state
+      _enumeration_set.detail
+         CD
+;
+         Enantioexcess determined by measurement of the visible/near UV
+         circular dichroism spectrum of the crystal taken into solution.
+;
+         EC
+;
+         Enantioexcess determined by enantioselective chromatography of the
+         crystal taken into solution.
+;
+         other
+;
+         Enantioexcess determined by a technique not in this list.
+;
+
+save_
+
+save_chemical.identifier_inchi
+
+    _definition.id                '_chemical.identifier_InChI'
+    _alias.definition_id          '_chemical_identifier_InChI'
+    _definition.update            2023-09-12
+    _description.text
+;
+    The IUPAC International Chemical Identifier (InChI) is a
+    textual identifier for chemical substances, designed to provide
+    a standard and human-readable way to encode molecular information
+    and to facilitate the search for such information in databases
+    and on the web.
+    Ref: McNaught, A. (2006). Chem. Int. (IUPAC), 28 (6), 12-14.
+         https://doi.org/10.1515/ci.2006.28.6.12
+         https://www.iupac.org/inchi/
+;
+    _name.category_id             chemical
+    _name.object_id               identifier_InChI
+    _type.purpose                 Encode
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Word
+    _description_example.case
+        InChI=1/C10H8/c1-2-6-10-8-4-3-7-9(10)5-1/h1-8H
+    _description_example.detail   naphthalene
+
+save_
+
+save_chemical.identifier_inchi_key
+
+    _definition.id                '_chemical.identifier_InChI_key'
+    _alias.definition_id          '_chemical_identifier_InChI_key'
+    _definition.update            2023-09-12
+    _description.text
+;
+    The InChIKey is a compact hashed version of the full InChI
+    (IUPAC International Chemical Identifier), designed to allow
+    for easy web searches of chemical compounds. See
+    https://www.iupac.org/inchi/
+;
+    _name.category_id             chemical
+    _name.object_id               identifier_InChI_key
+    _type.purpose                 Encode
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Word
+    _description_example.case     OROGSEYTTFOCAN-DNJOTXNNSA-N
+    _description_example.detail   codeine
+
+save_
+
+save_chemical.identifier_inchi_version
+
+    _definition.id                '_chemical.identifier_InChI_version'
+    _alias.definition_id          '_chemical_identifier_InChI_version'
+    _definition.update            2021-09-24
+    _description.text
+;
+    Version number of the InChI standard to which the associated
+    chemical identifier string applies.
+;
+    _name.category_id             chemical
+    _name.object_id               identifier_InChI_version
+    _type.purpose                 Encode
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Code
+    _description_example.case     1.03
+
+save_
+
+save_chemical.melting_point
+
+    _definition.id                '_chemical.melting_point'
+    _alias.definition_id          '_chemical_melting_point'
+    _definition.update            2012-11-22
+    _description.text
+;
+    The temperature at which a crystalline solid changes to a liquid.
+;
+    _name.category_id             chemical
+    _name.object_id               melting_point
+    _type.purpose                 Measurand
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   kelvins
+
+save_
+
+save_chemical.melting_point_su
+
+    _definition.id                '_chemical.melting_point_su'
+    _definition.update            2023-07-01
+    _description.text
+;
+    Standard uncertainty of _chemical.melting_point.
+;
+    _name.category_id             chemical
+    _name.object_id               melting_point_su
+    _name.linked_item_id          '_chemical.melting_point'
+    _units.code                   kelvins
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+save_
+
+save_chemical.melting_point_gt
+
+    _definition.id                '_chemical.melting_point_gt'
+    _alias.definition_id          '_chemical_melting_point_gt'
+    _definition.update            2012-12-11
+    _description.text
+;
+    A temperature above which the melting point lies.
+    _chemical.melting_point should be used in preference where possible.
+;
+    _name.category_id             chemical
+    _name.object_id               melting_point_gt
+    _type.purpose                 Number
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   kelvins
+
+save_
+
+save_chemical.melting_point_lt
+
+    _definition.id                '_chemical.melting_point_lt'
+    _alias.definition_id          '_chemical_melting_point_lt'
+    _definition.update            2012-12-11
+    _description.text
+;
+    A temperature below which the melting point lies.
+    _chemical.melting_point should be used in preference where possible.
+;
+    _name.category_id             chemical
+    _name.object_id               melting_point_lt
+    _type.purpose                 Number
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   kelvins
+
+save_
+
+save_chemical.name_common
+
+    _definition.id                '_chemical.name_common'
+    _alias.definition_id          '_chemical_name_common'
+    _definition.update            2012-11-22
+    _description.text
+;
+    Trivial name by which the compound is commonly known.
+;
+    _name.category_id             chemical
+    _name.object_id               name_common
+    _type.purpose                 Encode
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_chemical.name_mineral
+
+    _definition.id                '_chemical.name_mineral'
+    _alias.definition_id          '_chemical_name_mineral'
+    _definition.update            2012-11-22
+    _description.text
+;
+    Mineral name accepted by the International Mineralogical Association.
+    Use only for natural minerals.
+;
+    _name.category_id             chemical
+    _name.object_id               name_mineral
+    _type.purpose                 Encode
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_chemical.name_structure_type
+
+    _definition.id                '_chemical.name_structure_type'
+    _alias.definition_id          '_chemical_name_structure_type'
+    _definition.update            2012-11-22
+    _description.text
+;
+    Commonly used structure-type name. Usually only applied to
+    minerals or inorganic compounds.
+;
+    _name.category_id             chemical
+    _name.object_id               name_structure_type
+    _type.purpose                 Encode
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_chemical.name_systematic
+
+    _definition.id                '_chemical.name_systematic'
+    _alias.definition_id          '_chemical_name_systematic'
+    _definition.update            2012-11-22
+    _description.text
+;
+    IUPAC or Chemical Abstracts full name of compound.
+;
+    _name.category_id             chemical
+    _name.object_id               name_systematic
+    _type.purpose                 Encode
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_chemical.optical_rotation
+
+    _definition.id                '_chemical.optical_rotation'
+    _alias.definition_id          '_chemical_optical_rotation'
+    _definition.update            2012-11-22
+    _description.text
+;
+    The optical rotation in solution of the compound is
+    specified in the following format:
+
+       '[α]^TEMP^~WAVE~ = SORT (c = CONC, SOLV)'
+
+    where: TEMP is the temperature of the measurement in degrees Celsius,
+           WAVE is an indication of the wavelength of the light
+                used for the measurement,
+           CONC is the concentration of the solution given as the
+                mass of the substance in g in 100 ml of solution,
+           SORT is the signed value (preceded by a + or a - sign)
+                of 100.α/(l.c), where α is the signed optical
+                rotation in degrees measured in a cell of length l in
+                dm and c is the value of CONC in g, and
+           SOLV is the chemical formula of the solvent.
+;
+    _name.category_id             chemical
+    _name.object_id               optical_rotation
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+    _description_example.case     '[α]^25^~D~ = +108 (c = 3.42, CHCl~3~)'
+
+save_
+
+save_chemical.properties_biological
+
+    _definition.id                '_chemical.properties_biological'
+    _alias.definition_id          '_chemical_properties_biological'
+    _definition.update            2012-12-11
+    _description.text
+;
+    A description of the biological properties of the material.
+;
+    _name.category_id             chemical
+    _name.object_id               properties_biological
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+
+    loop_
+      _description_example.case
+;
+       diverse biological activities including use as a laxative
+       and strong antibacterial activity against S. aureus and weak
+       activity against cyclooxygenase-1 (COX-1)
+;
+;
+       antibiotic activity against Bacillus subtilis (ATCC 6051) but no
+       significant activity against Candida albicans (ATCC 14053),
+       Aspergillus flavus (NRRL 6541) & Fusarium verticillioides (NRRL 25457)
+;
+;
+       weakly potent lipoxygenase nonredox inhibitor
+;
+;
+       no influenza A virus sialidase inhibitory & plaque reduction activities
+;
+;
+       low toxicity against Drosophila melanogaster
+;
+
+save_
+
+save_chemical.properties_physical
+
+    _definition.id                '_chemical.properties_physical'
+    _alias.definition_id          '_chemical_properties_physical'
+    _definition.update            2012-12-11
+    _description.text
+;
+    A description of the physical properties of the material.
+;
+    _name.category_id             chemical
+    _name.object_id               properties_physical
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+
+    loop_
+      _description_example.case
+         'air-sensitive'
+         'moisture-sensitive'
+         'hygroscopic'
+         'deliquescent'
+         'oxygen-sensitive'
+         'photo-sensitive'
+         'pyrophoric'
+         'semiconductor'
+         'ferromagnetic at low temperature'
+         'paramagnetic and thermochromic'
+
+save_
+
+save_chemical.temperature_decomposition
+
+    _definition.id                '_chemical.temperature_decomposition'
+    _alias.definition_id          '_chemical_temperature_decomposition'
+    _definition.update            2012-12-11
+    _description.text
+;
+    The temperature at which a crystalline solid decomposes.
+;
+    _name.category_id             chemical
+    _name.object_id               temperature_decomposition
+    _type.purpose                 Measurand
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   kelvins
+
+save_
+
+save_chemical.temperature_decomposition_su
+
+    _definition.id                '_chemical.temperature_decomposition_su'
+
+    loop_
+      _alias.definition_id
+         '_chemical_temperature_decomposition_su'
+         '_chemical.temperature_decomposition_esd'
+
+    _definition.update            2021-03-03
+    _description.text
+;
+    Standard uncertainty of _chemical.temperature_decomposition.
+;
+    _name.category_id             chemical
+    _name.object_id               temperature_decomposition_su
+    _name.linked_item_id          '_chemical.temperature_decomposition'
+    _units.code                   kelvins
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+save_
+
+save_chemical.temperature_decomposition_gt
+
+    _definition.id                '_chemical.temperature_decomposition_gt'
+    _alias.definition_id          '_chemical_temperature_decomposition_gt'
+    _definition.update            2021-11-09
+    _description.text
+;
+    The temperature above which a crystalline solid decomposes.
+    _chemical.temperature_decomposition should be used in preference.
+;
+    _name.category_id             chemical
+    _name.object_id               temperature_decomposition_gt
+    _type.purpose                 Number
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   kelvins
+
+save_
+
+save_chemical.temperature_decomposition_lt
+
+    _definition.id                '_chemical.temperature_decomposition_lt'
+    _alias.definition_id          '_chemical_temperature_decomposition_lt'
+    _definition.update            2021-11-09
+    _description.text
+;
+    The temperature below which a crystalline solid decomposes.
+    _chemical.temperature_decomposition should be used in preference.
+;
+    _name.category_id             chemical
+    _name.object_id               temperature_decomposition_lt
+    _type.purpose                 Number
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   kelvins
+
+save_
+
+save_chemical.temperature_sublimation
+
+    _definition.id                '_chemical.temperature_sublimation'
+    _alias.definition_id          '_chemical_temperature_sublimation'
+    _definition.update            2012-12-11
+    _description.text
+;
+    The temperature at which a crystalline solid sublimates.
+;
+    _name.category_id             chemical
+    _name.object_id               temperature_sublimation
+    _type.purpose                 Measurand
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   kelvins
+
+save_
+
+save_chemical.temperature_sublimation_su
+
+    _definition.id                '_chemical.temperature_sublimation_su'
+
+    loop_
+      _alias.definition_id
+         '_chemical_temperature_sublimation_su'
+         '_chemical.temperature_sublimation_esd'
+
+    _definition.update            2021-03-03
+    _description.text
+;
+    Standard uncertainty of _chemical.temperature_sublimation.
+;
+    _name.category_id             chemical
+    _name.object_id               temperature_sublimation_su
+    _name.linked_item_id          '_chemical.temperature_sublimation'
+    _units.code                   kelvins
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+save_
+
+save_chemical.temperature_sublimation_gt
+
+    _definition.id                '_chemical.temperature_sublimation_gt'
+    _alias.definition_id          '_chemical_temperature_sublimation_gt'
+    _definition.update            2021-11-09
+    _description.text
+;
+    The temperature above which a crystalline solid sublimates.
+    _chemical.temperature_sublimation should be used in preference.
+;
+    _name.category_id             chemical
+    _name.object_id               temperature_sublimation_gt
+    _type.purpose                 Number
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   kelvins
+
+save_
+
+save_chemical.temperature_sublimation_lt
+
+    _definition.id                '_chemical.temperature_sublimation_lt'
+    _alias.definition_id          '_chemical_temperature_sublimation_lt'
+    _definition.update            2021-11-09
+    _description.text
+;
+    The temperature below which a crystalline solid sublimates.
+    _chemical.temperature_sublimation should be used in preference.
+;
+    _name.category_id             chemical
+    _name.object_id               temperature_sublimation_lt
+    _type.purpose                 Number
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   kelvins
+
+save_
+
+save_CHEMICAL_CONN_ATOM
+
+    _definition.id                CHEMICAL_CONN_ATOM
+    _definition.scope             Category
+    _definition.class             Loop
+    _definition.update            2021-06-29
+    _description.text
+;
+    The CATEGORY of data items which describe the 2D chemical structure of
+    the molecular species. They allow a 2D chemical diagram to be
+    reconstructed for use in a publication or in a database search
+    for structural and substructural relationships. In particular,
+    the chemical_conn_atom data items provide information about the
+    chemical properties of the atoms in the structure. In cases
+    where crystallographic and molecular symmetry elements coincide
+    they must also contain symmetry-generated atoms, so as to describe
+    a complete chemical entity.
+;
+    _name.category_id             CHEMICAL
+    _name.object_id               CHEMICAL_CONN_ATOM
+    _category_key.name            '_chemical_conn_atom.number'
+
+save_
+
+save_chemical_conn_atom.charge
+
+    _definition.id                '_chemical_conn_atom.charge'
+    _alias.definition_id          '_chemical_conn_atom_charge'
+    _definition.update            2021-03-01
+    _description.text
+;
+    The net integer charge assigned to this atom. This is the
+    formal charge assignment normally found in chemical diagrams.
+;
+    _name.category_id             chemical_conn_atom
+    _name.object_id               charge
+    _type.purpose                 Number
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Integer
+    _enumeration.range            -6:6
+    _units.code                   none
+
+save_
+
+save_chemical_conn_atom.display_x
+
+    _definition.id                '_chemical_conn_atom.display_x'
+    _alias.definition_id          '_chemical_conn_atom_display_x'
+    _definition.update            2012-11-22
+    _description.text
+;
+    Cartesian coordinate (x) of the atom site in a chemical diagram. The
+    coordinate origin is at the lower left corner, the x axis is horizontal.
+;
+    _name.category_id             chemical_conn_atom
+    _name.object_id               display_x
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:1.0
+    _units.code                   none
+
+save_
+
+save_chemical_conn_atom.display_y
+
+    _definition.id                '_chemical_conn_atom.display_y'
+    _alias.definition_id          '_chemical_conn_atom_display_y'
+    _definition.update            2012-11-22
+    _description.text
+;
+    Cartesian coordinate (y) of the atom site in a chemical diagram. The
+    coordinate origin is at the lower left corner, the y axis is vertical.
+;
+    _name.category_id             chemical_conn_atom
+    _name.object_id               display_y
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:1.0
+    _units.code                   none
+
+save_
+
+save_chemical_conn_atom.nca
+
+    _definition.id                '_chemical_conn_atom.NCA'
+    _alias.definition_id          '_chemical_conn_atom_NCA'
+    _definition.update            2021-03-01
+    _description.text
+;
+    Total number of connected atoms excluding terminal hydrogen atoms.
+;
+    _name.category_id             chemical_conn_atom
+    _name.object_id               NCA
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Integer
+    _enumeration.range            0:
+    _units.code                   none
+
+save_
+
+save_chemical_conn_atom.nh
+
+    _definition.id                '_chemical_conn_atom.NH'
+    _alias.definition_id          '_chemical_conn_atom_NH'
+    _definition.update            2021-03-01
+    _description.text
+;
+    Total number of hydrogen atoms attached to this atom,
+    regardless of whether they are included in the refinement or
+    the atom_site list. This number will be the same as
+    _atom_site.attached_hydrogens only if none of the hydrogen
+    atoms appear in the atom_site list.
+;
+    _name.category_id             chemical_conn_atom
+    _name.object_id               NH
+    _type.purpose                 Number
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Integer
+    _enumeration.range            0:
+    _units.code                   none
+
+save_
+
+save_chemical_conn_atom.number
+
+    _definition.id                '_chemical_conn_atom.number'
+    _alias.definition_id          '_chemical_conn_atom_number'
+    _definition.update            2021-03-01
+    _description.text
+;
+    The chemical sequence number to be associated with this atom.
+;
+    _name.category_id             chemical_conn_atom
+    _name.object_id               number
+    _type.purpose                 Number
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Integer
+    _enumeration.range            1:
+    _units.code                   none
+
+save_
+
+save_chemical_conn_atom.type_symbol
+
+    _definition.id                '_chemical_conn_atom.type_symbol'
+    _alias.definition_id          '_chemical_conn_atom_type_symbol'
+    _definition.update            2021-10-27
+    _description.text
+;
+    A code identifying the atom type.
+;
+    _name.category_id             chemical_conn_atom
+    _name.object_id               type_symbol
+    _name.linked_item_id          '_atom_type.symbol'
+    _type.purpose                 Link
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Word
+
+save_
+
+save_CHEMICAL_CONN_BOND
+
+    _definition.id                CHEMICAL_CONN_BOND
+    _definition.scope             Category
+    _definition.class             Loop
+    _definition.update            2021-06-29
+    _description.text
+;
+    The CATEGORY of data items which specify the connections between
+    the atoms sites in the chemical_conn_atom list and the nature
+    of the chemical bond between these atoms. These are details about
+    the two-dimensional (2D) chemical structure of the molecular species.
+    They allow a 2D chemical diagram to be reconstructed for use in a
+    publication or in a database search for structural and substructural
+    relationships.
+;
+    _name.category_id             CHEMICAL
+    _name.object_id               CHEMICAL_CONN_BOND
+
+    loop_
+      _category_key.name
+         '_chemical_conn_bond.atom_1'
+         '_chemical_conn_bond.atom_2'
+
+save_
+
+save_chemical_conn_bond.atom_1
+
+    _definition.id                '_chemical_conn_bond.atom_1'
+
+    loop_
+      _alias.definition_id
+         '_chemical_conn_bond_atom_1'
+         '_chem_comp_bond.atom_id_1'
+
+    _definition.update            2021-03-01
+    _description.text
+;
+    Index id of first atom in a bond connecting two atom sites.
+;
+    _name.category_id             chemical_conn_bond
+    _name.object_id               atom_1
+    _name.linked_item_id          '_chemical_conn_atom.number'
+    _type.purpose                 Link
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Integer
+    _enumeration.range            1:
+    _units.code                   none
+
+save_
+
+save_chemical_conn_bond.atom_2
+
+    _definition.id                '_chemical_conn_bond.atom_2'
+
+    loop_
+      _alias.definition_id
+         '_chemical_conn_bond_atom_2'
+         '_chem_comp_bond.atom_id_2'
+
+    _definition.update            2021-03-01
+    _description.text
+;
+    Index id of second atom in a bond connecting two atom sites.
+;
+    _name.category_id             chemical_conn_bond
+    _name.object_id               atom_2
+    _name.linked_item_id          '_chemical_conn_atom.number'
+    _type.purpose                 Link
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Integer
+    _enumeration.range            1:
+    _units.code                   none
+
+save_
+
+save_chemical_conn_bond.distance
+
+    _definition.id                '_chemical_conn_bond.distance'
+    _alias.definition_id          '_chem_comp_bond.value_dist'
+    _definition.update            2014-06-12
+    _description.text
+;
+    The value that should be taken as the target for the chemical
+    bond associated with the specified atoms, expressed as a
+    distance.
+;
+    _name.category_id             chemical_conn_bond
+    _name.object_id               distance
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   angstroms
+
+save_
+
+save_chemical_conn_bond.id
+
+    _definition.id                '_chemical_conn_bond.id'
+    _definition.update            2023-02-02
+    _description.text
+;
+    Unique identifier for the bond.
+;
+    _name.category_id             chemical_conn_bond
+    _name.object_id               id
+    _type.purpose                 Key
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Word
+
+save_
+
+save_chemical_conn_bond.type
+
+    _definition.id                '_chemical_conn_bond.type'
+
+    loop_
+      _alias.definition_id
+         '_chemical_conn_bond_type'
+         '_chem_comp_bond.value_order'
+
+    _definition.update            2012-11-22
+    _description.text
+;
+    Code for the chemical bond type.
+;
+    _name.category_id             chemical_conn_bond
+    _name.object_id               type
+    _type.purpose                 State
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Text
+
+    loop_
+      _enumeration_set.state
+      _enumeration_set.detail
+         sing                     'Single bond.'
+         doub                     'Double bond.'
+         trip                     'Triple bond.'
+         quad                     'Quadruple bond.'
+         arom                     'Aromatic bond.'
+         poly                     'Polymeric bond.'
+         delo                     'Delocalized double bond.'
+         pi                       'Pi bond.'
+
+save_
+
+save_CHEMICAL_FORMULA
+
+    _definition.id                CHEMICAL_FORMULA
+    _definition.scope             Category
+    _definition.class             Set
+    _definition.update            2023-01-13
+    _description.text
+;
+    The CATEGORY of data items which specify the composition and chemical
+    properties of the compound. The formula data items must agree
+    with those that specify the density, unit-cell and Z values.
+
+    The following rules apply to the construction of the data items
+    _chemical_formula.analytical, *.structural and *.sum. For the
+    data item *.moiety the formula construction is broken up into
+    residues or moieties, i.e. groups of atoms that form a molecular
+    unit or molecular ion. The rules given below apply within each
+    moiety, but different requirements apply to the way that moieties
+    are connected (see _chemical_formula.moiety).
+
+    1. Only recognized element symbols may be used.
+
+    2. Each element symbol is followed by a 'count' number. A count of
+       '1' may be omitted.
+
+    3. A space or parenthesis must separate each cluster of (element
+       symbol + count).
+
+    4. Where a group of elements is enclosed in parentheses, the
+       multiplier for the group must follow the closing parentheses.
+       That is, all element and group multipliers are assumed to be
+       printed as subscripted numbers. [An exception to this rule
+       exists for *.moiety formulae where pre- and post-multipliers
+       are permitted for molecular units].
+
+    5. Unless the elements are ordered in a manner that corresponds to
+       their chemical structure, as in _chemical_formula.structural,
+       the order of the elements within any group or moiety
+       depends on whether or not carbon is present. If carbon is
+       present, the order should be: C, then H, then the other
+       elements in alphabetical order of their symbol. If carbon is
+       not present, the elements are listed purely in alphabetical order
+       of their symbol. This is the 'Hill' system used by Chemical
+       Abstracts. This ordering is used in _chemical_formula.moiety
+       and _chemical_formula.sum.
+
+          _chemical_formula.IUPAC      '[Mo (C O)4 (C18 H33 P)2]'
+          _chemical_formula.moiety     'C40 H66 Mo O4 P2'
+          _chemical_formula.structural '((C O)4 (P (C6 H11)3)2)Mo'
+          _chemical_formula.sum         'C40 H66 Mo O4 P2'
+          _chemical_formula.weight      768.81
+;
+    _name.category_id             CHEMICAL
+    _name.object_id               CHEMICAL_FORMULA
+
+save_
+
+save_chemical_formula.analytical
+
+    _definition.id                '_chemical_formula.analytical'
+    _alias.definition_id          '_chemical_formula_analytical'
+    _definition.update            2012-11-22
+    _description.text
+;
+    Formula determined by standard chemical analysis including trace
+    elements. Parentheses are used only for standard uncertainties (su's).
+;
+    _name.category_id             chemical_formula
+    _name.object_id               analytical
+    _type.purpose                 Encode
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Text
+    _description_example.case     'Fe2.45(2)  Ni1.60(3)  S4'
+
+save_
+
+save_chemical_formula.iupac
+
+    _definition.id                '_chemical_formula.IUPAC'
+    _alias.definition_id          '_chemical_formula_IUPAC'
+    _definition.update            2021-09-24
+    _description.text
+;
+    Formula expressed in conformance with IUPAC rules for inorganic
+    and metal-organic compounds where these conflict with the rules
+    for any other chemical_formula entries. Typically used for
+    formatting a formula in accordance with journal rules. This
+    should appear in the data block in addition to the most
+    appropriate of the other chemical_formula data names.
+    Ref: IUPAC (1990). Nomenclature of Inorganic Chemistry.
+         Oxford: Blackwell Scientific Publications.
+;
+    _name.category_id             chemical_formula
+    _name.object_id               IUPAC
+    _type.purpose                 Encode
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Text
+    _description_example.case     '[Co Re (C12 H22 P)2 (C O)6].0.5C H3 O H'
+
+save_
+
+save_chemical_formula.moiety
+
+    _definition.id                '_chemical_formula.moiety'
+    _alias.definition_id          '_chemical_formula_moiety'
+    _definition.update            2012-11-22
+    _description.text
+;
+    Formula with each discrete bonded residue or ion shown as a
+    separate moiety. See above CHEMICAL_FORMULA for rules
+    for writing chemical formulae. In addition to the general
+    formulae requirements, the following rules apply:
+       1. Moieties are separated by commas ','.
+       2. The order of elements within a moiety follows general rule
+          5 in CHEMICAL_FORMULA.
+       3. Parentheses are not used within moieties but may surround
+          a moiety. Parentheses may not be nested.
+       4. Charges should be placed at the end of the moiety. The
+          Singlege '+' or '-' may be preceded by a numerical multiplier
+          and should be separated from the last (element symbol +
+          count) by a space. Pre- or post-multipliers may be used for
+          individual moieties.
+;
+    _name.category_id             chemical_formula
+    _name.object_id               moiety
+    _type.purpose                 Encode
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Text
+
+    loop_
+      _description_example.case
+         'C7 H4 Cl Hg N O3 S'
+         'C12 H17 N4 O S 1+, C6 H2 N3 O7 1-'
+         'C12 H16 N2 O6, 5(H2 O1)'
+         '(Cd 2+)3, (C6 N6 Cr 3-)2, 2(H2 O)'
+
+save_
+
+save_chemical_formula.structural
+
+    _definition.id                '_chemical_formula.structural'
+    _alias.definition_id          '_chemical_formula_structural'
+    _definition.update            2023-01-13
+    _description.text
+;
+    This formula should correspond to the structure as reported, i.e.
+    trace elements not included in atom type and atom site lists should
+    not be included. See category description for the rules for writing
+    chemical formulae for inorganics, organometallics, metal complexes
+    etc., in which bonded groups are preserved as discrete entities
+    within parentheses, with post-multipliers as required. The order of
+    the elements should give as much information as possible about the
+    chemical structure. Parentheses may be used and nested as required.
+    This formula should correspond to the structure as actually reported,
+    i.e. trace elements not included in atom-type and atom-site lists
+    should not be included (see also _chemical_formula.analytical).
+;
+    _name.category_id             chemical_formula
+    _name.object_id               structural
+    _type.purpose                 Encode
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Text
+
+    loop_
+      _description_example.case
+         '(Pt (N H3)2 (C5 H7 N3 O)2) (Cl O4)2'
+         'Ca ((Cl O3)2 O)2 (H2 O)6'
+
+save_
+
+save_chemical_formula.sum
+
+    _definition.id                '_chemical_formula.sum'
+    _alias.definition_id          '_chemical_formula_sum'
+    _definition.update            2012-11-22
+    _description.text
+;
+    Chemical formulae in which all discrete bonded residues and ions are
+    summed over the constituent elements, following the ordering given
+    in rule 5 of the CATEGORY description. Parentheses normally not used.
+;
+    _name.category_id             chemical_formula
+    _name.object_id               sum
+    _type.purpose                 Encode
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Text
+    _description_example.case     'C18 H19 N7 O8 S'
+
+save_
+
+save_chemical_formula.weight
+
+    _definition.id                '_chemical_formula.weight'
+    _alias.definition_id          '_chemical_formula_weight'
+    _definition.update            2021-09-24
+    _description.text
+;
+    Mass corresponding to the formulae _chemical_formula.structural,
+    *_IUPAC, *_moiety or *_sum and, together with the Z value and cell
+    parameters yield the density given as _exptl_crystal.density_diffrn.
+;
+    _name.category_id             chemical_formula
+    _name.object_id               weight
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            1.0:
+    _units.code                   dalton
+
+save_
+
+save_chemical_formula.weight_meas
+
+    _definition.id                '_chemical_formula.weight_meas'
+    _alias.definition_id          '_chemical_formula_weight_meas'
+    _definition.update            2012-11-22
+    _description.text
+;
+    Formula mass measured by a non-diffraction experiment.
+;
+    _name.category_id             chemical_formula
+    _name.object_id               weight_meas
+    _type.purpose                 Measurand
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            1.0:
+    _units.code                   dalton
+
+save_
+
+save_chemical_formula.weight_meas_su
+
+    _definition.id                '_chemical_formula.weight_meas_su'
+    _definition.update            2023-07-01
+    _description.text
+;
+    Standard uncertainty of _chemical_formula.weight_meas.
+;
+    _name.category_id             chemical_formula
+    _name.object_id               weight_meas_su
+    _name.linked_item_id          '_chemical_formula.weight_meas'
+    _units.code                   dalton
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+save_
+
+save_EXPTL_ABSORPT
+
+    _definition.id                EXPTL_ABSORPT
+    _definition.scope             Category
+    _definition.class             Set
+    _definition.update            2023-01-13
+    _description.text
+;
+    The CATEGORY of data items used to specify the experimental details
+    of the absorption measurements and corrections to the diffraction data.
+;
+    _name.category_id             EXPTL
+    _name.object_id               EXPTL_ABSORPT
+
+save_
+
+save_exptl_absorpt.coefficient_mu
+
+    _definition.id                '_exptl_absorpt.coefficient_mu'
+
+    loop_
+      _alias.definition_id
+         '_exptl_absorpt_coefficient_mu'
+         '_exptl.absorpt_coefficient_mu'
+
+    _definition.update            2023-06-25
+    _description.text
+;
+    Linear absorption coefficient, μ, calculated from the atomic content of
+    the cell, the density and the radiation wavelength.
+;
+    _name.category_id             exptl_absorpt
+    _name.object_id               coefficient_mu
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   reciprocal_millimetres
+
+save_
+
+save_exptl_absorpt.coefficient_mu_su
+
+    _definition.id                '_exptl_absorpt.coefficient_mu_su'
+    _definition.update            2023-07-01
+    _description.text
+;
+    Standard uncertainty of _exptl_absorpt.coefficient_mu.
+;
+    _name.category_id             exptl_absorpt
+    _name.object_id               coefficient_mu_su
+    _name.linked_item_id          '_exptl_absorpt.coefficient_mu'
+    _units.code                   reciprocal_millimetres
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+save_
+
+save_exptl_absorpt.correction_t_max
+
+    _definition.id                '_exptl_absorpt.correction_T_max'
+
+    loop_
+      _alias.definition_id
+         '_exptl_absorpt_correction_T_max'
+         '_exptl.absorpt_correction_T_max'
+
+    _definition.update            2012-11-22
+    _description.text
+;
+    Maximum transmission factor for the crystal and radiation applied
+    to the measured intensities, it includes the correction for
+    absorption by the specimen mount and diffractometer as well
+    as by the specimen itself. These values give the transmission (T)
+    factor by which measured intensities have been REDUCED due to
+    absorption. Sometimes referred to as absorption correction A or
+    1/A* (see "Crystal Structure Analysis for Chemists and Biologists"
+    by J.P. Glusker et al., Wiley)
+;
+    _name.category_id             exptl_absorpt
+    _name.object_id               correction_T_max
+    _type.purpose                 Number
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:1.0
+    _units.code                   none
+
+save_
+
+save_exptl_absorpt.correction_t_min
+
+    _definition.id                '_exptl_absorpt.correction_T_min'
+
+    loop_
+      _alias.definition_id
+         '_exptl_absorpt_correction_T_min'
+         '_exptl.absorpt_correction_T_min'
+
+    _definition.update            2021-08-15
+    _description.text
+;
+    Minimum transmission factor for the crystal and radiation applied
+    to the measured intensities, it includes the correction for
+    absorption by the specimen mount and diffractometer as well
+    as by the specimen itself. These values give the transmission (T)
+    factor by which measured intensities have been REDUCED due to
+    absorption. Sometimes referred to as absorption correction A or
+    1/A* (see "Crystal Structure Analysis for Chemists and Biologists"
+    by J.P. Glusker et al., Wiley)
+;
+    _name.category_id             exptl_absorpt
+    _name.object_id               correction_T_min
+    _type.purpose                 Number
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:1.0
+    _units.code                   none
+
+save_
+
+save_exptl_absorpt.correction_type
+
+    _definition.id                '_exptl_absorpt.correction_type'
+
+    loop_
+      _alias.definition_id
+         '_exptl_absorpt_correction_type'
+         '_exptl.absorpt_correction_type'
+
+    _definition.update            2023-01-13
+    _description.text
+;
+    Code identifying the absorption correction type and method.
+    The 'empirical' approach should NOT be used if more detailed
+    information on the crystal shape is available.
+;
+    _name.category_id             exptl_absorpt
+    _name.object_id               correction_type
+    _type.purpose                 State
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Text
+
+    loop_
+      _enumeration_set.state
+      _enumeration_set.detail
+         analytical               'Analytical from crystal shape.'
+         cylinder                 'Cylindrical.'
+         empirical                'Empirical from intensities.'
+         gaussian                 'Gaussian from crystal shape.'
+         integration              'Integration from crystal shape.'
+         multi-scan               'Symmetry-related measurements.'
+         none                     'No absorption correction applied.'
+         numerical                'Numerical from crystal shape.'
+         psi-scan                 'Psi-scan corrections.'
+         refdelf                  'Refined from delta-F.'
+         sphere                   'Spherical.'
+
+save_
+
+save_exptl_absorpt.process_details
+
+    _definition.id                '_exptl_absorpt.process_details'
+
+    loop_
+      _alias.definition_id
+         '_exptl_absorpt_process_details'
+         '_exptl.absorpt_process_details'
+
+    _definition.update            2012-11-22
+    _description.text
+;
+    Description of the absorption correction process applied to the
+    measured intensities. A literature reference should be supplied
+    for psi-scan or multi-scan techniques.
+;
+    _name.category_id             exptl_absorpt
+    _name.object_id               process_details
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+
+    loop_
+      _description_example.case
+         'Tompa analytical'
+         'MolEN (Fair, 1990)'
+         '(North, Phillips & Mathews, 1968)'
+
+save_
+
+save_exptl_absorpt.special_details
+
+    _definition.id                '_exptl_absorpt.special_details'
+    _alias.definition_id          '_exptl_absorpt_special_details'
+    _definition.update            2022-12-03
+    _description.text
+;
+    Details of the absorption correction process applied to the
+    measured intensities that cannot otherwise be given using
+    other data items from the EXPTL_ABSORPT category.
+;
+    _name.category_id             exptl_absorpt
+    _name.object_id               special_details
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+
+    loop_
+      _description_example.case
+      _description_example.detail
+;
+         X-ray beam inhomogeneity and goniometer imperfection account for much
+         of the difference between estimated values of Tmin and Tmax and the
+         _exptl_absorpt_correction_ values.
+;
+;
+         Text modified from:
+         Petty, Anthony J. et al. Computationally aided design of a high-
+         performance organic semiconductor: the development of a universal
+         crystal engineering core. Chemical Science, 2019
+         https://doi.org/10.1039/C9SC02930C
+         COD 1552381
+;
+;
+         Neutron linear absorption coefficient is wavelength dependent. The
+         value of 0.2216 (mm^-1^) shown in _exptl_absorpt_coefficient_mu is the
+         sample absorption coefficient for a neutron wavelength at 1.0 Å.
+;
+;
+         Text modified from:
+         Lengyel, Jeff et al. Antiferroelectric Phase Transition in a
+         Proton-Transfer Salt of Squaric Acid and 2,3-Dimethylpyrazine.
+         Journal of the American Chemical Society, 2019, 141, 16279-16287
+         https://doi.org/10.1021/jacs.9b04473
+         COD 4127699
+;
+
+save_
+
+save_EXPTL_CRYSTAL
+
+    _definition.id                EXPTL_CRYSTAL
+    _definition.scope             Category
+    _definition.class             Set
+    _definition.update            2022-05-09
+    _description.text
+;
+    The CATEGORY of data items used to specify information about
+    crystals used in the diffraction measurements.
+;
+    _name.category_id             EXPTL
+    _name.object_id               EXPTL_CRYSTAL
+    _category_key.name            '_exptl_crystal.id'
+
+save_
+
+save_exptl_crystal.colour
+
+    _definition.id                '_exptl_crystal.colour'
+    _alias.definition_id          '_exptl_crystal_colour'
+    _definition.update            2023-01-12
+    _description.text
+;
+    Colour description of the crystal.
+
+    Data items from EXPTL_CRYSTAL_APPEARANCE category should be used in
+    preference to this item when possible.
+;
+    _name.category_id             exptl_crystal
+    _name.object_id               colour
+    _type.purpose                 Composite
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Text
+
+    loop_
+      _description_example.case
+         'translucent pale green'
+         'dark yellow'
+         'metallic blue'
+         'red'
+         'colourless'
+         'dichroic dark purple/pale blue'
+
+    _method.purpose               Definition
+    _method.expression
+;
+    default_value = ""
+    With c as exptl_crystal_appearance {
+        if (not Is_missing(c.general))
+            default_value = c.general
+        if (not Is_missing(c.intensity)) {
+            if (len(default_value) > 0) default_value = default_value + " "
+            default_value = default_value + c.intensity
+        }
+        if (not Is_missing(c.hue)) {
+            if (len(default_value) > 0) default_value = default_value + " "
+            default_value = default_value + c.hue
+        }
+    }
+
+    if (len(default_value) > 0)
+        _enumeration.default = default_value
+;
+
+save_
+
+save_exptl_crystal.density_diffrn
+
+    _definition.id                '_exptl_crystal.density_diffrn'
+    _alias.definition_id          '_exptl_crystal_density_diffrn'
+    _definition.update            2012-11-22
+    _description.text
+;
+    Crystal density calculated from crystal unit cell and atomic content.
+;
+    _name.category_id             exptl_crystal
+    _name.object_id               density_diffrn
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   megagrams_per_metre_cubed
+    _method.purpose               Evaluation
+    _method.expression
+;
+    _exptl_crystal.density_diffrn = 1.6605 * _cell.atomic_mass / _cell.volume
+;
+
+save_
+
+save_exptl_crystal.density_diffrn_su
+
+    _definition.id                '_exptl_crystal.density_diffrn_su'
+    _definition.update            2023-07-01
+    _description.text
+;
+    Standard uncertainty of _exptl_crystal.density_diffrn.
+;
+    _name.category_id             exptl_crystal
+    _name.object_id               density_diffrn_su
+    _name.linked_item_id          '_exptl_crystal.density_diffrn'
+    _units.code                   megagrams_per_metre_cubed
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+save_
+
+save_exptl_crystal.density_meas
+
+    _definition.id                '_exptl_crystal.density_meas'
+    _alias.definition_id          '_exptl_crystal_density_meas'
+    _definition.update            2012-11-22
+    _description.text
+;
+    Crystal density measured using standard chemical and physical methods.
+;
+    _name.category_id             exptl_crystal
+    _name.object_id               density_meas
+    _type.purpose                 Measurand
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   megagrams_per_metre_cubed
+
+save_
+
+save_exptl_crystal.density_meas_su
+
+    _definition.id                '_exptl_crystal.density_meas_su'
+
+    loop_
+      _alias.definition_id
+         '_exptl_crystal_density_meas_su'
+         '_exptl_crystal.density_meas_esd'
+
+    _definition.update            2021-03-03
+    _description.text
+;
+    Standard uncertainty of _exptl_crystal.density_meas.
+;
+    _name.category_id             exptl_crystal
+    _name.object_id               density_meas_su
+    _name.linked_item_id          '_exptl_crystal.density_meas'
+    _units.code                   megagrams_per_metre_cubed
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+save_
+
+save_exptl_crystal.density_meas_gt
+
+    _definition.id                '_exptl_crystal.density_meas_gt'
+    _alias.definition_id          '_exptl_crystal_density_meas_gt'
+    _definition.update            2021-11-09
+    _description.text
+;
+    The value above which the density measured using standard
+    chemical and physical methods lies. This item is used only
+    when _exptl_crystal.density_meas cannot be employed. It is
+    intended for use in reporting information in databases and
+    archives which would be misleading if reported otherwise.
+;
+    _name.category_id             exptl_crystal
+    _name.object_id               density_meas_gt
+    _type.purpose                 Number
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   megagrams_per_metre_cubed
+
+save_
+
+save_exptl_crystal.density_meas_lt
+
+    _definition.id                '_exptl_crystal.density_meas_lt'
+    _alias.definition_id          '_exptl_crystal_density_meas_lt'
+    _definition.update            2021-11-09
+    _description.text
+;
+    The value below which the density measured using standard
+    chemical and physical methods lies. This item is used only
+    when _exptl_crystal.density_meas cannot be employed. It is
+    intended for use in reporting information in databases and
+    archives which would be misleading if reported otherwise.
+;
+    _name.category_id             exptl_crystal
+    _name.object_id               density_meas_lt
+    _type.purpose                 Number
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   megagrams_per_metre_cubed
+
+save_
+
+save_exptl_crystal.density_meas_temp
+
+    _definition.id                '_exptl_crystal.density_meas_temp'
+    _alias.definition_id          '_exptl_crystal_density_meas_temp'
+    _definition.update            2012-11-22
+    _description.text
+;
+    Temperature at which _exptl_crystal.density_meas was determined.
+;
+    _name.category_id             exptl_crystal
+    _name.object_id               density_meas_temp
+    _type.purpose                 Measurand
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   kelvins
+
+save_
+
+save_exptl_crystal.density_meas_temp_su
+
+    _definition.id                '_exptl_crystal.density_meas_temp_su'
+
+    loop_
+      _alias.definition_id
+         '_exptl_crystal_density_meas_temp_su'
+         '_exptl_crystal.density_meas_temp_esd'
+
+    _definition.update            2012-11-22
+    _description.text
+;
+    Standard uncertainty of _exptl_crystal.density_meas_temp.
+;
+    _name.category_id             exptl_crystal
+    _name.object_id               density_meas_temp_su
+    _name.linked_item_id          '_exptl_crystal.density_meas_temp'
+    _units.code                   kelvins
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+save_
+
+save_exptl_crystal.density_meas_temp_gt
+
+    _definition.id                '_exptl_crystal.density_meas_temp_gt'
+    _alias.definition_id          '_exptl_crystal_density_meas_temp_gt'
+    _definition.update            2021-11-09
+    _description.text
+;
+    Temperature above which the measured density was determined.
+    This item is used only when _exptl_crystal.density_meas_temp
+    cannot be employed. It is intended for use in reporting values
+    from databases which would be misleading if reported otherwise.
+;
+    _name.category_id             exptl_crystal
+    _name.object_id               density_meas_temp_gt
+    _type.purpose                 Number
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   kelvins
+
+save_
+
+save_exptl_crystal.density_meas_temp_lt
+
+    _definition.id                '_exptl_crystal.density_meas_temp_lt'
+    _alias.definition_id          '_exptl_crystal_density_meas_temp_lt'
+    _definition.update            2021-11-09
+    _description.text
+;
+    Temperature below which the measured density was determined.
+    This item is used only when _exptl_crystal.density_meas_temp
+    cannot be employed. It is intended for use in reporting values
+    from databases which would be misleading if reported otherwise.
+;
+    _name.category_id             exptl_crystal
+    _name.object_id               density_meas_temp_lt
+    _type.purpose                 Number
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   kelvins
+
+save_
+
+save_exptl_crystal.density_method
+
+    _definition.id                '_exptl_crystal.density_method'
+    _alias.definition_id          '_exptl_crystal_density_method'
+    _definition.update            2012-11-22
+    _description.text
+;
+    Description of method used to measure _exptl_crystal.density_meas.
+;
+    _name.category_id             exptl_crystal
+    _name.object_id               density_method
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+    _description_example.case     'flotation in aqueous KI'
+
+save_
+
+save_exptl_crystal.description
+
+    _definition.id                '_exptl_crystal.description'
+    _alias.definition_id          '_exptl_crystal_description'
+    _definition.update            2021-08-18
+    _description.text
+;
+    Description of the quality and habit of the crystal. The crystal
+    dimensions should be provided using the exptl_crystal.size_* data items.
+;
+    _name.category_id             exptl_crystal
+    _name.object_id               description
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_exptl_crystal.f_000
+
+    _definition.id                '_exptl_crystal.F_000'
+    _alias.definition_id          '_exptl_crystal_F_000'
+    _definition.update            2023-02-02
+    _description.text
+;
+    Number of electrons in the crystal unit cell contributing to F(000).
+    It may contain dispersion contributions, and is calculated as
+
+         F(000) = [ (sum f~r~)^2^ + (sum f~i~)^2^ ]^1/2^
+
+         f~r~   = real part of the scattering factors at θ = 0
+         f~i~   = imaginary part of the scattering factors at θ = 0
+
+                 the sum is taken over each atom in the unit cell
+
+    For X-rays, non-dispersive F(000) is a positive number and counts
+    the effective number of electrons in the unit cell; for neutrons,
+    non-dispersive F(000) (which may be negative) counts the total
+    nuclear scattering power in the unit cell. See
+       https://dictionary.iucr.org/F(000)
+;
+    _name.category_id             exptl_crystal
+    _name.object_id               F_000
+    _type.purpose                 Number
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Real
+    _method.purpose               Definition
+    _method.expression
+;
+         If (_diffrn_radiation.probe == "neutron")  _units.code =  "femtometres"
+    Else If (_diffrn_radiation.probe == "electron") _units.code =  "volts"
+    Else                                            _units.code =  "electrons"
+;
+
+save_
+
+save_exptl_crystal.id
+
+    _definition.id                '_exptl_crystal.id'
+    _alias.definition_id          '_exptl_crystal_id'
+    _definition.update            2022-05-09
+    _description.text
+;
+    Code identifying a crystal.
+;
+    _name.category_id             exptl_crystal
+    _name.object_id               id
+    _type.purpose                 Key
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Word
+
+save_
+
+save_exptl_crystal.preparation
+
+    _definition.id                '_exptl_crystal.preparation'
+    _alias.definition_id          '_exptl_crystal_preparation'
+    _definition.update            2012-11-22
+    _description.text
+;
+    Details of crystal growth and preparation of the crystals
+    (e.g. mounting) prior to the intensity measurements.
+;
+    _name.category_id             exptl_crystal
+    _name.object_id               preparation
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+    _description_example.case     'mounted in an argon-filled quartz capillary'
+
+save_
+
+save_exptl_crystal.pressure_history
+
+    _definition.id                '_exptl_crystal.pressure_history'
+    _alias.definition_id          '_exptl_crystal_pressure_history'
+    _definition.update            2012-11-22
+    _description.text
+;
+    Details concerning the pressure history of the crystals.
+;
+    _name.category_id             exptl_crystal
+    _name.object_id               pressure_history
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_exptl_crystal.recrystallization_method
+
+    _definition.id                '_exptl_crystal.recrystallization_method'
+    _alias.definition_id          '_exptl_crystal_recrystallization_method'
+    _definition.update            2012-12-11
+    _description.text
+;
+    Method used to recrystallize the sample. Sufficient details should
+    be given for the procedure to be repeated. Temperatures, solvents,
+    flux or carrier gases with concentrations or pressures and ambient
+    atmosphere details should be given.
+;
+    _name.category_id             exptl_crystal
+    _name.object_id               recrystallization_method
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_exptl_crystal.size_length
+
+    _definition.id                '_exptl_crystal.size_length'
+    _alias.definition_id          '_exptl_crystal_size_length'
+    _definition.update            2012-11-22
+    _description.text
+;
+    The length of needle/cylindrical crystals.
+;
+    _name.category_id             exptl_crystal
+    _name.object_id               size_length
+    _type.purpose                 Measurand
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   millimetres
+
+save_
+
+save_exptl_crystal.size_length_su
+
+    _definition.id                '_exptl_crystal.size_length_su'
+    _definition.update            2023-07-01
+    _description.text
+;
+    Standard uncertainty of _exptl_crystal.size_length.
+;
+    _name.category_id             exptl_crystal
+    _name.object_id               size_length_su
+    _name.linked_item_id          '_exptl_crystal.size_length'
+    _units.code                   millimetres
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+save_
+
+save_exptl_crystal.size_max
+
+    _definition.id                '_exptl_crystal.size_max'
+    _alias.definition_id          '_exptl_crystal_size_max'
+    _definition.update            2012-11-22
+    _description.text
+;
+    The maximum dimension of a crystal.
+;
+    _name.category_id             exptl_crystal
+    _name.object_id               size_max
+    _type.purpose                 Measurand
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   millimetres
+
+save_
+
+save_exptl_crystal.size_max_su
+
+    _definition.id                '_exptl_crystal.size_max_su'
+    _definition.update            2023-07-01
+    _description.text
+;
+    Standard uncertainty of _exptl_crystal.size_max.
+;
+    _name.category_id             exptl_crystal
+    _name.object_id               size_max_su
+    _name.linked_item_id          '_exptl_crystal.size_max'
+    _units.code                   millimetres
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+save_
+
+save_exptl_crystal.size_mid
+
+    _definition.id                '_exptl_crystal.size_mid'
+    _alias.definition_id          '_exptl_crystal_size_mid'
+    _definition.update            2023-01-16
+    _description.text
+;
+    The medial dimension of a crystal.
+;
+    _name.category_id             exptl_crystal
+    _name.object_id               size_mid
+    _type.purpose                 Measurand
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   millimetres
+
+save_
+
+save_exptl_crystal.size_mid_su
+
+    _definition.id                '_exptl_crystal.size_mid_su'
+    _definition.update            2023-07-01
+    _description.text
+;
+    Standard uncertainty of _exptl_crystal.size_mid.
+;
+    _name.category_id             exptl_crystal
+    _name.object_id               size_mid_su
+    _name.linked_item_id          '_exptl_crystal.size_mid'
+    _units.code                   millimetres
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+save_
+
+save_exptl_crystal.size_min
+
+    _definition.id                '_exptl_crystal.size_min'
+    _alias.definition_id          '_exptl_crystal_size_min'
+    _definition.update            2012-11-22
+    _description.text
+;
+    The minimum dimension of a crystal.
+;
+    _name.category_id             exptl_crystal
+    _name.object_id               size_min
+    _type.purpose                 Measurand
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   millimetres
+
+save_
+
+save_exptl_crystal.size_min_su
+
+    _definition.id                '_exptl_crystal.size_min_su'
+    _definition.update            2023-07-01
+    _description.text
+;
+    Standard uncertainty of _exptl_crystal.size_min.
+;
+    _name.category_id             exptl_crystal
+    _name.object_id               size_min_su
+    _name.linked_item_id          '_exptl_crystal.size_min'
+    _units.code                   millimetres
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+save_
+
+save_exptl_crystal.size_rad
+
+    _definition.id                '_exptl_crystal.size_rad'
+    _alias.definition_id          '_exptl_crystal_size_rad'
+    _definition.update            2012-11-22
+    _description.text
+;
+    The radius of a spherical or cylindrical crystal.
+;
+    _name.category_id             exptl_crystal
+    _name.object_id               size_rad
+    _type.purpose                 Measurand
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   millimetres
+
+save_
+
+save_exptl_crystal.size_rad_su
+
+    _definition.id                '_exptl_crystal.size_rad_su'
+    _definition.update            2023-07-01
+    _description.text
+;
+    Standard uncertainty of _exptl_crystal.size_rad.
+;
+    _name.category_id             exptl_crystal
+    _name.object_id               size_rad_su
+    _name.linked_item_id          '_exptl_crystal.size_rad'
+    _units.code                   millimetres
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+save_
+
+save_exptl_crystal.thermal_history
+
+    _definition.id                '_exptl_crystal.thermal_history'
+    _alias.definition_id          '_exptl_crystal_thermal_history'
+    _definition.update            2012-11-22
+    _description.text
+;
+    Details concerning the thermal history of the crystals.
+;
+    _name.category_id             exptl_crystal
+    _name.object_id               thermal_history
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_EXPTL_CRYSTAL_APPEARANCE
+
+    _definition.id                EXPTL_CRYSTAL_APPEARANCE
+    _definition.scope             Category
+    _definition.class             Set
+    _definition.update            2012-11-22
+    _description.text
+;
+    The CATEGORY of ENUMERATION items used to specify information about the
+    crystal colour and appearance.
+;
+    _name.category_id             EXPTL_CRYSTAL
+    _name.object_id               EXPTL_CRYSTAL_APPEARANCE
+
+save_
+
+save_exptl_crystal_appearance.general
+
+    _definition.id                '_exptl_crystal_appearance.general'
+
+    loop_
+      _alias.definition_id
+         '_exptl_crystal_colour_lustre'
+         '_exptl_crystal.colour_lustre'
+
+    _definition.update            2021-11-04
+    _description.text
+;
+    Appearance of the crystal as prescribed state codes. Note that 'dull'
+    and 'clear' should no longer be used.
+;
+    _name.category_id             exptl_crystal_appearance
+    _name.object_id               general
+    _type.purpose                 State
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Word
+
+    loop_
+      _enumeration_set.state
+         metallic
+         lustrous
+         transparent
+         translucent
+         opaque
+         dull
+         clear
+         .
+
+save_
+
+save_exptl_crystal_appearance.hue
+
+    _definition.id                '_exptl_crystal_appearance.hue'
+
+    loop_
+      _alias.definition_id
+         '_exptl_crystal_colour_primary'
+         '_exptl_crystal.colour_primary'
+
+    _definition.update            2021-11-04
+    _description.text
+;
+    Colour hue of the crystals as prescribed state codes.
+;
+    _name.category_id             exptl_crystal_appearance
+    _name.object_id               hue
+    _type.purpose                 State
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Word
+
+    _import.get                   [{'file':templ_enum.cif  'save':colour_rgb}]
+
+save_
+
+save_exptl_crystal_appearance.intensity
+
+    _definition.id                '_exptl_crystal_appearance.intensity'
+
+    loop_
+      _alias.definition_id
+         '_exptl_crystal_colour_modifier'
+         '_exptl_crystal.colour_modifier'
+
+    _definition.update            2021-11-04
+    _description.text
+;
+    Colour intensity of the crystal as prescribed state codes.
+;
+    _name.category_id             exptl_crystal_appearance
+    _name.object_id               intensity
+    _type.purpose                 State
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Word
+
+    loop_
+      _enumeration_set.state
+         dark
+         light
+         intense
+         pale
+         whitish
+         blackish
+         greyish
+         grayish
+         brownish
+         reddish
+         pinkish
+         orangish
+         yellowish
+         greenish
+         bluish
+         .
+
+save_
+
+save_EXPTL_CRYSTAL_FACE
+
+    _definition.id                EXPTL_CRYSTAL_FACE
+    _definition.scope             Category
+    _definition.class             Loop
+    _definition.update            2021-06-29
+    _description.text
+;
+    The CATEGORY of data items which specify the dimensions of the
+    crystal used in the diffraction measurements.
+;
+    _name.category_id             EXPTL_CRYSTAL
+    _name.object_id               EXPTL_CRYSTAL_FACE
+
+    loop_
+      _category_key.name
+         '_exptl_crystal_face.index_h'
+         '_exptl_crystal_face.index_k'
+         '_exptl_crystal_face.index_l'
+
+save_
+
+save_exptl_crystal_face.diffr_chi
+
+    _definition.id                '_exptl_crystal_face.diffr_chi'
+    _alias.definition_id          '_exptl_crystal_face_diffr_chi'
+    _name.category_id             exptl_crystal_face
+    _name.object_id               diffr_chi
+
+    _import.get                   [{'file':templ_attr.cif  'save':face_angle}]
+
+save_
+
+save_exptl_crystal_face.diffr_chi_su
+
+    _definition.id                '_exptl_crystal_face.diffr_chi_su'
+    _definition.update            2023-07-01
+    _description.text
+;
+    Standard uncertainty of _exptl_crystal_face.diffr_chi.
+;
+    _name.category_id             exptl_crystal_face
+    _name.object_id               diffr_chi_su
+    _name.linked_item_id          '_exptl_crystal_face.diffr_chi'
+    _units.code                   degrees
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+save_
+
+save_exptl_crystal_face.diffr_kappa
+
+    _definition.id                '_exptl_crystal_face.diffr_kappa'
+    _alias.definition_id          '_exptl_crystal_face_diffr_kappa'
+    _name.category_id             exptl_crystal_face
+    _name.object_id               diffr_kappa
+
+    _import.get                   [{'file':templ_attr.cif  'save':face_angle}]
+
+save_
+
+save_exptl_crystal_face.diffr_kappa_su
+
+    _definition.id                '_exptl_crystal_face.diffr_kappa_su'
+    _definition.update            2023-07-01
+    _description.text
+;
+    Standard uncertainty of _exptl_crystal_face.diffr_kappa.
+;
+    _name.category_id             exptl_crystal_face
+    _name.object_id               diffr_kappa_su
+    _name.linked_item_id          '_exptl_crystal_face.diffr_kappa'
+    _units.code                   degrees
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+save_
+
+save_exptl_crystal_face.diffr_phi
+
+    _definition.id                '_exptl_crystal_face.diffr_phi'
+    _alias.definition_id          '_exptl_crystal_face_diffr_phi'
+    _name.category_id             exptl_crystal_face
+    _name.object_id               diffr_phi
+
+    _import.get                   [{'file':templ_attr.cif  'save':face_angle}]
+
+save_
+
+save_exptl_crystal_face.diffr_phi_su
+
+    _definition.id                '_exptl_crystal_face.diffr_phi_su'
+    _definition.update            2023-07-01
+    _description.text
+;
+    Standard uncertainty of _exptl_crystal_face.diffr_phi.
+;
+    _name.category_id             exptl_crystal_face
+    _name.object_id               diffr_phi_su
+    _name.linked_item_id          '_exptl_crystal_face.diffr_phi'
+    _units.code                   degrees
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+save_
+
+save_exptl_crystal_face.diffr_psi
+
+    _definition.id                '_exptl_crystal_face.diffr_psi'
+    _alias.definition_id          '_exptl_crystal_face_diffr_psi'
+    _name.category_id             exptl_crystal_face
+    _name.object_id               diffr_psi
+
+    _import.get                   [{'file':templ_attr.cif  'save':face_angle}]
+
+save_
+
+save_exptl_crystal_face.diffr_psi_su
+
+    _definition.id                '_exptl_crystal_face.diffr_psi_su'
+    _definition.update            2023-07-01
+    _description.text
+;
+    Standard uncertainty of _exptl_crystal_face.diffr_psi.
+;
+    _name.category_id             exptl_crystal_face
+    _name.object_id               diffr_psi_su
+    _name.linked_item_id          '_exptl_crystal_face.diffr_psi'
+    _units.code                   degrees
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+save_
+
+save_exptl_crystal_face.hkl
+
+    _definition.id                '_exptl_crystal_face.hkl'
+    _definition.update            2021-03-01
+    _description.text
+;
+    Miller indices of the crystal face.
+;
+    _name.category_id             exptl_crystal_face
+    _name.object_id               hkl
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Matrix
+    _type.dimension               '[3]'
+    _type.contents                Integer
+    _units.code                   none
+    _method.purpose               Evaluation
+    _method.expression
+;
+    With f as exptl_crystal_face
+
+     _exptl_crystal_face.hkl = [f.index_h, f.index_h, f.index_l]
+;
+
+save_
+
+save_exptl_crystal_face.index_h
+
+    _definition.id                '_exptl_crystal_face.index_h'
+    _alias.definition_id          '_exptl_crystal_face_index_h'
+    _name.category_id             exptl_crystal_face
+    _name.object_id               index_h
+
+    _import.get                   [{'file':templ_attr.cif  'save':miller_index}]
+
+save_
+
+save_exptl_crystal_face.index_k
+
+    _definition.id                '_exptl_crystal_face.index_k'
+    _alias.definition_id          '_exptl_crystal_face_index_k'
+    _name.category_id             exptl_crystal_face
+    _name.object_id               index_k
+
+    _import.get                   [{'file':templ_attr.cif  'save':miller_index}]
+
+save_
+
+save_exptl_crystal_face.index_l
+
+    _definition.id                '_exptl_crystal_face.index_l'
+    _alias.definition_id          '_exptl_crystal_face_index_l'
+    _name.category_id             exptl_crystal_face
+    _name.object_id               index_l
+
+    _import.get                   [{'file':templ_attr.cif  'save':miller_index}]
+
+save_
+
+save_exptl_crystal_face.perp_dist
+
+    _definition.id                '_exptl_crystal_face.perp_dist'
+    _alias.definition_id          '_exptl_crystal_face_perp_dist'
+    _definition.update            2012-11-22
+    _description.text
+;
+    Perpendicular distance of face to the centre of rotation of the crystal.
+;
+    _name.category_id             exptl_crystal_face
+    _name.object_id               perp_dist
+    _type.purpose                 Measurand
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   millimetres
+
+save_
+
+save_exptl_crystal_face.perp_dist_su
+
+    _definition.id                '_exptl_crystal_face.perp_dist_su'
+    _definition.update            2023-07-01
+    _description.text
+;
+    Standard uncertainty of _exptl_crystal_face.perp_dist.
+;
+    _name.category_id             exptl_crystal_face
+    _name.object_id               perp_dist_su
+    _name.linked_item_id          '_exptl_crystal_face.perp_dist'
+    _units.code                   millimetres
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+save_
+
+save_SPACE_GROUP
+
+    _definition.id                SPACE_GROUP
+    _definition.scope             Category
+    _definition.class             Set
+    _definition.update            2023-01-13
+    _description.text
+;
+    The CATEGORY of data items used to specify space group
+    information about the crystal used in the diffraction measurements.
+
+    Space-group types are identified by their number as listed in
+    International Tables for Crystallography Volume A, or by their
+    Schoenflies symbol. Specific settings of the space groups can
+    be identified by their Hall symbol, by specifying their
+    symmetry operations or generators, or by giving the
+    transformation that relates the specific setting to the
+    reference setting based on International Tables Volume A and
+    stored in this dictionary.
+
+    The commonly used Hermann-Mauguin symbol determines the
+    space-group type uniquely, but several different Hermann-Mauguin
+    symbols may refer to the same space-group type. A
+    Hermann-Mauguin symbol contains information on the choice of
+    the basis, but not on the choice of origin.
+
+    Ref: International Tables for Crystallography (2002). Volume A,
+         Space-group symmetry, edited by Th. Hahn, 5th ed.
+         Dordrecht: Kluwer Academic Publishers.
+;
+    _name.category_id             EXPTL
+    _name.object_id               SPACE_GROUP
+
+save_
+
+save_space_group.bravais_type
+
+    _definition.id                '_space_group.Bravais_type'
+    _definition.update            2014-06-12
+    _description.text
+;
+    The symbol denoting the lattice type (Bravais type) to which the
+    translational subgroup (vector lattice) of the space group
+    belongs. It consists of a lower-case letter indicating the
+    crystal system followed by an upper-case letter indicating
+    the lattice centring. The setting-independent symbol mS
+    replaces the setting-dependent symbols mB and mC, and the
+    setting-independent symbol oS replaces the setting-dependent
+    symbols oA, oB and oC.
+
+    Ref: International Tables for Crystallography (2002). Volume A,
+         Space-group symmetry, edited by Th. Hahn, 5th ed., p. 15.
+         Dordrecht: Kluwer Academic Publishers.
+;
+    _name.category_id             space_group
+    _name.object_id               Bravais_type
+    _type.purpose                 State
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Text
+
+    loop_
+      _enumeration_set.state
+         aP
+         mP
+         mS
+         oP
+         oS
+         oI
+         oF
+         tP
+         tI
+         hP
+         hR
+         cP
+         cI
+         cF
+
+    _description_example.case     aP
+    _description_example.detail   'Triclinic (anorthic) primitive lattice.'
+
+save_
+
+save_space_group.centring_type
+
+    _definition.id                '_space_group.centring_type'
+    _definition.update            2014-06-12
+    _description.text
+;
+    Symbol for the lattice centring. This symbol may be dependent
+    on the coordinate system chosen.
+;
+    _name.category_id             space_group
+    _name.object_id               centring_type
+    _type.purpose                 State
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Text
+
+    loop_
+      _enumeration_set.state
+      _enumeration_set.detail
+         P         'Primitive            no centring'
+         A         'A-face centred       (0,1/2,1/2)'
+         B         'B-face centred       (1/2,0,1/2)'
+         C         'C-face centred       (1/2,1/2,0)'
+         F         'All faces centred    (0,1/2,1/2), (1/2,0,1/2), (1/2,1/2,0)'
+         I         'Body centred         (1/2,1/2,1/2)'
+         R         'Rhombohedral obverse centred (2/3,1/3,1/3), (1/3,2/3,2/3)'
+         Rrev      'Rhombohedral reverse centred (1/3,2/3,1/3), (2/3,1/3,2/3)'
+         H         'Hexagonal centred    (2/3,1/3,0), (1/3,2/3,0)'
+
+save_
+
+save_space_group.crystal_system
+
+    _definition.id                '_space_group.crystal_system'
+    _alias.definition_id          '_space_group_crystal_system'
+    _definition.update            2016-05-09
+    _description.text
+;
+    The name of the system of geometric crystal classes of space
+    groups (crystal system) to which the space group belongs.
+    Note that rhombohedral space groups belong to the
+    trigonal system.
+;
+    _name.category_id             space_group
+    _name.object_id               crystal_system
+    _type.purpose                 State
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Text
+
+    loop_
+      _enumeration_set.state
+         triclinic
+         monoclinic
+         orthorhombic
+         tetragonal
+         trigonal
+         hexagonal
+         cubic
+
+save_
+
+save_space_group.it_coordinate_system_code
+
+    _definition.id                '_space_group.IT_coordinate_system_code'
+    _definition.update            2016-05-13
+    _description.text
+;
+    A qualifier taken from the enumeration list identifying which
+    setting in International Tables for Crystallography Volume A
+    (2002) (IT) is used.  See IT Table 4.3.2.1, Section 2.2.16,
+    Table 2.2.16.1, Section 2.2.16.1 and Fig. 2.2.6.4.  This item
+    is not computer-interpretable and cannot be used to define the
+    coordinate system.
+
+    Ref: International Tables for Crystallography (2002). Volume A,
+         Space-group symmetry, edited by Th. Hahn, 5th ed.
+         Dordrecht: Kluwer Academic Publishers.
+;
+    _name.category_id             space_group
+    _name.object_id               IT_coordinate_system_code
+    _type.purpose                 State
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Text
+
+    loop_
+      _enumeration_set.state
+      _enumeration_set.detail
+         b1                     'monoclinic unique axis b, cell choice 1, abc'
+         b2                     'monoclinic unique axis b, cell choice 2, abc'
+         b3                     'monoclinic unique axis b, cell choice 3, abc'
+         -b1                    'monoclinic unique axis b, cell choice 1, c-ba'
+         -b2                    'monoclinic unique axis b, cell choice 2, c-ba'
+         -b3                    'monoclinic unique axis b, cell choice 3, c-ba'
+         c1                     'monoclinic unique axis c, cell choice 1, abc'
+         c2                     'monoclinic unique axis c, cell choice 2, abc'
+         c3                     'monoclinic unique axis c, cell choice 3, abc'
+         -c1                    'monoclinic unique axis c, cell choice 1, ba-c'
+         -c2                    'monoclinic unique axis c, cell choice 2, ba-c'
+         -c3                    'monoclinic unique axis c, cell choice 3, ba-c'
+         a1                     'monoclinic unique axis a, cell choice 1, abc'
+         a2                     'monoclinic unique axis a, cell choice 2, abc'
+         a3                     'monoclinic unique axis a, cell choice 3, abc'
+         -a1                    'monoclinic unique axis a, cell choice 1, -acb'
+         -a2                    'monoclinic unique axis a, cell choice 2, -acb'
+         -a3                    'monoclinic unique axis a, cell choice 3, -acb'
+         abc                    'orthorhombic'
+         ba-c                   'orthorhombic'
+         cab                    'orthorhombic'
+         -cba                   'orthorhombic'
+         bca                    'orthorhombic'
+         a-cb                   'orthorhombic'
+         1abc                   'orthorhombic origin choice 1'
+         1ba-c                  'orthorhombic origin choice 1'
+         1cab                   'orthorhombic origin choice 1'
+         1-cba                  'orthorhombic origin choice 1'
+         1bca                   'orthorhombic origin choice 1'
+         1a-cb                  'orthorhombic origin choice 1'
+         2abc                   'orthorhombic origin choice 2'
+         2ba-c                  'orthorhombic origin choice 2'
+         2cab                   'orthorhombic origin choice 2'
+         2-cba                  'orthorhombic origin choice 2'
+         2bca                   'orthorhombic origin choice 2'
+         2a-cb                  'orthorhombic origin choice 2'
+         1                      'tetragonal or cubic origin choice 1'
+         2                      'tetragonal or cubic origin choice 2'
+         h                      'trigonal using hexagonal axes'
+         r                      'trigonal using rhombohedral axes'
+
+save_
+
+save_space_group.it_number
+
+    _definition.id                '_space_group.IT_number'
+
+    loop_
+      _alias.definition_id
+      _alias.deprecation_date
+         '_space_group_IT_number'                                    .
+         '_symmetry.Int_Tables_number'                               .
+         '_symmetry_Int_Tables_number'                               2003-10-04
+
+    _definition.update            2024-02-14
+    _description.text
+;
+    The number as assigned in International Tables for Crystallography
+    Vol. A, specifying the proper affine class (i.e. the orientation
+    preserving affine class) of space groups (crystallographic space
+    group type) to which the space group belongs. This number defines
+    the space group type but not the coordinate system expressed.
+;
+    _name.category_id             space_group
+    _name.object_id               IT_number
+    _type.purpose                 Number
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Integer
+    _enumeration.range            1:230
+    _units.code                   none
+
+save_
+
+save_space_group.laue_class
+
+    _definition.id                '_space_group.Laue_class'
+    _definition.update            2014-06-12
+    _description.text
+;
+    The Hermann-Mauguin symbol of the geometric crystal class of the
+    point group of the space group where a centre of inversion is
+    added if not already present.
+;
+    _name.category_id             space_group
+    _name.object_id               Laue_class
+    _type.purpose                 State
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Text
+
+    loop_
+      _enumeration_set.state
+         -1
+         2/m
+         mmm
+         4/m
+         4/mmm
+         -3
+         -3m
+         6/m
+         6/mmm
+         m-3
+         m-3m
+
+save_
+
+save_space_group.multiplicity
+
+    _definition.id                '_space_group.multiplicity'
+    _definition.update            2021-03-01
+    _description.text
+;
+    Number of unique symmetry elements in the space group.
+;
+    _name.category_id             space_group
+    _name.object_id               multiplicity
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Integer
+    _enumeration.range            1:192
+    _units.code                   none
+    _method.purpose               Evaluation
+    _method.expression
+;
+    n =  0
+
+    Loop  s  as  space_group_symop  n +=  1
+
+     _space_group.multiplicity  =   n
+;
+
+save_
+
+save_space_group.name_h-m_alt
+
+    _definition.id                '_space_group.name_H-M_alt'
+    _alias.definition_id          '_space_group_name_H-M_alt'
+    _definition.update            2023-01-13
+    _description.text
+;
+    _space_group.name_H-M_alt allows for any Hermann-Mauguin symbol
+    to be given. The way in which this item is used is determined
+    by the user and in general is not intended to be interpreted by
+    computer. It may, for example, be used to give one of the
+    extended Hermann-Mauguin symbols given in Table 4.3.1 of
+    International Tables for Crystallography Vol. A (1995) or
+    a Hermann-Mauguin symbol for a conventional or unconventional
+    setting.
+    Each component of the space group name is separated by a
+    space or underscore. The use of space is strongly
+    recommended. The underscore is only retained because it
+    was used in earlier archived files. It should not be
+    used in new CIFs. Subscripts should appear without special
+    symbols. Bars should be given as negative signs before the
+    numbers to which they apply.
+    The commonly used Hermann-Mauguin symbol determines the space
+    group type uniquely, but a given space group type may be
+    described by more than one Hermann-Mauguin symbol. The space
+    group type is best described using _space_group.IT_number.
+    The Hermann-Mauguin symbol may contain information on the
+    choice of basis though not on the choice of origin. To
+    define the setting uniquely use _space_group.name_Hall or
+    list the symmetry operations.
+;
+    _name.category_id             space_group
+    _name.object_id               name_H_M_alt
+    _type.purpose                 Encode
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+
+    loop_
+      _description_example.case
+      _description_example.detail
+         'P 1 21/m 1'                            'Space group No. 10.'
+         'P 2/n 2/n 2/n (origin at -1)'          'Space group No. 48 origin 2.'
+         'R -3 2/m'                              'Space group No. 166 rhomb.'
+
+save_
+
+save_space_group.name_h-m_alt_description
+
+    _definition.id                '_space_group.name_H-M_alt_description'
+    _definition.update            2016-05-13
+    _description.text
+;
+    A free-text description of the code appearing in
+    _space_group.name_H-M_alt.
+;
+    _name.category_id             space_group
+    _name.object_id               name_H_M_alt_description
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_space_group.name_h-m_full
+
+    _definition.id                '_space_group.name_H-M_full'
+
+    loop_
+      _alias.definition_id
+      _alias.deprecation_date
+         '_symmetry.space_group_name_H-M'                            .
+         '_symmetry_space_group_name_H-M'                            2003-10-04
+
+    _definition.update            2024-02-14
+    _description.text
+;
+    The full international Hermann-Mauguin space-group symbol as
+    defined in Section 2.2.3 and given as the second item of the
+    second line of each of the space-group tables of Part 7 of
+    International Tables for Crystallography Volume A (2002).
+
+    Each component of the space-group name is separated by a
+    space or an underscore character. The use of a space is
+    strongly recommended.  The underscore is only retained
+    because it was used in old CIFs. It should not be used in
+    new CIFs.
+
+    Subscripts should appear without special symbols. Bars should
+    be given as negative signs before the numbers to which they
+    apply. The commonly used Hermann-Mauguin symbol determines the
+    space-group type uniquely, but a given space-group type may
+    be described by more than one Hermann-Mauguin symbol. The
+    space-group type is best described using
+    _space_group.IT_number or _space_group.name_Schoenflies. The
+    full international Hermann-Mauguin symbol contains information
+    about the choice of basis for monoclinic and orthorhombic
+    space groups, but does not give information about the choice
+    of origin. To define the setting uniquely use
+    _space_group.name_Hall, or list the symmetry operations
+    or generators.
+
+    Ref: International Tables for Crystallography (2002). Volume A,
+         Space-group symmetry, edited by Th. Hahn, 5th ed.
+         Dordrecht: Kluwer Academic Publishers.
+;
+    _name.category_id             space_group
+    _name.object_id               name_H_M_full
+    _type.purpose                 Describe
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Text
+    _description_example.case     'P 21/n 21/m 21/a'
+    _description_example.detail   'Full symbol for Pnma.'
+
+save_
+
+save_space_group.name_h-m_ref
+
+    _definition.id                '_space_group.name_H-M_ref'
+    _definition.update            2021-10-21
+    _description.text
+;
+    The short international Hermann-Mauguin space-group symbol as
+    defined in Section 2.2.3 and given as the first item of each
+    space-group table in Part 7 of International Tables
+    for Crystallography Volume A (2002).
+
+    Each component of the space-group name is separated by a
+    space character. Subscripts appear without special symbols.
+    Bars are given as negative signs before the numbers to which
+    they apply.
+
+    The short international Hermann-Mauguin symbol determines
+    the space-group type uniquely. However, the space-group
+    type is better described using _space_group.IT_number or
+    _space_group.name_Schoenflies. The short international
+    Hermann-Mauguin symbol contains no information on the
+    choice of basis or origin. To define the setting uniquely
+    use _space_group.name_Hall, or list the symmetry operations
+    or generators.
+
+    _space_group.name_H-M_alt may be used to give the
+    Hermann-Mauguin symbol corresponding to the setting used.
+
+    In the enumeration list, each possible value is identified by
+    space-group number and Schoenflies symbol.
+
+    Ref: International Tables for Crystallography (2002). Volume A,
+         Space-group symmetry, edited by Th. Hahn, 5th ed.
+         Dordrecht: Kluwer Academic Publishers.
+;
+    _name.category_id             space_group
+    _name.object_id               name_H_M_ref
+    _type.purpose                 State
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Text
+
+    _import.get                   [{'file':templ_enum.cif  'save':h_m_ref}]
+
+save_
+
+save_space_group.name_hall
+
+    _definition.id                '_space_group.name_Hall'
+
+    loop_
+      _alias.definition_id
+      _alias.deprecation_date
+         '_space_group_name_Hall'                                    .
+         '_symmetry_space_group_name_Hall'                           2003-10-04
+         '_symmetry.space_group_name_Hall'                           .
+
+    _definition.update            2023-02-13
+    _description.text
+;
+    Space group symbol defined by Hall. Each component of the
+    space group name is separated by a space or an underscore.
+    The use of space is strongly recommended because it specifies
+    the coordinate system. The underscore in the name is only
+    retained because it was used in earlier archived files. It
+    should not be used in new CIFs.
+    Ref: Hall, S. R. (1981). Acta Cryst. A37, 517-525
+         [See also International Tables for Crystallography,
+         Vol. B (1993) 1.4 Appendix B]
+;
+    _name.category_id             space_group
+    _name.object_id               name_Hall
+    _type.purpose                 Encode
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+
+    loop_
+      _description_example.case
+         'P 2ac 2n'
+         '-R 3 2"'
+         'P 61 2 2 (0 0 -1)'
+
+save_
+
+save_space_group.name_schoenflies
+
+    _definition.id                '_space_group.name_Schoenflies'
+    _definition.update            2023-02-06
+    _description.text
+;
+    The Schoenflies symbol as listed in International Tables for
+    Crystallography Volume A denoting the proper affine class (i.e.
+    orientation-preserving affine class) of space groups
+    (space-group type) to which the space group belongs. This
+    symbol defines the space-group type independently of the
+    coordinate system in which the space group is expressed.
+
+    The symbol is given with a period, '.', separating the
+    Schoenflies point group and the superscript.
+
+    Ref: International Tables for Crystallography (2002). Volume A,
+         Space-group symmetry, edited by Th. Hahn, 5th ed.
+         Dordrecht: Kluwer Academic Publishers.
+;
+    _name.category_id             space_group
+    _name.object_id               name_Schoenflies
+    _type.purpose                 State
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Word
+    _description_example.case     C2h.5
+    _description_example.detail   'Schoenflies symbol for space group No. 14.'
+
+    _import.get                   [{'file':templ_enum.cif  'save':schoenflies}]
+
+save_
+
+save_space_group.patterson_name_h-m
+
+    _definition.id                '_space_group.Patterson_name_H-M'
+    _definition.update            2016-05-13
+    _description.text
+;
+    The Hermann-Mauguin symbol of the type of that centrosymmetric
+    symmorphic space group to which the Patterson function belongs;
+    see Table 2.2.5.1 in International Tables for Crystallography
+    Volume A (2002).
+
+    A space separates each symbol referring to different axes.
+    Underscores may replace the spaces, but this use is discouraged.
+    Subscripts should appear without special symbols.
+    Bars should be given as negative signs before the number
+    to which they apply.
+
+    Ref: International Tables for Crystallography (2002). Volume A,
+         Space-group symmetry, edited by Th. Hahn, 5th ed.,
+         Table 2.2.5.1. Dordrecht: Kluwer Academic Publishers.
+;
+    _name.category_id             space_group
+    _name.object_id               Patterson_name_H_M
+    _type.purpose                 Describe
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Text
+
+    loop_
+      _description_example.case
+         'P -1'
+         'P 2/m'
+         'C 2/m'
+         'P m m m'
+         'C m m m'
+         'I m m m'
+         'F m m m'
+         'P 4/m'
+         'I 4/m'
+         'P 4/m m m'
+         'I 4/m m m'
+         'P -3'
+         'R -3'
+         'P -3 m 1'
+         'R -3 m'
+         'P -3 1 m'
+         'P 6/m'
+         'P 6/m m m'
+         'P m -3'
+         'I m -3'
+         'F m -3'
+         'P m -3 m'
+         'I m -3 m'
+         'F m -3 m'
+
+save_
+
+save_space_group.point_group_h-m
+
+    _definition.id                '_space_group.point_group_H-M'
+    _definition.update            2016-05-13
+    _description.text
+;
+    The Hermann-Mauguin symbol denoting the geometric crystal
+    class of space groups to which the space group belongs, and
+    the geometric crystal class of point groups to which the
+    point group of the space group belongs.
+;
+    _name.category_id             space_group
+    _name.object_id               point_group_H_M
+    _type.purpose                 Describe
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Text
+
+    loop_
+      _description_example.case
+         -4
+         4/m
+
+save_
+
+save_symmetry.cell_setting
+
+    _definition.id                '_symmetry.cell_setting'
+    _definition_replaced.id       1
+    _definition_replaced.by       '_space_group.crystal_system'
+    _alias.definition_id          '_symmetry_cell_setting'
+    _alias.deprecation_date       2003-10-04
+    _definition.update            2024-02-14
+    _description.text
+;
+    This data item should not be used and is DEPRECATED as it is
+    ambiguous.
+
+    The original definition is as follows:
+
+    The cell settings for this space-group symmetry.
+;
+    _name.category_id             space_group
+    _name.object_id               deprecated_setting
+    _type.purpose                 Describe
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Text
+
+    loop_
+      _enumeration_set.state
+         triclinic
+         monoclinic
+         orthorhombic
+         tetragonal
+         rhombohedral
+         trigonal
+         hexagonal
+         cubic
+
+save_
+
+save_SPACE_GROUP_GENERATOR
+
+    _definition.id                SPACE_GROUP_GENERATOR
+    _definition.scope             Category
+    _definition.class             Loop
+    _definition.update            2021-06-29
+    _description.text
+;
+    The CATEGORY of data items used to list generators for
+    the space group
+;
+    _name.category_id             SPACE_GROUP
+    _name.object_id               SPACE_GROUP_GENERATOR
+    _category_key.name            '_space_group_generator.key'
+
+save_
+
+save_space_group_generator.key
+
+    _definition.id                '_space_group_generator.key'
+    _definition.update            2023-02-03
+    _description.text
+;
+    Arbitrary identifier for each entry in the _space_group_generator.xyz list.
+;
+    _name.category_id             space_group_generator
+    _name.object_id               key
+    _type.purpose                 Key
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Word
+
+save_
+
+save_space_group_generator.xyz
+
+    _definition.id                '_space_group_generator.xyz'
+    _definition.update            2016-05-10
+    _description.text
+;
+    A parsable string giving one of the symmetry generators of the
+    space group in algebraic form.  If W is a matrix representation
+    of the rotational part of the generator defined by the positions
+    and signs of x, y and z, and w is a column of translations
+    defined by the fractions, an equivalent position X' is
+    generated from a given position X by
+
+              X' = WX + w.
+
+    (Note: X is used to represent the bold italic x in International
+    Tables for Crystallography Volume A, Section 5.)
+
+    When a list of symmetry generators is given, it is assumed
+    that the complete list of symmetry operations of the space
+    group (including the identity operation) can be generated
+    through repeated multiplication of the generators, that is,
+    (W3, w3) is an operation of the space group if (W2,w2) and
+    (W1,w1) [where (W1,w1) is applied first] are either operations
+    or generators and:
+
+            W3 = W2 x W1
+            w3 = W2 x w1 + w2.
+
+    Ref: International Tables for Crystallography (2002). Volume A,
+         Space-group symmetry, edited by Th. Hahn, 5th ed.
+         Dordrecht: Kluwer Academic Publishers.
+;
+    _name.category_id             space_group_generator
+    _name.object_id               xyz
+    _type.purpose                 Encode
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Code
+    _description_example.case     x,1/2-y,1/2+z
+    _description_example.detail
+;
+    C glide reflection through the plane (x,1/4,z) chosen as one of
+    the generators of the space group.
+;
+
+save_
+
+save_SPACE_GROUP_SYMOP
+
+    _definition.id                SPACE_GROUP_SYMOP
+    _definition.scope             Category
+    _definition.class             Loop
+    _definition.update            2021-06-29
+    _description.text
+;
+    The CATEGORY of data items used to describe symmetry equivalent sites
+    in the crystal unit cell.
+;
+    _name.category_id             SPACE_GROUP
+    _name.object_id               SPACE_GROUP_SYMOP
+    _category_key.name            '_space_group_symop.id'
+
+save_
+
+save_space_group_symop.id
+
+    _definition.id                '_space_group_symop.id'
+
+    loop_
+      _alias.definition_id
+      _alias.deprecation_date
+         '_space_group_symop_id'                                     .
+         '_symmetry_equiv.pos_site_id'                               .
+         '_symmetry_equiv_pos_site_id'                               2003-10-04
+
+    _definition.update            2024-02-14
+    _description.text
+;
+    Index identifying each entry in the _space_group_symop.operation_xyz
+    list. It is normally the sequence number of the entry in that
+    list, and should be identified with the code 'n' in the geometry
+    symmetry codes of the form 'n_pqr'. The identity operation
+    (i.e. _space_group_symop.operation_xyz set to 'x,y,z') should be
+    set to 1.
+;
+    _name.category_id             space_group_symop
+    _name.object_id               id
+    _type.purpose                 Number
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Integer
+    _enumeration.range            1:192
+    _units.code                   none
+    _method.purpose               Evaluation
+    _method.expression
+;
+    _space_group_symop.id = Current_row(space_group_symop.id) + 1
+;
+
+save_
+
+save_space_group_symop.operation_description
+
+    _definition.id                '_space_group_symop.operation_description'
+    _definition.update            2016-05-13
+    _description.text
+;
+    An optional text description of a particular symmetry operation
+    of the space group.
+;
+    _name.category_id             space_group_symop
+    _name.object_id               operation_description
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_space_group_symop.operation_xyz
+
+    _definition.id                '_space_group_symop.operation_xyz'
+
+    loop_
+      _alias.definition_id
+      _alias.deprecation_date
+         '_space_group_symop_operation_xyz'                          .
+         '_symmetry_equiv.pos_as_xyz'                                .
+         '_symmetry_equiv_pos_as_xyz'                                2003-10-04
+
+    _definition.update            2024-02-14
+    _description.text
+;
+    A parsable string giving one of the symmetry operations of the
+    space group in algebraic form.  If W is a matrix representation
+    of the rotational part of the symmetry operation defined by the
+    positions and signs of x, y and z, and w is a column of
+    translations defined by fractions, an equivalent position
+    X' is generated from a given position X by the equation
+
+              X' = WX + w
+
+    (Note: X is used to represent bold_italics_x in International
+    Tables for Crystallography Vol. A, Part 5)
+
+    When a list of symmetry operations is given, it must contain
+    a complete set of coordinate representatives which generates
+    all the operations of the space group by the addition of
+    all primitive translations of the space group. Such
+    representatives are to be found as the coordinates of
+    the general-equivalent position in International Tables for
+    Crystallography Vol. A (2002), to which it is necessary to
+    add any centring translations shown above the
+    general-equivalent position.
+
+    That is to say, it is necessary to list explicitly all the
+    symmetry operations required to generate all the atoms in
+    the unit cell defined by the setting used.
+;
+    _name.category_id             space_group_symop
+    _name.object_id               operation_xyz
+    _type.purpose                 Encode
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+    _description_example.case     x,1/2-y,1/2+z
+    _description_example.detail
+        'Glide reflection through the plane (x,1/4,z) with glide vector (1/2)c.'
+
+save_
+
+save_space_group_symop.r
+
+    _definition.id                '_space_group_symop.R'
+    _definition.update            2021-07-07
+    _description.text
+;
+    A matrix containing the symmetry rotation operations of a space group
+
+                   |  r11  r12  r13  |
+             R  =  |  r21  r22  r23  |
+                   |  r31  r32  r33  |
+;
+    _name.category_id             space_group_symop
+    _name.object_id               R
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Matrix
+    _type.dimension               '[3,3]'
+    _type.contents                Real
+    _units.code                   none
+    _method.purpose               Evaluation
+    _method.expression
+;
+                   sm =  _space_group_symop.Seitz_matrix
+    _space_group_symop.R =  [[sm[0,0],sm[0,1],sm[0,2]],
+                          [sm[1,0],sm[1,1],sm[1,2]],
+                          [sm[2,0],sm[2,1],sm[2,2]]]
+;
+
+save_
+
+save_space_group_symop.rt
+
+    _definition.id                '_space_group_symop.RT'
+    _definition.update            2021-03-03
+    _description.text
+;
+    The TRANSPOSE of the symmetry rotation matrix representing the point
+    group operations of the space group
+
+                    |  r11  r21  r31  |
+             RT  =  |  r12  r22  r32  |
+                    |  r13  r23  r33  |
+;
+    _name.category_id             space_group_symop
+    _name.object_id               RT
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Matrix
+    _type.dimension               '[3,3]'
+    _type.contents                Real
+    _units.code                   none
+    _method.purpose               Evaluation
+    _method.expression
+;
+    _space_group_symop.RT =  Transpose (_space_group_symop.R)
+;
+
+save_
+
+save_space_group_symop.seitz_matrix
+
+    _definition.id                '_space_group_symop.Seitz_matrix'
+    _definition.update            2021-03-01
+    _description.text
+;
+    A matrix containing the symmetry operations of a space group
+    in 4x4 Seitz format.
+
+                   |  r11  r12  r13  t1  |
+      | R  T |     |  r21  r22  r23  t2  |
+      | 0  1 |     |  r31  r32  r33  t3  |
+                   |   0    0    0    1  |
+;
+    _name.category_id             space_group_symop
+    _name.object_id               Seitz_matrix
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Matrix
+    _type.dimension               '[4,4]'
+    _type.contents                Real
+    _units.code                   none
+    _method.purpose               Evaluation
+    _method.expression
+;
+    _space_group_symop.Seitz_matrix =  SeitzFromJones
+    (_space_group_symop.operation_xyz)
+;
+
+save_
+
+save_space_group_symop.t
+
+    _definition.id                '_space_group_symop.T'
+    _definition.update            2021-03-01
+    _description.text
+;
+    A vector containing the symmetry translation operations of a space group.
+;
+    _name.category_id             space_group_symop
+    _name.object_id               T
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Matrix
+    _type.dimension               '[3]'
+    _type.contents                Real
+    _units.code                   none
+    _method.purpose               Evaluation
+    _method.expression
+;
+                   sm =  _space_group_symop.Seitz_matrix
+
+    _space_group_symop.T =   [sm[0,3],sm[1,3],sm[2,3]]
+;
+
+save_
+
+save_SPACE_GROUP_WYCKOFF
+
+    _definition.id                SPACE_GROUP_WYCKOFF
+    _definition.scope             Category
+    _definition.class             Loop
+    _definition.update            2023-01-13
+    _description.text
+;
+    Contains information about Wyckoff positions of a space group.
+    Only one site can be given for each special position, but the
+    remainder can be generated by applying the symmetry operations
+    stored in _space_group_symop.operation_xyz.
+;
+    _name.category_id             SPACE_GROUP
+    _name.object_id               SPACE_GROUP_WYCKOFF
+    _category_key.name            '_space_group_Wyckoff.id'
+
+save_
+
+save_space_group_wyckoff.coords_xyz
+
+    _definition.id                '_space_group_Wyckoff.coords_xyz'
+    _definition.update            2014-06-12
+    _description.text
+;
+    Coordinates of one site of a Wyckoff position expressed in
+    terms of its fractional coordinates (x,y,z) in the unit cell.
+    To generate the coordinates of all sites of this Wyckoff
+    position, it is necessary to multiply these coordinates by the
+    symmetry operations stored in _space_group_symop.operation_xyz.
+;
+    _name.category_id             space_group_Wyckoff
+    _name.object_id               coords_xyz
+    _type.purpose                 Encode
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Code
+    _description_example.case     x,1/2,0
+    _description_example.detail
+        'Coordinates of Wyckoff site with 2.. symmetry.'
+
+save_
+
+save_space_group_wyckoff.id
+
+    _definition.id                '_space_group_Wyckoff.id'
+    _definition.update            2023-09-12
+    _description.text
+;
+    An arbitrary code that is unique to a particular Wyckoff position.
+;
+    _name.category_id             space_group_Wyckoff
+    _name.object_id               id
+    _type.purpose                 Key
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Word
+
+save_
+
+save_space_group_wyckoff.letter
+
+    _definition.id                '_space_group_Wyckoff.letter'
+    _definition.update            2023-06-14
+    _description.text
+;
+    The Wyckoff letter associated with this position, as given in
+    International Tables for Crystallography Volume A. The
+    enumeration values '\a' and α are equivalent, and correspond to
+    the Greek letter 'alpha' used in International Tables.
+
+    Ref: International Tables for Crystallography (2002). Volume A,
+         Space-group symmetry, edited by Th. Hahn, 5th ed.
+         Dordrecht: Kluwer Academic Publishers.
+;
+    _name.category_id             space_group_Wyckoff
+    _name.object_id               letter
+    _type.purpose                 State
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Text
+
+    _import.get
+        [{'file':templ_enum.cif  'save':wyckoff_letter}]
+
+save_
+
+save_space_group_wyckoff.multiplicity
+
+    _definition.id                '_space_group_Wyckoff.multiplicity'
+    _definition.update            2021-08-19
+    _description.text
+;
+    The multiplicity of this Wyckoff position as given in
+    International Tables Volume A. It is the number of equivalent
+    sites per conventional unit cell.
+
+    Ref: International Tables for Crystallography (2002). Volume A,
+         Space-group symmetry, edited by Th. Hahn, 5th ed.
+         Dordrecht: Kluwer Academic Publishers.
+;
+    _name.category_id             space_group_Wyckoff
+    _name.object_id               multiplicity
+    _type.purpose                 Number
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Integer
+    _enumeration.range            1:192
+    _units.code                   none
+
+save_
+
+save_space_group_wyckoff.site_symmetry
+
+    _definition.id                '_space_group_Wyckoff.site_symmetry'
+    _definition.update            2014-06-12
+    _description.text
+;
+    The subgroup of the space group that leaves the point fixed.
+    It is isomorphic to a subgroup of the point group of the
+    space group. The site-symmetry symbol indicates the symmetry
+    in the symmetry direction determined by the Hermann-Mauguin
+    symbol of the space group (see International Tables for
+    Crystallography Volume A, Section 2.2.12).
+
+    Ref: International Tables for Crystallography (2002). Volume A,
+         Space-group symmetry, edited by Th. Hahn, 5th ed.
+         Dordrecht: Kluwer Academic Publishers.
+;
+    _name.category_id             space_group_Wyckoff
+    _name.object_id               site_symmetry
+    _type.purpose                 Encode
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Code
+
+    loop_
+      _description_example.case
+      _description_example.detail
+         2.22
+;
+         Position 2b in space group No. 94, P 42 21 2.
+;
+         42.2
+;
+         Position 6b in space group No. 222, P n -3 n.
+;
+         2..
+;
+         Site symmetry for the Wyckoff position 96f in space group
+         No. 228, F d -3 c.  The site-symmetry group is isomorphic to
+         the point group 2 with the twofold axis along one of the {100}
+         directions.
+;
+
+save_
+
+save_MODEL
+
+    _definition.id                MODEL
+    _definition.scope             Category
+    _definition.class             Set
+    _definition.update            2024-05-15
+    _description.text
+;
+    Items in the MODEL Category specify data for the crystal structure
+    postulated and modelled from the atomic coordinates derived and
+    refined from the diffraction information. The structural model is
+    described principally in terms of the geometry of the 'connected'
+    atom sites and the crystal symmetry in which they reside.
+;
+    _name.category_id             CIF_CORE_HEAD
+    _name.object_id               MODEL
+
+save_
+
+save_GEOM
+
+    _definition.id                GEOM
+    _definition.scope             Category
+    _definition.class             Set
+    _definition.update            2012-11-22
+    _description.text
+;
+    The CATEGORY of data items used to specify the geometry
+    of the structural model as derived from the atomic sites.
+    The geometry is expressed in terms of the interatomic
+    angles (GEOM_ANGLE data), covalent bond distances
+    (GEOM_BOND data), contact distances (GEOM_CONTACT data),
+    hydrogen bonds (GEOM_HBOND data) and torsion geometry
+    (GEOM_TORSION data).
+    Geometry data are usually redundant, in that they can be
+    calculated from other more fundamental quantities in the data
+    block. However, they serve the dual purposes of providing a
+    check on the correctness of both sets of data and of enabling
+    the most important geometric data to be identified for
+    publication by setting the appropriate publication flag.
+;
+    _name.category_id             MODEL
+    _name.object_id               GEOM
+
+save_
+
+save_geom.bond_distance_incr
+
+    _definition.id                '_geom.bond_distance_incr'
+    _definition.update            2012-11-22
+    _description.text
+;
+    Increment added to the bond radii for the atomic species to
+    specify the maximum permitted "bonded" distance between two
+    atom sites.
+;
+    _name.category_id             geom
+    _name.object_id               bond_distance_incr
+    _type.purpose                 Number
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Real
+    _units.code                   angstroms
+
+save_
+
+save_geom.bond_distance_min
+
+    _definition.id                '_geom.bond_distance_min'
+    _definition.update            2012-11-22
+    _description.text
+;
+    Minimum permitted "bonded" distance between two atom sites.
+;
+    _name.category_id             geom
+    _name.object_id               bond_distance_min
+    _type.purpose                 Number
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Real
+    _units.code                   angstroms
+
+save_
+
+save_geom.contact_distance_incr
+
+    _definition.id                '_geom.contact_distance_incr'
+    _definition.update            2012-11-22
+    _description.text
+;
+    Increment added to the bond radii for the atomic species to
+    specify the maximum permitted "contact" distance between two
+    "non-bonded" atom sites.
+;
+    _name.category_id             geom
+    _name.object_id               contact_distance_incr
+    _type.purpose                 Number
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Real
+    _units.code                   angstroms
+
+save_
+
+save_geom.contact_distance_min
+
+    _definition.id                '_geom.contact_distance_min'
+    _definition.update            2012-11-22
+    _description.text
+;
+    Minimum permitted "contact" distance between two "non-bonded" atom sites.
+;
+    _name.category_id             geom
+    _name.object_id               contact_distance_min
+    _type.purpose                 Number
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Real
+    _units.code                   angstroms
+
+save_
+
+save_geom.special_details
+
+    _definition.id                '_geom.special_details'
+
+    loop_
+      _alias.definition_id
+         '_geom_special_details'
+         '_geom.details'
+
+    _definition.update            2012-11-22
+    _description.text
+;
+    Description of geometry information not covered by the existing data
+    names in the geometry categories, such as least-squares planes.
+;
+    _name.category_id             geom
+    _name.object_id               special_details
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_GEOM_ANGLE
+
+    _definition.id                GEOM_ANGLE
+    _definition.scope             Category
+    _definition.class             Loop
+    _definition.update            2021-06-29
+    _description.text
+;
+    The CATEGORY of data items used to specify the geometry angles in the
+    structural model as derived from the atomic sites.
+;
+    _name.category_id             GEOM
+    _name.object_id               GEOM_ANGLE
+
+    loop_
+      _category_key.name
+         '_geom_angle.atom_site_label_1'
+         '_geom_angle.atom_site_label_2'
+         '_geom_angle.atom_site_label_3'
+         '_geom_angle.site_symmetry_1'
+         '_geom_angle.site_symmetry_2'
+         '_geom_angle.site_symmetry_3'
+
+    _method.purpose               Evaluation
+    _method.expression
+;
+    dmin =  _geom.bond_distance_min
+
+    Loop  m1  as  model_site  :i  {   # loop vertex model site
+
+       rad1  =   m1.radius_bond + _geom.bond_distance_incr
+
+       Loop  m2  as  model_site  :j  {  # loop first target site
+
+          If (i==j or m1.mole_index != m2.mole_index) Next
+          v1 =  m2.Cartn_xyz - m1.Cartn_xyz
+          d1 =  Norm (v1)
+
+          If (d1<dmin or d1>(rad1+m2.radius_bond))  Next
+
+          rad2  =   m2.radius_bond + _geom.bond_distance_incr
+
+          Loop  m3  as  model_site  :k>j  {  # loop second target site
+
+             If (i==k or m1.mole_index != m3.mole_index) Next
+             v2 =  m3.Cartn_xyz - m1.Cartn_xyz
+             d2 =  Norm (v2)
+
+             If (d2<dmin or d2>(rad2+m3.radius_bond)) Next
+
+             angle =  Acosd ( v1*v2 / (d1*d2) )
+
+             geom_angle( .atom_site_label_1  = m2.label,
+                         .atom_site_label_2  = m1.label,
+                         .atom_site_label_3  = m3.label,
+                         .site_symmetry_1 = m2.symop,
+                         .site_symmetry_2 = m1.symop,
+                         .site_symmetry_3 = m3.symop,
+                         .distances =  List ( d1, d2 ),
+                         .value     =  angle )
+    }   }   }
+;
+
+save_
+
+save_geom_angle.atom_site_label_1
+
+    _definition.id                '_geom_angle.atom_site_label_1'
+
+    loop_
+      _alias.definition_id
+         '_geom_angle_atom_site_label_1'
+         '_geom_angle.atom_site_id_1'
+
+    _name.category_id             geom_angle
+    _name.object_id               atom_site_label_1
+
+    _import.get                   [{'file':templ_attr.cif  'save':atom_site_id}]
+
+save_
+
+save_geom_angle.atom_site_label_2
+
+    _definition.id                '_geom_angle.atom_site_label_2'
+
+    loop_
+      _alias.definition_id
+         '_geom_angle_atom_site_label_2'
+         '_geom_angle.atom_site_id_2'
+
+    _definition.update            2019-04-03
+    _description.text
+;
+    The unique identifier for the vertex atom of the angle.
+;
+    _name.category_id             geom_angle
+    _name.object_id               atom_site_label_2
+    _name.linked_item_id          '_atom_site.label'
+    _type.purpose                 Link
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Word
+
+save_
+
+save_geom_angle.atom_site_label_3
+
+    _definition.id                '_geom_angle.atom_site_label_3'
+
+    loop_
+      _alias.definition_id
+         '_geom_angle_atom_site_label_3'
+         '_geom_angle.atom_site_id_3'
+
+    _name.category_id             geom_angle
+    _name.object_id               atom_site_label_3
+
+    _import.get                   [{'file':templ_attr.cif  'save':atom_site_id}]
+
+save_
+
+save_geom_angle.distances
+
+    _definition.id                '_geom_angle.distances'
+    _definition.update            2012-11-22
+    _description.text
+;
+    The pair of distances between sites 1 - 2 and 2 - 3.
+;
+    _name.category_id             geom_angle
+    _name.object_id               distances
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               List
+    _type.dimension               '[2]'
+    _type.contents                Real
+    _units.code                   angstroms
+
+save_
+
+save_geom_angle.distances_su
+
+    _definition.id                '_geom_angle.distances_su'
+    _definition.update            2023-07-01
+    _description.text
+;
+    Standard uncertainty of _geom_angle.distances.
+;
+    _name.category_id             geom_angle
+    _name.object_id               distances_su
+    _name.linked_item_id          '_geom_angle.distances'
+    _type.purpose                 SU
+    _type.source                  Related
+    _type.container               List
+    _type.dimension               '[2]'
+    _type.contents                Real
+    _units.code                   angstroms
+
+save_
+
+save_geom_angle.id
+
+    _definition.id                '_geom_angle.id'
+    _definition.update            2023-02-02
+    _description.text
+;
+    An arbitrary, unique identifier for the angle formed by the three atoms.
+;
+    _name.category_id             geom_angle
+    _name.object_id               id
+    _type.purpose                 Key
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Word
+
+save_
+
+save_geom_angle.publ_flag
+
+    _definition.id                '_geom_angle.publ_flag'
+    _alias.definition_id          '_geom_angle_publ_flag'
+    _definition.update            2012-11-22
+    _description.text
+;
+    Code signals if the angle is referred to in a publication or
+    should be placed in a table of significant angles.
+;
+    _name.category_id             geom_angle
+    _name.object_id               publ_flag
+    _type.purpose                 State
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Text
+
+    loop_
+      _enumeration_set.state
+      _enumeration_set.detail
+         no                       'Do not include angle in special list.'
+         n                        'Abbreviation for "no".'
+         yes                      'Do include angle in special list.'
+         y                        'Abbreviation for "yes".'
+
+    _enumeration.default          no
+
+save_
+
+save_geom_angle.site_symmetry_1
+
+    _definition.id                '_geom_angle.site_symmetry_1'
+    _alias.definition_id          '_geom_angle_site_symmetry_1'
+    _name.category_id             geom_angle
+    _name.object_id               site_symmetry_1
+
+    _import.get
+        [{'file':templ_attr.cif  'save':site_symmetry}]
+
+save_
+
+save_geom_angle.site_symmetry_2
+
+    _definition.id                '_geom_angle.site_symmetry_2'
+    _alias.definition_id          '_geom_angle_site_symmetry_2'
+    _name.category_id             geom_angle
+    _name.object_id               site_symmetry_2
+
+    _import.get
+        [{'file':templ_attr.cif  'save':site_symmetry}]
+
+save_
+
+save_geom_angle.site_symmetry_3
+
+    _definition.id                '_geom_angle.site_symmetry_3'
+    _alias.definition_id          '_geom_angle_site_symmetry_3'
+    _name.category_id             geom_angle
+    _name.object_id               site_symmetry_3
+
+    _import.get
+        [{'file':templ_attr.cif  'save':site_symmetry}]
+
+save_
+
+save_geom_angle.value
+
+    _definition.id                '_geom_angle.value'
+    _alias.definition_id          '_geom_angle'
+    _definition.update            2020-03-13
+    _description.text
+;
+    Angle defined by the atoms located at atom_site_x/site_symmetry_x for
+    x = 1,2,3. The vertex atom is at site x = 2.
+;
+    _name.category_id             geom_angle
+    _name.object_id               value
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:180.0
+    _units.code                   degrees
+    _method.purpose               Evaluation
+    _method.expression
+;
+    With a as geom_angle
+    xc = List()
+    bundle = [[a.site_symmetry_1,a.atom_site_label_1],
+              [a.site_symmetry_2,a.atom_site_label_2],
+              [a.site_symmetry_3.a.atom_site_label_3]]
+    for symop,label in bundle {
+        xf   =   SymEquiv(symop,  _atom_site[label].fract_xyz)
+        xc ++=  _atom_sites_Cartn_transform.matrix * xf
+    }
+      v1,v2  =  xc[0]-xc[1], xc[2]-xc[1]
+
+     _geom_angle.value =  Acosd ( v1 * v2 / ( Norm (v1) * Norm (v2) ) )
+;
+
+save_
+
+save_geom_angle.value_su
+
+    _definition.id                '_geom_angle.value_su'
+
+    loop_
+      _alias.definition_id
+         '_geom_angle_su'
+         '_geom_angle.value_esd'
+
+    _definition.update            2021-03-03
+    _description.text
+;
+    Standard uncertainty of _geom_angle.value.
+;
+    _name.category_id             geom_angle
+    _name.object_id               value_su
+    _name.linked_item_id          '_geom_angle.value'
+    _units.code                   degrees
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+save_
+
+save_GEOM_BOND
+
+    _definition.id                GEOM_BOND
+    _definition.scope             Category
+    _definition.class             Loop
+    _definition.update            2021-06-29
+    _description.text
+;
+    The CATEGORY of data items used to specify the geometry bonds in the
+    structural model as derived from the atomic sites.
+;
+    _name.category_id             GEOM
+    _name.object_id               GEOM_BOND
+
+    loop_
+      _category_key.name
+         '_geom_bond.atom_site_label_1'
+         '_geom_bond.atom_site_label_2'
+         '_geom_bond.site_symmetry_1'
+         '_geom_bond.site_symmetry_2'
+
+    _method.purpose               Evaluation
+    _method.expression
+;
+    dmin =  _geom.bond_distance_min
+
+    Loop  m1  as  model_site  :i  {
+
+       rad   =   m1.radius_bond + _geom.bond_distance_incr
+
+       Loop  m2  as  model_site  :j  {
+
+          If (i==j or m1.mole_index != m2.mole_index) Next
+
+          d =  Norm (m1.Cartn_xyz - m2.Cartn_xyz)
+
+          If (d<dmin or d>(rad+m2.radius_bond)) Next
+
+          geom_bond( .atom_site_label_1        =  m1.label,
+                     .atom_site_label_2        =  m2.label,
+                     .site_symmetry_1          =  m1.symop,
+                     .site_symmetry_2          =  m2.symop,
+                     .distance  =  d  )
+     }   }
+;
+
+save_
+
+save_geom_bond.atom_site_label_1
+
+    _definition.id                '_geom_bond.atom_site_label_1'
+
+    loop_
+      _alias.definition_id
+         '_geom_bond_atom_site_label_1'
+         '_geom_bond.atom_site_id_1'
+
+    _name.category_id             geom_bond
+    _name.object_id               atom_site_label_1
+
+    _import.get                   [{'file':templ_attr.cif  'save':atom_site_id}]
+
+save_
+
+save_geom_bond.atom_site_label_2
+
+    _definition.id                '_geom_bond.atom_site_label_2'
+
+    loop_
+      _alias.definition_id
+         '_geom_bond_atom_site_label_2'
+         '_geom_bond.atom_site_id_2'
+
+    _name.category_id             geom_bond
+    _name.object_id               atom_site_label_2
+
+    _import.get                   [{'file':templ_attr.cif  'save':atom_site_id}]
+
+save_
+
+save_geom_bond.distance
+
+    _definition.id                '_geom_bond.distance'
+
+    loop_
+      _alias.definition_id
+         '_geom_bond_distance'
+         '_geom_bond.dist'
+
+    _definition.update            2012-12-14
+    _description.text
+;
+    Intramolecular bond distance between the sites identified
+    by _geom_bond.id
+;
+    _name.category_id             geom_bond
+    _name.object_id               distance
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   angstroms
+    _method.purpose               Evaluation
+    _method.expression
+;
+    With b as geom_bond
+
+    xc = List()
+
+    For [label,symop] in  [[b.atom_site_label_1,b.site_symmetry_1],
+                           [b.atom_site_label_2,b.site_symmetry_2]]   {
+
+        xf   =   SymEquiv(symop, _atom_site[label].fract_xyz)
+
+        xc ++=  _atom_sites_Cartn_transform.matrix * xf
+     }
+     _geom_bond.distance =  Norm ( xc[0] - xc[1] )
+;
+
+save_
+
+save_geom_bond.distance_su
+
+    _definition.id                '_geom_bond.distance_su'
+
+    loop_
+      _alias.definition_id
+         '_geom_bond_distance_su'
+         '_geom_bond.dist_esd'
+
+    _definition.update            2021-03-03
+    _description.text
+;
+    Standard uncertainty of _geom_bond.distance.
+;
+    _name.category_id             geom_bond
+    _name.object_id               distance_su
+    _name.linked_item_id          '_geom_bond.distance'
+    _units.code                   angstroms
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+save_
+
+save_geom_bond.id
+
+    _definition.id                '_geom_bond.id'
+    _definition.update            2023-02-02
+    _description.text
+;
+    Unique identifier for the bond.
+;
+    _name.category_id             geom_bond
+    _name.object_id               id
+    _type.purpose                 Key
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Word
+
+save_
+
+save_geom_bond.multiplicity
+
+    _definition.id                '_geom_bond.multiplicity'
+    _alias.definition_id          '_geom_bond_multiplicity'
+    _definition.update            2021-03-01
+    _description.text
+;
+    The number of times the given bond appears in the environment
+    of the atoms labelled _geom_bond.atom_site_label_1. In cases
+    where the full list of bonds is given, one of the series of
+    equivalent bonds may be assigned the appropriate multiplicity
+    while the others are assigned a value of 0.
+;
+    _name.category_id             geom_bond
+    _name.object_id               multiplicity
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Integer
+    _enumeration.range            0:
+    _units.code                   none
+
+save_
+
+save_geom_bond.publ_flag
+
+    _definition.id                '_geom_bond.publ_flag'
+    _alias.definition_id          '_geom_bond_publ_flag'
+    _definition.update            2012-11-22
+    _description.text
+;
+    This code signals whether the angle is referred to in a
+    publication or should be placed in a table of significant angles.
+;
+    _name.category_id             geom_bond
+    _name.object_id               publ_flag
+    _type.purpose                 State
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Text
+
+    loop_
+      _enumeration_set.state
+      _enumeration_set.detail
+         no                       'Do not include bond in special list.'
+         n                        'Abbreviation for "no".'
+         yes                      'Do include bond in special list.'
+         y                        'Abbreviation for "yes".'
+
+    _enumeration.default          no
+
+save_
+
+save_geom_bond.site_symmetry_1
+
+    _definition.id                '_geom_bond.site_symmetry_1'
+    _alias.definition_id          '_geom_bond_site_symmetry_1'
+    _name.category_id             geom_bond
+    _name.object_id               site_symmetry_1
+
+    _import.get
+        [{'file':templ_attr.cif  'save':site_symmetry}]
+
+save_
+
+save_geom_bond.site_symmetry_2
+
+    _definition.id                '_geom_bond.site_symmetry_2'
+    _alias.definition_id          '_geom_bond_site_symmetry_2'
+    _name.category_id             geom_bond
+    _name.object_id               site_symmetry_2
+
+    _import.get
+        [{'file':templ_attr.cif  'save':site_symmetry}]
+
+save_
+
+save_geom_bond.valence
+
+    _definition.id                '_geom_bond.valence'
+    _alias.definition_id          '_geom_bond_valence'
+    _definition.update            2012-12-11
+    _description.text
+;
+    Bond valence calculated from the bond distance.
+;
+    _name.category_id             geom_bond
+    _name.object_id               valence
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   electrons
+
+save_
+
+save_geom_bond.valence_su
+
+    _definition.id                '_geom_bond.valence_su'
+    _definition.update            2023-07-01
+    _description.text
+;
+    Standard uncertainty of _geom_bond.valence.
+;
+    _name.category_id             geom_bond
+    _name.object_id               valence_su
+    _name.linked_item_id          '_geom_bond.valence'
+    _units.code                   electrons
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+save_
+
+save_GEOM_CONTACT
+
+    _definition.id                GEOM_CONTACT
+    _definition.scope             Category
+    _definition.class             Loop
+    _definition.update            2021-06-29
+    _description.text
+;
+    The CATEGORY of data items used to specify the interatomic
+    contact distances in the structural model.
+;
+    _name.category_id             GEOM
+    _name.object_id               GEOM_CONTACT
+
+    loop_
+      _category_key.name
+         '_geom_contact.atom_site_label_1'
+         '_geom_contact.atom_site_label_2'
+         '_geom_contact.site_symmetry_1'
+         '_geom_contact.site_symmetry_2'
+
+    _method.purpose               Evaluation
+    _method.expression
+;
+    Loop  m1  as  model_site  {
+
+       rb  =   m1.radius_bond    + _geom.bond_distance_incr
+       rc  =   m1.radius_contact + _geom.contact_distance_incr
+
+       Loop  m2  as  model_site  {
+
+          If (m2.symop != '1_555')  Next
+          radb  =   rb + m2.radius_bond
+          radc  =   rc + m2.radius_contact
+          label =   m2.label
+
+          Loop  s  as  space_group_symop  :ns   {
+
+             axyz      =   s.R * m2.fract_xyz + s.T
+
+             Do i = -2,2 { Do j = -2,2 { Do k = -2,2 { # cell translations
+
+                tran  =   List ([i,j,k])
+                bxyz  =   axyz + tran
+                cxyz  =  _atom_sites_Cartn_transform.matrix * bxyz
+                d     =   Norm (cxyz - m1.Cartn_xyz)
+
+                If (d < radb or d > radc) Next
+
+                geom_contact( .atom_site_label_1        =  m1.label,
+                              .site_symmetry_1          =  m1.symop,
+                              .atom_site_label_2        =  label,
+                              .site_symmetry_2          = Symop(ns+1,tran),
+                              .distance  =  d  )
+    }  }  }  }  }  }
+;
+
+save_
+
+save_geom_contact.atom_site_label_1
+
+    _definition.id                '_geom_contact.atom_site_label_1'
+
+    loop_
+      _alias.definition_id
+         '_geom_contact_atom_site_label_1'
+         '_geom_contact.atom_site_id_1'
+
+    _name.category_id             geom_contact
+    _name.object_id               atom_site_label_1
+
+    _import.get                   [{'file':templ_attr.cif  'save':atom_site_id}]
+
+save_
+
+save_geom_contact.atom_site_label_2
+
+    _definition.id                '_geom_contact.atom_site_label_2'
+
+    loop_
+      _alias.definition_id
+         '_geom_contact_atom_site_label_2'
+         '_geom_contact.atom_site_id_2'
+
+    _name.category_id             geom_contact
+    _name.object_id               atom_site_label_2
+
+    _import.get                   [{'file':templ_attr.cif  'save':atom_site_id}]
+
+save_
+
+save_geom_contact.distance
+
+    _definition.id                '_geom_contact.distance'
+
+    loop_
+      _alias.definition_id
+         '_geom_contact_distance'
+         '_geom_contact.dist'
+
+    _definition.update            2019-07-25
+    _description.text
+;
+    Intermolecular distance between the atomic sites identified
+    by _geom_contact.id
+;
+    _name.category_id             geom_contact
+    _name.object_id               distance
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   angstroms
+    _method.purpose               Evaluation
+    _method.expression
+;
+    With c as geom_contact
+
+    xc = List()
+
+    For [label,symop] in  [[c.atom_site_label_1,c.site_symmetry_1,
+                            c.atom_site_label_2,c.site_symmetry_2]] {
+
+        xf   =   SymEquiv(symop, _atom_site[label].fract_xyz)
+
+        xc ++=  _atom_sites_Cartn_transform.matrix * xf
+    }
+    _geom_contact.distance =  Norm ( xc[0] - xc[1] )
+;
+
+save_
+
+save_geom_contact.distance_su
+
+    _definition.id                '_geom_contact.distance_su'
+
+    loop_
+      _alias.definition_id
+         '_geom_contact_distance_su'
+         '_geom_contact.dist_esd'
+
+    _definition.update            2021-03-03
+    _description.text
+;
+    Standard uncertainty of _geom_contact.distance.
+;
+    _name.category_id             geom_contact
+    _name.object_id               distance_su
+    _name.linked_item_id          '_geom_contact.distance'
+    _units.code                   angstroms
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+save_
+
+save_geom_contact.id
+
+    _definition.id                '_geom_contact.id'
+    _definition.update            2023-02-02
+    _description.text
+;
+    An identifier for the contact that is unique within the loop.
+;
+    _name.category_id             geom_contact
+    _name.object_id               id
+    _type.purpose                 Key
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Word
+
+save_
+
+save_geom_contact.publ_flag
+
+    _definition.id                '_geom_contact.publ_flag'
+    _alias.definition_id          '_geom_contact_publ_flag'
+    _definition.update            2012-11-22
+    _description.text
+;
+    This code signals whether the contact distance is referred to
+    in a publication or should be placed in a list of significant
+    contact distances.
+;
+    _name.category_id             geom_contact
+    _name.object_id               publ_flag
+    _type.purpose                 State
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Text
+
+    loop_
+      _enumeration_set.state
+      _enumeration_set.detail
+         no                       'Do not include distance in special list.'
+         n                        'Abbreviation for "no".'
+         yes                      'Do include distance in special list.'
+         y                        'Abbreviation for "yes".'
+
+    _enumeration.default          no
+
+save_
+
+save_geom_contact.site_symmetry_1
+
+    _definition.id                '_geom_contact.site_symmetry_1'
+    _alias.definition_id          '_geom_contact_site_symmetry_1'
+    _name.category_id             geom_contact
+    _name.object_id               site_symmetry_1
+
+    _import.get
+        [{'file':templ_attr.cif  'save':site_symmetry}]
+
+save_
+
+save_geom_contact.site_symmetry_2
+
+    _definition.id                '_geom_contact.site_symmetry_2'
+    _alias.definition_id          '_geom_contact_site_symmetry_2'
+    _name.category_id             geom_contact
+    _name.object_id               site_symmetry_2
+
+    _import.get
+        [{'file':templ_attr.cif  'save':site_symmetry}]
+
+save_
+
+save_GEOM_HBOND
+
+    _definition.id                GEOM_HBOND
+    _definition.scope             Category
+    _definition.class             Loop
+    _definition.update            2021-06-29
+    _description.text
+;
+    The CATEGORY of data items used to specify the hydrogen bond
+    distances in the structural model as derived from atomic sites.
+;
+    _name.category_id             GEOM
+    _name.object_id               GEOM_HBOND
+
+    loop_
+      _category_key.name
+         '_geom_hbond.atom_site_label_D'
+         '_geom_hbond.atom_site_label_H'
+         '_geom_hbond.atom_site_label_A'
+         '_geom_hbond.site_symmetry_D'
+         '_geom_hbond.site_symmetry_H'
+         '_geom_hbond.site_symmetry_A'
+
+save_
+
+save_geom_hbond.angle_dha
+
+    _definition.id                '_geom_hbond.angle_DHA'
+    _alias.definition_id          '_geom_hbond_angle_DHA'
+    _definition.update            2020-03-13
+    _description.text
+;
+    Angle subtended by the sites identified by _geom_hbond.id.
+    The hydrogen at site H is at the apex of the angle.
+;
+    _name.category_id             geom_hbond
+    _name.object_id               angle_DHA
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:180.0
+    _units.code                   degrees
+    _method.purpose               Evaluation
+    _method.expression
+;
+    With a as geom_hbond
+
+    xc = List()
+
+    bundle = [[ a.atom_site_label_D, a.site_symmetry_D ],
+              [ a.atom_site_label_H, a.site_symmetry_H ],
+              [ a.atom_site_label_A, a.site_symmetry_A ]]
+    For [label,symop] in bundle   {
+
+        xf   =   SymEquiv(symop, _atom_site[label].fract_xyz)
+
+        xc ++=  _atom_sites_Cartn_transform.matrix * xf
+     }
+        v1,v2  =  xc[0]-xc[1], xc[2]-xc[1]
+
+    _geom_hbond.angle_DHA  =  Acosd ( v1 * v2 / ( Norm (v1) * Norm (v2) ) )
+;
+
+save_
+
+save_geom_hbond.angle_dha_su
+
+    _definition.id                '_geom_hbond.angle_DHA_su'
+
+    loop_
+      _alias.definition_id
+         '_geom_hbond_angle_DHA_su'
+         '_geom_hbond.angle_DHA_esd'
+
+    _definition.update            2021-03-03
+    _description.text
+;
+    Standard uncertainty of _geom_hbond.angle_DHA.
+;
+    _name.category_id             geom_hbond
+    _name.object_id               angle_DHA_su
+    _name.linked_item_id          '_geom_hbond.angle_DHA'
+    _units.code                   degrees
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+save_
+
+save_geom_hbond.atom_site_label_a
+
+    _definition.id                '_geom_hbond.atom_site_label_A'
+
+    loop_
+      _alias.definition_id
+         '_geom_hbond_atom_site_label_A'
+         '_geom_hbond.atom_site_id_A'
+
+    _name.category_id             geom_hbond
+    _name.object_id               atom_site_label_A
+
+    _import.get                   [{'file':templ_attr.cif  'save':atom_site_id}]
+
+save_
+
+save_geom_hbond.atom_site_label_d
+
+    _definition.id                '_geom_hbond.atom_site_label_D'
+
+    loop_
+      _alias.definition_id
+         '_geom_hbond_atom_site_label_D'
+         '_geom_hbond.atom_site_id_D'
+
+    _name.category_id             geom_hbond
+    _name.object_id               atom_site_label_D
+
+    _import.get                   [{'file':templ_attr.cif  'save':atom_site_id}]
+
+save_
+
+save_geom_hbond.atom_site_label_h
+
+    _definition.id                '_geom_hbond.atom_site_label_H'
+
+    loop_
+      _alias.definition_id
+         '_geom_hbond_atom_site_label_H'
+         '_geom_hbond.atom_site_id_H'
+
+    _name.category_id             geom_hbond
+    _name.object_id               atom_site_label_H
+
+    _import.get                   [{'file':templ_attr.cif  'save':atom_site_id}]
+
+save_
+
+save_geom_hbond.distance_da
+
+    _definition.id                '_geom_hbond.distance_DA'
+
+    loop_
+      _alias.definition_id
+         '_geom_hbond_distance_DA'
+         '_geom_hbond.dist_DA'
+
+    _definition.update            2012-12-14
+    _description.text
+;
+    The set of data items which specify the distance between the
+    three atom sites identified by _geom_hbond.id.
+;
+    _name.category_id             geom_hbond
+    _name.object_id               distance_DA
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   angstroms
+    _method.purpose               Evaluation
+    _method.expression
+;
+    with g as geom_hbond
+    l,s  =   g.atom_site_label_D, g.site_symmetry_D
+    d_pos =   SymEquiv(s, _atom_site[l].fract_xyz)
+    d_pos =  _atom_sites_Cartn_transform.matrix * d_pos
+    l,s  =   g.atom_site_label_A,g.site_symmetry_A
+    a_pos   =   SymEquiv(s, _atom_site[l].fract_xyz)
+    a_pos   = _atom_sites_Cartn_transform.matrix * a_pos
+    _geom_hbond.distance_DA =  Norm ( a_pos - d_pos )
+;
+
+save_
+
+save_geom_hbond.distance_da_su
+
+    _definition.id                '_geom_hbond.distance_DA_su'
+
+    loop_
+      _alias.definition_id
+         '_geom_hbond_distance_DA_su'
+         '_geom_hbond.dist_DA_esd'
+
+    _definition.update            2021-03-03
+    _description.text
+;
+    Standard uncertainty of _geom_hbond.distance_DA.
+;
+    _name.category_id             geom_hbond
+    _name.object_id               distance_DA_su
+    _name.linked_item_id          '_geom_hbond.distance_DA'
+    _units.code                   angstroms
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+save_
+
+save_geom_hbond.distance_dh
+
+    _definition.id                '_geom_hbond.distance_DH'
+
+    loop_
+      _alias.definition_id
+         '_geom_hbond_distance_DH'
+         '_geom_hbond.dist_DH'
+
+    _definition.update            2012-12-14
+    _description.text
+;
+    The set of data items which specify the distance between the
+    three atom sites identified by _geom_hbond.id.
+;
+    _name.category_id             geom_hbond
+    _name.object_id               distance_DH
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   angstroms
+    _method.purpose               Evaluation
+    _method.expression
+;
+    with g as geom_hbond
+    l,s  =   g.atom_site_label_D, g.site_symmetry_D
+    d_pos =   SymEquiv(s, _atom_site[l].fract_xyz)
+    d_pos =  _atom_sites_Cartn_transform.matrix * d_pos
+    l,s  =   g.atom_site_label_H,g.site_symmetry_H
+    h_pos   =   SymEquiv(s, _atom_site[l].fract_xyz)
+    h_pos   = _atom_sites_Cartn_transform.matrix * h_pos
+    _geom_hbond.distance_DH =  Norm ( h_pos - d_pos )
+;
+
+save_
+
+save_geom_hbond.distance_dh_su
+
+    _definition.id                '_geom_hbond.distance_DH_su'
+
+    loop_
+      _alias.definition_id
+         '_geom_hbond_distance_DH_su'
+         '_geom_hbond.dist_DH_esd'
+
+    _definition.update            2021-03-03
+    _description.text
+;
+    Standard uncertainty of _geom_hbond.distance_DH.
+;
+    _name.category_id             geom_hbond
+    _name.object_id               distance_DH_su
+    _name.linked_item_id          '_geom_hbond.distance_DH'
+    _units.code                   angstroms
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+save_
+
+save_geom_hbond.distance_ha
+
+    _definition.id                '_geom_hbond.distance_HA'
+
+    loop_
+      _alias.definition_id
+         '_geom_hbond_distance_HA'
+         '_geom_hbond.dist_HA'
+
+    _definition.update            2012-12-14
+    _description.text
+;
+    The set of data items which specify the distance between the
+    three atom sites identified by _geom_hbond.id.
+;
+    _name.category_id             geom_hbond
+    _name.object_id               distance_HA
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   angstroms
+    _method.purpose               Evaluation
+    _method.expression
+;
+    with g as geom_hbond
+    l,s  =   g.atom_site_label_A, g.site_symmetry_A
+    a_pos =   SymEquiv(s, _atom_site[l].fract_xyz)
+    a_pos =  _atom_sites_Cartn_transform.matrix * a_pos
+    l,s  =   g.atom_site_label_H,g.site_symmetry_H
+    h_pos   =   SymEquiv(s, _atom_site[l].fract_xyz)
+    h_pos   = _atom_sites_Cartn_transform.matrix * h_pos
+    _geom_hbond.distance_HA =  Norm ( h_pos - a_pos )
+;
+
+save_
+
+save_geom_hbond.distance_ha_su
+
+    _definition.id                '_geom_hbond.distance_HA_su'
+
+    loop_
+      _alias.definition_id
+         '_geom_hbond_distance_HA_su'
+         '_geom_hbond.dist_HA_esd'
+
+    _definition.update            2021-03-03
+    _description.text
+;
+    Standard uncertainty of _geom_hbond.distance_HA.
+;
+    _name.category_id             geom_hbond
+    _name.object_id               distance_HA_su
+    _name.linked_item_id          '_geom_hbond.distance_HA'
+    _units.code                   angstroms
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+save_
+
+save_geom_hbond.id
+
+    _definition.id                '_geom_hbond.id'
+    _definition.update            2023-02-02
+    _description.text
+;
+    An identifier for the hydrogen bond that is unique within the loop.
+;
+    _name.category_id             geom_hbond
+    _name.object_id               id
+    _type.purpose                 Key
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Word
+
+save_
+
+save_geom_hbond.publ_flag
+
+    _definition.id                '_geom_hbond.publ_flag'
+    _alias.definition_id          '_geom_hbond_publ_flag'
+    _definition.update            2012-11-22
+    _description.text
+;
+    This code signals whether the hydrogen-bond information
+    is referred to in a publication or should be placed in a
+    table of significant hydrogen-bond geometry.
+;
+    _name.category_id             geom_hbond
+    _name.object_id               publ_flag
+    _type.purpose                 State
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Text
+
+    loop_
+      _enumeration_set.state
+      _enumeration_set.detail
+         no                       'Do not include bond in special list.'
+         n                        'Abbreviation for "no".'
+         yes                      'Do include bond in special list.'
+         y                        'Abbreviation for "yes".'
+
+    _enumeration.default          no
+
+save_
+
+save_geom_hbond.site_symmetry_a
+
+    _definition.id                '_geom_hbond.site_symmetry_A'
+    _alias.definition_id          '_geom_hbond_site_symmetry_A'
+    _name.category_id             geom_hbond
+    _name.object_id               site_symmetry_A
+
+    _import.get
+        [{'file':templ_attr.cif  'save':site_symmetry}]
+
+save_
+
+save_geom_hbond.site_symmetry_d
+
+    _definition.id                '_geom_hbond.site_symmetry_D'
+    _alias.definition_id          '_geom_hbond_site_symmetry_D'
+    _name.category_id             geom_hbond
+    _name.object_id               site_symmetry_D
+
+    _import.get
+        [{'file':templ_attr.cif  'save':site_symmetry}]
+
+save_
+
+save_geom_hbond.site_symmetry_h
+
+    _definition.id                '_geom_hbond.site_symmetry_H'
+    _alias.definition_id          '_geom_hbond_site_symmetry_H'
+    _name.category_id             geom_hbond
+    _name.object_id               site_symmetry_H
+
+    _import.get
+        [{'file':templ_attr.cif  'save':site_symmetry}]
+
+save_
+
+save_GEOM_TORSION
+
+    _definition.id                GEOM_TORSION
+    _definition.scope             Category
+    _definition.class             Loop
+    _definition.update            2021-06-29
+    _description.text
+;
+    The CATEGORY of data items used to specify the torsion angles in the
+    structural model as derived from the atomic sites.
+;
+    _name.category_id             GEOM
+    _name.object_id               GEOM_TORSION
+
+    loop_
+      _category_key.name
+         '_geom_torsion.atom_site_label_1'
+         '_geom_torsion.atom_site_label_2'
+         '_geom_torsion.atom_site_label_3'
+         '_geom_torsion.atom_site_label_4'
+         '_geom_torsion.site_symmetry_1'
+         '_geom_torsion.site_symmetry_2'
+         '_geom_torsion.site_symmetry_3'
+         '_geom_torsion.site_symmetry_4'
+
+    _method.purpose               Evaluation
+    _method.expression
+;
+    dmin =  _geom.bond_distance_min
+
+    Loop  m1  as  model_site  :i  {
+
+       rad1  =   m1.radius_bond + _geom.bond_distance_incr
+
+       Loop  m2  as  model_site  :j  {
+
+          If (i==j or m2.mole_index!=m1.mole_index) Next
+          v21 =  m1.Cartn_xyz - m2.Cartn_xyz
+          d21 =  Norm (v21)
+
+          If (d21 < dmin or d21 > (rad1+m2.radius_bond)) Next
+          rad2  =   m2.radius_bond + _geom.bond_distance_incr
+
+          Loop  m3  as  model_site  :k  {
+
+             If (k==i or k==j or m3.mole_index!=m2.mole_index) Next
+             v23 =  m3.Cartn_xyz - m2.Cartn_xyz
+             d23 =  Norm (v23)
+
+             If (d23 < dmin or d23 > (rad2+m3.radius_bond)) Next
+             rad3  =   m3.radius_bond + _geom.bond_distance_incr
+
+             Loop  m4  as  model_site  :l  {
+
+                If (l==k or l==j or l==i or m4.mole_index!=m3.mole_index) Next
+                v34 =  m4.Cartn_xyz - m3.Cartn_xyz
+                d34 =  Norm (v34)
+
+                If (d34 < dmin or d34 > (rad3+m4.radius_bond)) Next
+
+                u1    =   v21 ^ v23
+                u2    =   v34 ^ v23
+
+                angle =  Acosd ( u1 * u2 / ( Norm(u1) * Norm(u2) ) )
+                If ( (u1^u2)*v23 < 0 ) angle = -angle
+
+                geom_torsion(
+                              .atom_site_label_1 = m1.label,
+                              .atom_site_label_2 = m2.label,
+                              .atom_site_label_3 = m3.label,
+                              .atom_site_label_4 = m4.label,
+                              .site_symmetry_1   = m1.symop,
+                              .site_symmetry_2   = m2.symop,
+                              .site_symmetry_3   = m3.symop,
+                              .site_symmetry_4   = m4.symop,
+                              .distances =  List ( d21,d23,d34 ),
+                              .angle     =  angle )
+    }   }   }    }
+;
+
+save_
+
+save_geom_torsion.angle
+
+    _definition.id                '_geom_torsion.angle'
+
+    loop_
+      _alias.definition_id
+         '_geom_torsion'
+         '_geom_torsion.value'
+
+    _definition.update            2019-07-25
+    _description.text
+;
+    Angle defined by the sites identified by _geom_torsion.id.
+    The torsion-angle definition should be that of Klyne and Prelog.
+    The vector direction *_label_2 to *_label_3 is the viewing
+    direction, and the torsion angle is the angle of twist required
+    to superimpose the projection of the vector between site 2 and
+    site 1 onto the projection of the vector between site 3 and
+    site 4. Clockwise torsions are positive, anticlockwise torsions
+    are negative.
+    Ref: Klyne, W. & Prelog, V. (1960). Experientia, 16, 521-523.
+;
+    _name.category_id             geom_torsion
+    _name.object_id               angle
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            -180.0:180.0
+    _units.code                   degrees
+
+save_
+
+save_geom_torsion.angle_su
+
+    _definition.id                '_geom_torsion.angle_su'
+
+    loop_
+      _alias.definition_id
+         '_geom_torsion_su'
+         '_geom_torsion.value_esd'
+
+    _definition.update            2021-03-03
+    _description.text
+;
+    Standard uncertainty of _geom_torsion.angle.
+;
+    _name.category_id             geom_torsion
+    _name.object_id               angle_su
+    _name.linked_item_id          '_geom_torsion.angle'
+    _units.code                   degrees
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+save_
+
+save_geom_torsion.atom_site_label_1
+
+    _definition.id                '_geom_torsion.atom_site_label_1'
+
+    loop_
+      _alias.definition_id
+         '_geom_torsion_atom_site_label_1'
+         '_geom_torsion.atom_site_id_1'
+
+    _name.category_id             geom_torsion
+    _name.object_id               atom_site_label_1
+
+    _import.get                   [{'file':templ_attr.cif  'save':atom_site_id}]
+
+save_
+
+save_geom_torsion.atom_site_label_2
+
+    _definition.id                '_geom_torsion.atom_site_label_2'
+
+    loop_
+      _alias.definition_id
+         '_geom_torsion_atom_site_label_2'
+         '_geom_torsion.atom_site_id_2'
+
+    _name.category_id             geom_torsion
+    _name.object_id               atom_site_label_2
+
+    _import.get                   [{'file':templ_attr.cif  'save':atom_site_id}]
+
+save_
+
+save_geom_torsion.atom_site_label_3
+
+    _definition.id                '_geom_torsion.atom_site_label_3'
+
+    loop_
+      _alias.definition_id
+         '_geom_torsion_atom_site_label_3'
+         '_geom_torsion.atom_site_id_3'
+
+    _name.category_id             geom_torsion
+    _name.object_id               atom_site_label_3
+
+    _import.get                   [{'file':templ_attr.cif  'save':atom_site_id}]
+
+save_
+
+save_geom_torsion.atom_site_label_4
+
+    _definition.id                '_geom_torsion.atom_site_label_4'
+
+    loop_
+      _alias.definition_id
+         '_geom_torsion_atom_site_label_4'
+         '_geom_torsion.atom_site_id_4'
+
+    _name.category_id             geom_torsion
+    _name.object_id               atom_site_label_4
+
+    _import.get                   [{'file':templ_attr.cif  'save':atom_site_id}]
+
+save_
+
+save_geom_torsion.distances
+
+    _definition.id                '_geom_torsion.distances'
+    _definition.update            2012-11-22
+    _description.text
+;
+    Distances between sites 1 - 2, 2 - 3 and 3 - 4.
+;
+    _name.category_id             geom_torsion
+    _name.object_id               distances
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               List
+    _type.dimension               '[3]'
+    _type.contents                Real
+    _units.code                   angstroms
+
+save_
+
+save_geom_torsion.distances_su
+
+    _definition.id                '_geom_torsion.distances_su'
+    _definition.update            2023-07-01
+    _description.text
+;
+    Standard uncertainty of _geom_torsion.distances.
+;
+    _name.category_id             geom_torsion
+    _name.object_id               distances_su
+    _name.linked_item_id          '_geom_torsion.distances'
+    _type.purpose                 SU
+    _type.source                  Related
+    _type.container               List
+    _type.dimension               '[3]'
+    _type.contents                Real
+    _units.code                   angstroms
+
+save_
+
+save_geom_torsion.id
+
+    _definition.id                '_geom_torsion.id'
+    _definition.update            2023-02-02
+    _description.text
+;
+    An identifier for the torsion angle that is unique within its loop.
+;
+    _name.category_id             geom_torsion
+    _name.object_id               id
+    _type.purpose                 Key
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Word
+
+save_
+
+save_geom_torsion.publ_flag
+
+    _definition.id                '_geom_torsion.publ_flag'
+    _alias.definition_id          '_geom_torsion_publ_flag'
+    _definition.update            2012-11-22
+    _description.text
+;
+    Code signals if the torsion angle is required for publication.
+;
+    _name.category_id             geom_torsion
+    _name.object_id               publ_flag
+    _type.purpose                 State
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Text
+
+    loop_
+      _enumeration_set.state
+      _enumeration_set.detail
+         yes                      'Publish.'
+         y                        'Abbreviation for "yes".'
+         no                       'Do not publish.'
+         n                        'Abbreviation for "no".'
+
+    _enumeration.default          no
+
+save_
+
+save_geom_torsion.site_symmetry_1
+
+    _definition.id                '_geom_torsion.site_symmetry_1'
+    _alias.definition_id          '_geom_torsion_site_symmetry_1'
+    _name.category_id             geom_torsion
+    _name.object_id               site_symmetry_1
+
+    _import.get
+        [{'file':templ_attr.cif  'save':site_symmetry}]
+
+save_
+
+save_geom_torsion.site_symmetry_2
+
+    _definition.id                '_geom_torsion.site_symmetry_2'
+    _alias.definition_id          '_geom_torsion_site_symmetry_2'
+    _name.category_id             geom_torsion
+    _name.object_id               site_symmetry_2
+
+    _import.get
+        [{'file':templ_attr.cif  'save':site_symmetry}]
+
+save_
+
+save_geom_torsion.site_symmetry_3
+
+    _definition.id                '_geom_torsion.site_symmetry_3'
+    _alias.definition_id          '_geom_torsion_site_symmetry_3'
+    _name.category_id             geom_torsion
+    _name.object_id               site_symmetry_3
+
+    _import.get
+        [{'file':templ_attr.cif  'save':site_symmetry}]
+
+save_
+
+save_geom_torsion.site_symmetry_4
+
+    _definition.id                '_geom_torsion.site_symmetry_4'
+    _alias.definition_id          '_geom_torsion_site_symmetry_4'
+    _name.category_id             geom_torsion
+    _name.object_id               site_symmetry_4
+
+    _import.get
+        [{'file':templ_attr.cif  'save':site_symmetry}]
+
+save_
+
+save_MODEL_SITE
+
+    _definition.id                MODEL_SITE
+    _definition.scope             Category
+    _definition.class             Loop
+    _definition.update            2021-06-29
+    _description.text
+;
+    The CATEGORY of data items used to describe atomic sites and
+    connections in the proposed atomic model.
+;
+    _name.category_id             MODEL
+    _name.object_id               MODEL_SITE
+
+    loop_
+      _category_key.name
+         '_model_site.label'
+         '_model_site.symop'
+
+    _method.purpose               Evaluation
+    _method.expression
+;
+    atomlist  = List()
+    Loop  a  as  atom_site  {
+       axyz       =    a.fract_xyz
+       cxyz       =   _atom_sites_Cartn_transform.matrix * axyz
+       radb       =   _atom_type[a.type_symbol].radius_bond
+       radc       =   _atom_type[a.type_symbol].radius_contact
+       ls         =   List ( a.label, "1_555" )
+       atomlist ++=   [ls, axyz, cxyz, radb, radc, 0]
+    }
+
+    molelist  = List()
+    dmin     =  _geom.bond_distance_min
+    m        =  0
+    n        =  0
+
+    For [ls1,a1,c1,rb1,rc1,m1] in atomlist  {
+        If (m1 != 0) Next
+        m         +=  1
+        n         +=  1
+        molelist ++=  [ls1,a1,c1,rb1,rc1,n,m]
+        atomlist --=  [ls1,a1,c1,rb1,rc1,m]
+
+        Repeat  {
+            connect =  "no"
+
+            For [ls2,a2,c2,rb2,rc2,n2,m2] in molelist  {
+                If (m2 != m) Next
+
+                For [ls3,a3,c3,rb3,rc3,m3] in atomlist  {
+                    dmax  =  rb2 + rb3 + _geom.bond_distance_incr
+
+                    Loop  s  as  space_group_symop  :ns   {
+
+                        axyz      =   s.R * a3 + s.T
+                        tran      =   Closest (axyz, a2)
+                        bxyz      =   axyz + tran
+                        cxyz      =  _atom_sites_Cartn_transform.matrix *bxyz
+                        d         =   Norm (cxyz - c2)
+
+                       If (d > dmin and d < dmax)          {
+                           ls  =   List ( ls3[0], Symop(ns+1, tran) )
+
+                           If (ls not in Strip(molelist,0))    {
+                               n         +=  1
+                               molelist ++=  [ls,bxyz,cxyz,rb3,rc3,n,m]
+                               atomlist --=  [ls3,a3,c3,rb3,rc3,m]
+                               connect    =  "yes"
+        }   }   }   }   }
+       If (connect == "no") Break
+    }  }
+
+    For [ls,ax,cx,rb,rc,n,m] in molelist  {
+
+       model_site( .label              =  ls[0],
+                   .symop           =  ls[1],
+                   .fract_xyz       =  ax,
+                   .Cartn_xyz       =  cx,
+                   .radius_bond     =  rb,
+                   .radius_contact  =  rc,
+                   .index           =  n,
+                   .mole_index      =  m  )
+     }
+;
+
+save_
+
+save_model_site.adp_eigenvalues
+
+    _definition.id                '_model_site.ADP_eigenvalues'
+    _definition.update            2021-09-24
+    _description.text
+;
+    The set of three ADP eigenvalues for the associated eigenvectors
+    given by _model_site.ADP_eigenvectors. The eigenvalues are
+    sorted in order of magnitude with the largest first.
+;
+    _name.category_id             model_site
+    _name.object_id               ADP_eigenvalues
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               Array
+    _type.dimension               '[3]'
+    _type.contents                Real
+    _units.code                   none
+    _method.purpose               Evaluation
+    _method.expression
+;
+    A    =  _cell.orthogonal_matrix
+    U    =  A * _model_site.ADP_matrix_beta * Transpose(A) /(2*Pi**2)
+    _model_site.ADP_eigenvalues  =  Eigen( U )[:,0]
+;
+
+save_
+
+save_model_site.adp_eigenvalues_su
+
+    _definition.id                '_model_site.ADP_eigenvalues_su'
+    _definition.update            2023-07-01
+    _description.text
+;
+    Standard uncertainty of _model_site.ADP_eigenvalues.
+;
+    _name.category_id             model_site
+    _name.object_id               ADP_eigenvalues_su
+    _name.linked_item_id          '_model_site.ADP_eigenvalues'
+    _type.purpose                 SU
+    _type.source                  Related
+    _type.container               Array
+    _type.dimension               '[3]'
+    _type.contents                Real
+    _units.code                   none
+
+save_
+
+save_model_site.adp_eigenvectors
+
+    _definition.id                '_model_site.ADP_eigenvectors'
+    _definition.update            2021-09-24
+    _description.text
+;
+    The set of three ADP eigenvectors corresponding to the values
+    given in _model_site.ADP_eigenvalues. The eigenvectors are
+    contained in the rows of a matrix ordered from top to bottom
+    in order largest to smallest corresponding eigenvalue. The
+    eigenvector elements are direction cosines to the orthogonal
+    axes X,Y,Z.
+;
+    _name.category_id             model_site
+    _name.object_id               ADP_eigenvectors
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               Array
+    _type.dimension               '[3,3]'
+    _type.contents                Real
+    _units.code                   angstrom_squared
+    _method.purpose               Evaluation
+    _method.expression
+;
+    A    =  _cell.orthogonal_matrix
+    U    =  A * _model_site.ADP_matrix_beta * Transpose(A) /(2*Pi**2)
+    _model_site.ADP_eigenvectors  =  Eigen( U )[:,1:4]
+;
+
+save_
+
+save_model_site.adp_eigenvectors_su
+
+    _definition.id                '_model_site.ADP_eigenvectors_su'
+    _definition.update            2023-07-01
+    _description.text
+;
+    Standard uncertainty of _model_site.ADP_eigenvectors.
+;
+    _name.category_id             model_site
+    _name.object_id               ADP_eigenvectors_su
+    _name.linked_item_id          '_model_site.ADP_eigenvectors'
+    _type.purpose                 SU
+    _type.source                  Related
+    _type.container               Array
+    _type.dimension               '[3,3]'
+    _type.contents                Real
+    _units.code                   angstrom_squared
+
+save_
+
+save_model_site.adp_matrix_beta
+
+    _definition.id                '_model_site.ADP_matrix_beta'
+    _definition.update            2021-09-24
+    _description.text
+;
+    Matrix of dimensionless anisotropic atomic displacement parameters.
+;
+    _name.category_id             model_site
+    _name.object_id               ADP_matrix_beta
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               Matrix
+    _type.dimension               '[3,3]'
+    _type.contents                Real
+    _units.code                   none
+    _method.purpose               Evaluation
+    _method.expression
+;
+    with m as model_site
+    a = atom_site[m.label]
+    s = space_group_symop[SymKey(m.symop)]
+
+    _model_site.ADP_matrix_beta =  s.R * a.matrix_beta * s.RT
+;
+
+save_
+
+save_model_site.adp_matrix_beta_su
+
+    _definition.id                '_model_site.ADP_matrix_beta_su'
+    _definition.update            2023-07-01
+    _description.text
+;
+    Standard uncertainty of _model_site.ADP_matrix_beta.
+;
+    _name.category_id             model_site
+    _name.object_id               ADP_matrix_beta_su
+    _name.linked_item_id          '_model_site.ADP_matrix_beta'
+    _type.purpose                 SU
+    _type.source                  Related
+    _type.container               Matrix
+    _type.dimension               '[3,3]'
+    _type.contents                Real
+    _units.code                   none
+
+save_
+
+save_model_site.cartn_xyz
+
+    _definition.id                '_model_site.Cartn_xyz'
+    _definition.update            2021-07-07
+    _description.text
+;
+    Vector of Cartesian (orthogonal angstrom) atom site coordinates.
+;
+    _name.category_id             model_site
+    _name.object_id               Cartn_xyz
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               Matrix
+    _type.dimension               '[3]'
+    _type.contents                Real
+    _units.code                   angstroms
+    _method.purpose               Evaluation
+    _method.expression
+;
+     With  m  as  model_site
+
+    _model_site.Cartn_xyz =  _atom_sites_Cartn_transform.matrix * m.fract_xyz
+;
+
+save_
+
+save_model_site.cartn_xyz_su
+
+    _definition.id                '_model_site.Cartn_xyz_su'
+    _definition.update            2023-07-01
+    _description.text
+;
+    Standard uncertainty of _model_site.Cartn_xyz.
+;
+    _name.category_id             model_site
+    _name.object_id               Cartn_xyz_su
+    _name.linked_item_id          '_model_site.Cartn_xyz'
+    _type.purpose                 SU
+    _type.source                  Related
+    _type.container               Matrix
+    _type.dimension               '[3]'
+    _type.contents                Real
+    _units.code                   angstroms
+
+save_
+
+save_model_site.display_colour
+
+    _definition.id                '_model_site.display_colour'
+    _definition.update            2023-02-06
+    _description.text
+;
+    Display colour code assigned to this atom site. Note that the
+    possible colours are enumerated in the colour_RGB list, and
+    the default code is enumerated in the colour_hue list.
+;
+    _name.category_id             model_site
+    _name.object_id               display_colour
+    _type.purpose                 State
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Word
+    _enumeration.def_index_id     '_model_site.type_symbol'
+
+    _import.get                   [
+                                   {'file':templ_enum.cif  'save':colour_rgb}
+                                   {'file':templ_enum.cif  'save':colour_hue}
+                                  ]
+
+save_
+
+save_model_site.fract_xyz
+
+    _definition.id                '_model_site.fract_xyz'
+    _definition.update            2021-03-01
+    _description.text
+;
+    Vector of fractional atom site coordinates.
+;
+    _name.category_id             model_site
+    _name.object_id               fract_xyz
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               Matrix
+    _type.dimension               '[3]'
+    _type.contents                Real
+    _units.code                   none
+    _method.purpose               Evaluation
+    _method.expression
+;
+        With  m  as  model_site
+
+                      xyz =  _atom_site[m.label].fract_xyz
+
+    _model_site.fract_xyz =  SymEquiv(m.symop, xyz)
+;
+
+save_
+
+save_model_site.fract_xyz_su
+
+    _definition.id                '_model_site.fract_xyz_su'
+    _definition.update            2023-07-01
+    _description.text
+;
+    Standard uncertainty of _model_site.fract_xyz.
+;
+    _name.category_id             model_site
+    _name.object_id               fract_xyz_su
+    _name.linked_item_id          '_model_site.fract_xyz'
+    _type.purpose                 SU
+    _type.source                  Related
+    _type.container               Matrix
+    _type.dimension               '[3]'
+    _type.contents                Real
+    _units.code                   none
+
+save_
+
+save_model_site.id
+
+    _definition.id                '_model_site.id'
+    _definition.update            2023-02-02
+    _description.text
+;
+    An identifier for the model site that is unique within its loop.
+;
+    _name.category_id             model_site
+    _name.object_id               id
+    _type.purpose                 Key
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Word
+
+save_
+
+save_model_site.index
+
+    _definition.id                '_model_site.index'
+    _definition.update            2021-03-01
+    _description.text
+;
+    Index number of an atomic site in the connected molecule.
+;
+    _name.category_id             model_site
+    _name.object_id               index
+    _type.purpose                 Number
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Integer
+    _enumeration.range            1:
+    _units.code                   none
+
+save_
+
+save_model_site.label
+
+    _definition.id                '_model_site.label'
+    _definition.update            2012-11-22
+    _description.text
+;
+    Code identifies a site in the ATOM_SITE category of data.
+;
+    _name.category_id             model_site
+    _name.object_id               label
+    _name.linked_item_id          '_atom_site.label'
+    _type.purpose                 Link
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Word
+
+save_
+
+save_model_site.mole_index
+
+    _definition.id                '_model_site.mole_index'
+    _definition.update            2023-01-13
+    _description.text
+;
+    Index number of distinct molecules in the cell, not related by symmetry.
+;
+    _name.category_id             model_site
+    _name.object_id               mole_index
+    _type.purpose                 Number
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Integer
+    _enumeration.range            1:
+    _units.code                   none
+
+save_
+
+save_model_site.radius_bond
+
+    _definition.id                '_model_site.radius_bond'
+    _definition.update            2012-11-22
+    _description.text
+;
+    Atomic radius of atom located at this site.
+;
+    _name.category_id             model_site
+    _name.object_id               radius_bond
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.1:
+    _units.code                   angstroms
+    _method.purpose               Evaluation
+    _method.expression
+;
+     With  m  as  model_site
+
+    _model_site.radius_bond =  _atom_type[m.type_symbol].radius_bond
+;
+
+save_
+
+save_model_site.radius_contact
+
+    _definition.id                '_model_site.radius_contact'
+    _definition.update            2012-11-22
+    _description.text
+;
+    Atomic contact radius of atom specie located at this site.
+;
+    _name.category_id             model_site
+    _name.object_id               radius_contact
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            1.0:
+    _units.code                   angstroms
+    _method.purpose               Evaluation
+    _method.expression
+;
+     With  m  as  model_site
+
+    _model_site.radius_contact =  _atom_type[m.type_symbol].radius_contact
+;
+
+save_
+
+save_model_site.symop
+
+    _definition.id                '_model_site.symop'
+    _name.category_id             model_site
+    _name.object_id               symop
+
+    _import.get
+        [{'file':templ_attr.cif  'save':site_symmetry}]
+
+save_
+
+save_model_site.type_symbol
+
+    _definition.id                '_model_site.type_symbol'
+    _definition.update            2021-10-27
+    _description.text
+;
+    Code to identify the atom specie(s) occupying this site.
+;
+    _name.category_id             model_site
+    _name.object_id               type_symbol
+    _name.linked_item_id          '_atom_type.symbol'
+    _type.purpose                 Link
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Word
+    _method.purpose               Evaluation
+    _method.expression
+;
+    _model_site.type_symbol  =   AtomType ( _model_site.label )
+;
+
+save_
+
+save_VALENCE
+
+    _definition.id                VALENCE
+    _definition.scope             Category
+    _definition.class             Set
+    _definition.update            2012-12-13
+    _description.text
+;
+    The CATEGORY of items used to specify bond valence parameters
+    used to calculate bond valences from bond lengths.
+;
+    _name.category_id             MODEL
+    _name.object_id               VALENCE
+
+save_
+
+save_VALENCE_PARAM
+
+    _definition.id                VALENCE_PARAM
+    _definition.scope             Category
+    _definition.class             Loop
+    _definition.update            2021-06-29
+    _description.text
+;
+    The CATEGORY of items for listing bond valences.
+;
+    _name.category_id             VALENCE
+    _name.object_id               VALENCE_PARAM
+    _category_key.name            '_valence_param.id'
+
+save_
+
+save_valence_param.atom_1
+
+    _definition.id                '_valence_param.atom_1'
+    _alias.definition_id          '_valence_param_atom_1'
+    _definition.update            2021-10-27
+    _description.text
+;
+    Atom type symbol for atom 1 forming a bond whose
+    valence parameters are given in this category.
+;
+    _name.category_id             valence_param
+    _name.object_id               atom_1
+    _name.linked_item_id          '_atom_type.symbol'
+    _type.purpose                 Link
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Word
+
+save_
+
+save_valence_param.atom_1_valence
+
+    _definition.id                '_valence_param.atom_1_valence'
+    _alias.definition_id          '_valence_param_atom_1_valence'
+    _definition.update            2021-03-01
+    _description.text
+;
+    The formal charge of the atom 1 whose bond
+    valence parameters are given in this category.
+;
+    _name.category_id             valence_param
+    _name.object_id               atom_1_valence
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   none
+
+save_
+
+save_valence_param.atom_2
+
+    _definition.id                '_valence_param.atom_2'
+    _alias.definition_id          '_valence_param_atom_2'
+    _definition.update            2021-10-27
+    _description.text
+;
+    Atom type symbol for atom 2 forming a bond whose
+    valence parameters are given in this category.
+;
+    _name.category_id             valence_param
+    _name.object_id               atom_2
+    _name.linked_item_id          '_atom_type.symbol'
+    _type.purpose                 Link
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Word
+
+save_
+
+save_valence_param.atom_2_valence
+
+    _definition.id                '_valence_param.atom_2_valence'
+    _alias.definition_id          '_valence_param_atom_2_valence'
+    _definition.update            2021-03-01
+    _description.text
+;
+    The formal charge of the atom 2 whose bond
+    valence parameters are given in this category.
+;
+    _name.category_id             valence_param
+    _name.object_id               atom_2_valence
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   none
+
+save_
+
+save_valence_param.b
+
+    _definition.id                '_valence_param.B'
+    _alias.definition_id          '_valence_param_B'
+    _definition.update            2012-12-13
+    _description.text
+;
+    The bond valence parameter B used in the expression
+    s = exp[(Ro - R)/B] where s is the valence of bond length R.
+;
+    _name.category_id             valence_param
+    _name.object_id               B
+    _type.purpose                 Number
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.1:
+    _units.code                   angstroms
+
+save_
+
+save_valence_param.details
+
+    _definition.id                '_valence_param.details'
+    _alias.definition_id          '_valence_param_details'
+    _definition.update            2012-12-13
+    _description.text
+;
+    Details of valence parameters of stated bond.
+;
+    _name.category_id             valence_param
+    _name.object_id               details
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_valence_param.id
+
+    _definition.id                '_valence_param.id'
+    _alias.definition_id          '_valence_param_id'
+    _definition.update            2021-03-01
+    _description.text
+;
+    Unique index loop number of the valence parameter loop.
+;
+    _name.category_id             valence_param
+    _name.object_id               id
+    _type.purpose                 Number
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Integer
+    _enumeration.range            1:
+    _units.code                   none
+
+save_
+
+save_valence_param.ref_id
+
+    _definition.id                '_valence_param.ref_id'
+    _alias.definition_id          '_valence_param_ref_id'
+    _definition.update            2021-10-27
+    _description.text
+;
+    Code linking parameters to the key _valence_ref.id key
+    in the reference list in category VALENCE_REF.
+;
+    _name.category_id             valence_param
+    _name.object_id               ref_id
+    _name.linked_item_id          '_valence_ref.id'
+    _type.purpose                 Link
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Word
+
+save_
+
+save_valence_param.ro
+
+    _definition.id                '_valence_param.Ro'
+    _alias.definition_id          '_valence_param_Ro'
+    _definition.update            2012-12-13
+    _description.text
+;
+    The bond valence parameter Ro used in the expression
+    s = exp[(Ro - R)/B] where s is the valence of bond length R.
+;
+    _name.category_id             valence_param
+    _name.object_id               Ro
+    _type.purpose                 Number
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            1.0:
+    _units.code                   angstroms
+
+save_
+
+save_VALENCE_REF
+
+    _definition.id                VALENCE_REF
+    _definition.scope             Category
+    _definition.class             Loop
+    _definition.update            2021-06-29
+    _description.text
+;
+    The CATEGORY of items for listing valence references.
+;
+    _name.category_id             VALENCE
+    _name.object_id               VALENCE_REF
+    _category_key.name            '_valence_ref.id'
+
+save_
+
+save_valence_ref.id
+
+    _definition.id                '_valence_ref.id'
+    _alias.definition_id          '_valence_ref_id'
+    _definition.update            2023-09-12
+    _description.text
+;
+    Unique loop code of the valence references.
+;
+    _name.category_id             valence_ref
+    _name.object_id               id
+    _type.purpose                 Key
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Word
+
+save_
+
+save_valence_ref.reference
+
+    _definition.id                '_valence_ref.reference'
+    _alias.definition_id          '_valence_ref_reference'
+    _definition.update            2021-03-03
+    _description.text
+;
+    Literature reference from which the valence parameters
+    identified by _valence_param.id were taken.
+;
+    _name.category_id             valence_ref
+    _name.object_id               reference
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_PUBLICATION
+
+    _definition.id                PUBLICATION
+    _definition.scope             Category
+    _definition.class             Set
+    _definition.update            2024-05-15
+    _description.text
+;
+    The DICTIONARY group encompassing the CORE PUBLICATION data items defined
+    and used within the Crystallographic Information Framework (CIF).
+;
+    _name.category_id             CIF_CORE_HEAD
+    _name.object_id               PUBLICATION
+
+save_
+
+save_AUDIT
+
+    _definition.id                AUDIT
+    _definition.scope             Category
+    _definition.class             Set
+    _definition.update            2012-05-07
+    _description.text
+;
+    The CATEGORY of data items used to record details about the
+    creation and subsequent updating of the data block.
+;
+    _name.category_id             PUBLICATION
+    _name.object_id               AUDIT
+
+save_
+
+save_audit.block_code
+
+    _definition.id                '_audit.block_code'
+
+    loop_
+      _alias.definition_id
+         '_audit_block_code'
+         '_audit.revision_id'
+
+    _definition.update            2019-01-09
+    _description.text
+;
+    A unique block code identifier for each revision.
+;
+    _name.category_id             audit
+    _name.object_id               block_code
+    _type.purpose                 Encode
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Word
+    _description_example.case     TOZ_1991-03-20
+
+save_
+
+save_audit.block_doi
+
+    _definition.id                '_audit.block_DOI'
+    _alias.definition_id          '_audit_block_DOI'
+    _definition.update            2023-02-02
+    _description.text
+;
+    The digital object identifier (DOI) registered to identify
+    the data set publication represented by the current
+    data block. This can be used as a unique identifier for
+    the data block so long as the code used is a valid DOI
+    (i.e. begins with a valid publisher prefix assigned by a
+    Registration Agency and a suffix guaranteed to be unique
+    by the publisher) and has had its metadata deposited
+    with a DOI Registration Agency.
+
+    A DOI is a unique character string identifying any
+    object of intellectual property. It provides a
+    persistent identifier for an object on a digital network
+    and permits the association of related current data in a
+    structured extensible way. A DOI is an implementation
+    of the Internet concepts of Uniform Resource Name and
+    Universal Resource Locator managed according to the
+    specifications of the International DOI Foundation
+    (see https://www.doi.org/).
+;
+    _name.category_id             audit
+    _name.object_id               block_DOI
+    _type.purpose                 Encode
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Text
+    _description_example.case     10.5517/CC6V9DQ
+
+save_
+
+save_audit.creation_date
+
+    _definition.id                '_audit.creation_date'
+    _alias.definition_id          '_audit_creation_date'
+    _definition.update            2019-03-26
+    _description.text
+;
+    The timestamp of the data revision.
+;
+    _name.category_id             audit
+    _name.object_id               creation_date
+    _type.purpose                 Encode
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                DateTime
+
+    loop_
+      _description_example.case
+         1991-03-20
+         2019-03-26T10:33:06Z
+         2019-03-26T18:33:06.42-08:00
+
+save_
+
+save_audit.creation_method
+
+    _definition.id                '_audit.creation_method'
+    _alias.definition_id          '_audit_creation_method'
+    _definition.update            2012-11-29
+    _description.text
+;
+    A description of how the revision was applied to the data.
+;
+    _name.category_id             audit
+    _name.object_id               creation_method
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+    _description_example.case     'spawned by the program QBEE'
+
+save_
+
+save_audit.schema
+
+    _definition.id                '_audit.schema'
+    _definition.update            2021-08-18
+    _description.text
+;
+    This data item identifies the type of information contained in the
+    data block. Software written for one schema will not, in general,
+    correctly interpret datafiles written against a different schema.
+
+    Specifically, each value of _audit.schema corresponds to a list
+    of categories that were (potentially implicitly) restricted to a
+    single packet in the default Base schema, but which can contain
+    multiple packets in the specified schema.  All categories
+    containing child keys of the listed categories may also contain
+    multiple packets and do not need to be listed.
+
+    The category list for each schema may instead be determined from
+    examination of the dictionaries that this data block conforms to
+    (see _audit_conform.dict_name).
+;
+    _name.category_id             audit
+    _name.object_id               schema
+    _type.purpose                 State
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Text
+
+    loop_
+      _enumeration_set.state
+      _enumeration_set.detail
+         'Base'
+;
+         Original Core CIF schema.
+;
+         'Space group tables'
+;
+         space_group category is looped.
+;
+         'Entry'
+;
+         Entry category is defined and looped: information from multiple data
+         blocks in one block.
+;
+         'Custom'
+;
+         Examine dictionaries listed using data items from the AUDIT_CONFORM
+         category.
+;
+         'Local'
+;
+         Locally modified dictionaries. These datafiles should not be
+         distributed.
+;
+
+    _enumeration.default          Base
+
+save_
+
+save_audit.update_record
+
+    _definition.id                '_audit.update_record'
+    _alias.definition_id          '_audit_update_record'
+    _definition.update            2021-08-18
+    _description.text
+;
+    A description of the revision applied to the data.
+;
+    _name.category_id             audit
+    _name.object_id               update_record
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+    _description_example.case     'Updated by coeditor'
+
+save_
+
+save_AUDIT_AUTHOR
+
+    _definition.id                AUDIT_AUTHOR
+    _definition.scope             Category
+    _definition.class             Loop
+    _definition.update            2021-06-29
+    _description.text
+;
+    The CATEGORY of data items used for author(s) details.
+;
+    _name.category_id             AUDIT
+    _name.object_id               AUDIT_AUTHOR
+    _category_key.name            '_audit_author.id'
+
+save_
+
+save_audit_author.address
+
+    _definition.id                '_audit_author.address'
+    _alias.definition_id          '_audit_author_address'
+    _definition.update            2019-01-09
+    _description.text
+;
+    The address of an author of this data block. If there are
+    multiple authors, _audit_author.address is looped with
+    _audit_author.name.
+;
+    _name.category_id             audit_author
+    _name.object_id               address
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+    _description_example.case
+;
+    Department
+    Institute
+    Street
+    City and postcode
+    COUNTRY
+;
+
+save_
+
+save_audit_author.email
+
+    _definition.id                '_audit_author.email'
+    _definition.update            2023-06-02
+    _description.text
+;
+    The electronic mail address of an author of the data block, in a form
+    recognizable to international networks. The format of e-mail addresses is
+    given in Section 3.4, Address Specification, of Internet Message Format,
+    RFC 2822, P. Resnick (Editor), Network Standards Group, April 2001.
+;
+    _name.category_id             audit_author
+    _name.object_id               email
+    _type.purpose                 Encode
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+
+    loop_
+      _description_example.case
+         name@host.domain.country
+         bm@iucr.org
+
+save_
+
+save_audit_author.fax
+
+    _definition.id                '_audit_author.fax'
+    _definition.update            2023-06-02
+    _description.text
+;
+    Facsimile telephone number of an author of the data block.
+    The recommended style is the international dialing prefix, followed
+    by the area code in parentheses, followed by the local number with
+    no spaces. The earlier convention of including the international
+    dialing prefix in parentheses is no longer recommended.
+;
+    _name.category_id             audit_author
+    _name.object_id               fax
+    _type.purpose                 Encode
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+
+    loop_
+      _description_example.case
+         12(34)9477334
+         12()349477334
+
+save_
+
+save_audit_author.id
+
+    _definition.id                '_audit_author.id'
+    _definition.update            2023-02-02
+    _description.text
+;
+    Arbitrary identifier for this author.
+;
+    _name.category_id             audit_author
+    _name.object_id               id
+    _type.purpose                 Key
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Word
+    _method.purpose               Definition
+    _method.expression
+;
+    _enumeration.default = Unique_id(audit_author.id)
+;
+
+save_
+
+save_audit_author.id_orcid
+
+    _definition.id                '_audit_author.id_ORCID'
+    _definition.update            2023-02-02
+    _description.text
+;
+    Identifier in the ORCID Registry of a publication
+    author. ORCID is an open, non-profit, community-driven
+    service to provide a registry of unique researcher
+    identifiers (https://orcid.org/).
+;
+    _name.category_id             audit_author
+    _name.object_id               id_ORCID
+    _type.purpose                 Encode
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Code
+    _description_example.case     0000-0003-0391-0002
+
+save_
+
+save_audit_author.name
+
+    _definition.id                '_audit_author.name'
+    _alias.definition_id          '_audit_author_name'
+    _definition.update            2023-01-10
+    _description.text
+;
+    The name of an author of this data block. If there are multiple
+    authors, _audit_author.name is looped with _audit_author.address.
+    The family name(s), followed by a comma and including any
+    dynastic components, precedes the first name(s) or initial(s).
+    For authors with only one name, provide the full name without
+    abbreviation.
+;
+    _name.category_id             audit_author
+    _name.object_id               name
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+
+    loop_
+      _description_example.case
+         "Bleary, Percival R."
+         "O'Neil, F.K."
+         "Van den Bossche, G."
+         "Yang, D.-L."
+         "Simonov, Yu.A."
+         "Müller, H.A."
+         "Ross II, C.R."
+         "Chandra"
+
+save_
+
+save_audit_author.phone
+
+    _definition.id                '_audit_author.phone'
+    _definition.update            2023-06-02
+    _description.text
+;
+    Telephone number of an author of the data block.
+    The recommended style is the international dialing prefix,
+    followed by the area code in parentheses, followed by the
+    local number and any extension number prefixed by 'x', with
+    no spaces. The earlier convention of including the international
+    dialing prefix in parentheses is no longer recommended.
+;
+    _name.category_id             audit_author
+    _name.object_id               phone
+    _type.purpose                 Encode
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+
+    loop_
+      _description_example.case
+         12(34)9477330
+         12()349477330
+         12(34)9477330x5543
+
+save_
+
+save_AUDIT_AUTHOR_ROLE
+
+    _definition.id                AUDIT_AUTHOR_ROLE
+    _definition.scope             Category
+    _definition.class             Loop
+    _definition.update            2020-08-06
+    _description.text
+;
+    The CATEGORY of data items used to describe the role that
+    authors took in the production of the dataset.
+;
+    _name.category_id             AUDIT
+    _name.object_id               AUDIT_AUTHOR_ROLE
+
+    loop_
+      _category_key.name
+         '_audit_author_role.id'
+         '_audit_author_role.role'
+
+save_
+
+save_audit_author_role.id
+
+    _definition.id                '_audit_author_role.id'
+    _definition.update            2023-02-02
+    _description.text
+;
+    Unique identifier for the author for whom a role is identified.
+    This may be repeated where an author took on multiple roles.
+    The identifier for the author is drawn from the list of authors
+    given in the AUDIT_AUTHOR category.
+;
+    _name.category_id             audit_author_role
+    _name.object_id               id
+    _name.linked_item_id          '_audit_author.id'
+    _type.purpose                 Link
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Word
+
+save_
+
+save_audit_author_role.role
+
+    _definition.id                '_audit_author_role.role'
+    _definition.update            2023-01-13
+    _description.text
+;
+    The role taken by the author identified by _audit_author_role.id,
+    drawn from a predefined list. Additional details can be provided
+    in _audit_author_role.special_details
+;
+    _name.category_id             audit_author_role
+    _name.object_id               role
+    _type.purpose                 State
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Text
+
+    loop_
+      _enumeration_set.state
+      _enumeration_set.detail
+         design
+;
+         Conceived and/or designed the experiment.
+;
+         synthesis
+;
+         Synthesized the samples.
+;
+         preparation
+;
+         Prepared the samples for measurement, e.g. crystallized or
+         recrystallized the sample.
+;
+         characterisation
+;
+         Performed non-crystallographic measurements on the samples.
+;
+         measurement
+;
+         Collected and/or reduced diffraction data.
+;
+         analysis
+;
+         Obtained fitted parameters, such as a structural model, from the data.
+;
+         software
+;
+         Developed bespoke software for specialised data processing and/or
+         analysis.
+;
+         submission
+;
+         Prepared the final CIF file.
+;
+         other
+;
+         None of the listed roles. See _audit_author_role.special_details.
+;
+
+save_
+
+save_audit_author_role.special_details
+
+    _definition.id                '_audit_author_role.special_details'
+    _definition.update            2020-09-17
+    _description.text
+;
+    Description of the contribution of the author identified by
+    _audit_author_role.id.
+;
+    _name.category_id             audit_author_role
+    _name.object_id               special_details
+    _type.purpose                 Describe
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_AUDIT_CONFORM
+
+    _definition.id                AUDIT_CONFORM
+    _definition.scope             Category
+    _definition.class             Loop
+    _definition.update            2021-06-29
+    _description.text
+;
+    The CATEGORY of data items used describe dictionary versions
+    by which data names in the current data block are conformant.
+;
+    _name.category_id             AUDIT
+    _name.object_id               AUDIT_CONFORM
+    _category_key.name            '_audit_conform.dict_name'
+
+save_
+
+save_audit_conform.dict_location
+
+    _definition.id                '_audit_conform.dict_location'
+    _alias.definition_id          '_audit_conform_dict_location'
+    _definition.update            2012-11-29
+    _description.text
+;
+    File name or uniform resource locator (URL) where the
+    conformant data dictionary resides.
+;
+    _name.category_id             audit_conform
+    _name.object_id               dict_location
+    _type.purpose                 Encode
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_audit_conform.dict_name
+
+    _definition.id                '_audit_conform.dict_name'
+    _alias.definition_id          '_audit_conform_dict_name'
+    _definition.update            2012-11-29
+    _description.text
+;
+    Name identifying highest-level data dictionary defining
+    data names used in this file.
+;
+    _name.category_id             audit_conform
+    _name.object_id               dict_name
+    _type.purpose                 Encode
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_audit_conform.dict_version
+
+    _definition.id                '_audit_conform.dict_version'
+    _alias.definition_id          '_audit_conform_dict_version'
+    _definition.update            2021-11-04
+    _description.text
+;
+    Code for the version of data dictionary defining data names
+    used in this file.
+;
+    _name.category_id             audit_conform
+    _name.object_id               dict_version
+    _type.purpose                 Encode
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Word
+
+save_
+
+save_AUDIT_CONTACT_AUTHOR
+
+    _definition.id                AUDIT_CONTACT_AUTHOR
+    _definition.scope             Category
+    _definition.class             Loop
+    _definition.update            2021-06-29
+    _description.text
+;
+    The CATEGORY of data items used for contact author(s) details.
+;
+    _name.category_id             AUDIT
+    _name.object_id               AUDIT_CONTACT_AUTHOR
+    _category_key.name            '_audit_contact_author.id'
+
+save_
+
+save_audit_contact_author.address
+
+    _definition.id                '_audit_contact_author.address'
+    _alias.definition_id          '_audit_contact_author_address'
+    _definition.update            2019-01-09
+    _description.text
+;
+    The mailing address of the author of the data block to whom
+    correspondence should be addressed.
+;
+    _name.category_id             audit_contact_author
+    _name.object_id               address
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+    _description_example.case
+;
+    Department
+    Institute
+    Street
+    City and postcode
+    COUNTRY
+;
+
+save_
+
+save_audit_contact_author.email
+
+    _definition.id                '_audit_contact_author.email'
+    _alias.definition_id          '_audit_contact_author_email'
+    _definition.update            2012-11-29
+    _description.text
+;
+    The electronic mail address of the author of the data block
+    to whom correspondence should be addressed, in a form
+    recognizable to international networks. The format of e-mail
+    addresses is given in Section 3.4, Address Specification, of
+    Internet Message Format, RFC 2822, P. Resnick (Editor),
+    Network Standards Group, April 2001.
+;
+    _name.category_id             audit_contact_author
+    _name.object_id               email
+    _type.purpose                 Encode
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+
+    loop_
+      _description_example.case
+         name@host.domain.country
+         bm@iucr.org
+
+save_
+
+save_audit_contact_author.fax
+
+    _definition.id                '_audit_contact_author.fax'
+    _alias.definition_id          '_audit_contact_author_fax'
+    _definition.update            2012-11-29
+    _description.text
+;
+    Facsimile telephone number of the author submitting the manuscript
+    and data block.
+    The recommended style is the international dialing prefix, followed
+    by the area code in parentheses, followed by the local number with
+    no spaces. The earlier convention of including the international
+    dialing prefix in parentheses is no longer recommended.
+;
+    _name.category_id             audit_contact_author
+    _name.object_id               fax
+    _type.purpose                 Encode
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+
+    loop_
+      _description_example.case
+         12(34)9477334
+         12()349477334
+
+save_
+
+save_audit_contact_author.id
+
+    _definition.id                '_audit_contact_author.id'
+    _definition.update            2023-02-02
+    _description.text
+;
+    Arbitrary identifier for this author.
+;
+    _name.category_id             audit_contact_author
+    _name.object_id               id
+    _name.linked_item_id          '_audit_author.id'
+    _type.purpose                 Link
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Word
+    _method.purpose               Definition
+    _method.expression
+;
+    with aca as audit_contact_author
+    count = 0
+    target = ''
+    loop aa as audit_author {
+        if (aca.name == aa.name) {
+            count++
+            target = aa.id
+            }
+        }
+    if (count == 1) {
+        _enumeration.default = target
+        }
+    else {
+        _enumeration.default = missing
+    }
+;
+
+save_
+
+save_audit_contact_author.name
+
+    _definition.id                '_audit_contact_author.name'
+
+    loop_
+      _alias.definition_id
+         '_audit_contact_author_name'
+         '_audit_contact_author'
+
+    _definition.update            2023-01-10
+    _description.text
+;
+    The name of the author of the data block to whom correspondence
+    should be addressed. The family name(s), followed by a comma and
+    including any dynastic components, precedes the first name(s) or
+    initial(s). For authors with only one name, provide the full name
+    without abbreviation.
+;
+    _name.category_id             audit_contact_author
+    _name.object_id               name
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+
+    loop_
+      _description_example.case
+         "Bleary, Percival R."
+         "O'Neil, F.K."
+         "Van den Bossche, G."
+         "Chandra"
+
+save_
+
+save_audit_contact_author.phone
+
+    _definition.id                '_audit_contact_author.phone'
+    _alias.definition_id          '_audit_contact_author_phone'
+    _definition.update            2012-11-29
+    _description.text
+;
+    Telephone number of author submitting the manuscript and data block.
+    The recommended style is the international dialing prefix,
+    followed by the area code in parentheses, followed by the
+    local number and any extension number prefixed by 'x', with
+    no spaces. The earlier convention of including the international
+    dialing prefix in parentheses is no longer recommended.
+;
+    _name.category_id             audit_contact_author
+    _name.object_id               phone
+    _type.purpose                 Encode
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+
+    loop_
+      _description_example.case
+         12(34)9477330
+         12()349477330
+         12(34)9477330x5543
+
+save_
+
+save_AUDIT_LINK
+
+    _definition.id                AUDIT_LINK
+    _definition.scope             Category
+    _definition.class             Loop
+    _definition.update            2021-06-29
+    _description.text
+;
+    The CATEGORY of data items used to record details about the
+    relationships between data blocks in the current CIF.
+;
+    _name.category_id             AUDIT
+    _name.object_id               AUDIT_LINK
+    _category_key.name            '_audit_link.block_code'
+
+save_
+
+save_audit_link.block_code
+
+    _definition.id                '_audit_link.block_code'
+    _alias.definition_id          '_audit_link_block_code'
+    _definition.update            2021-10-27
+    _description.text
+;
+    The value of _audit.block_code associated with a data block
+    in the current file related to the current data block. The
+    special value '.' may be used to refer to the current data
+    block for completeness.
+;
+    _name.category_id             audit_link
+    _name.object_id               block_code
+    _type.purpose                 Encode
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Word
+
+save_
+
+save_audit_link.block_description
+
+    _definition.id                '_audit_link.block_description'
+    _alias.definition_id          '_audit_link_block_description'
+    _definition.update            2012-11-29
+    _description.text
+;
+    Description of the relationship of the referenced data block
+    to the current one.
+;
+    _name.category_id             audit_link
+    _name.object_id               block_description
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_AUDIT_SUPPORT
+
+    _definition.id                AUDIT_SUPPORT
+    _definition.scope             Category
+    _definition.class             Loop
+    _definition.update            2021-09-27
+    _description.text
+;
+    Data items in the AUDIT_SUPPORT category record details about the
+    funding support for the data collected and analysed in the data set.
+;
+    _name.category_id             AUDIT
+    _name.object_id               AUDIT_SUPPORT
+    _category_key.name            '_audit_support.id'
+    _description_example.case
+;
+    loop_
+    _audit_support.id
+    _audit_support.funding_organization
+    _audit_support.funding_organization_doi
+    _audit_support.award_type
+    _audit_support.award_number
+    _audit_support.award_recipient
+
+    1 'Engineering and Physical Sciences Research Council'
+    'https://doi.org/10.13039/501100000266'
+    studentship 'EP-M506515-1' 'E. T. Broadhurst'
+    2 'Swedish Funding Council'
+    ?
+    grant '2017-05333' 'M. Lightowler'
+    3 'Wellcome Trust'
+    'https://doi.org/10.13039/100004440'
+    grant 'WT087658' 'University of Edinburgh EM facility'
+    4 'Scottish Universities Life Sciences Alliance (SULSA)'
+    ?
+    other ? 'University of Edinburgh EM facility'
+    5 'Harvard Medical School'
+    'https://doi.org/10.13039/100006691'
+    ? ? ?
+;
+    _description_example.detail
+;
+    Example prepared from funding data published in
+    https://doi.org/10.1107/S2052252519016105.
+;
+
+save_
+
+save_audit_support.award_number
+
+    _definition.id                '_audit_support.award_number'
+    _definition.update            2020-08-23
+    _description.text
+;
+    The award number associated with this source of support.
+;
+    _name.category_id             audit_support
+    _name.object_id               award_number
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+    _description_example.case     FA9550-14-1-0409
+
+save_
+
+save_audit_support.award_recipient
+
+    _definition.id                '_audit_support.award_recipient'
+    _definition.update            2020-08-23
+    _description.text
+;
+    The recipient of the support. May be an
+    individual or institution.
+;
+    _name.category_id             audit_support
+    _name.object_id               award_recipient
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+    _description_example.case     'Cardiff University'
+
+save_
+
+save_audit_support.award_type
+
+    _definition.id                '_audit_support.award_type'
+    _definition.update            2020-08-23
+    _description.text
+;
+    Type or kind of award.
+;
+    _name.category_id             audit_support
+    _name.object_id               award_type
+    _type.purpose                 State
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+
+    loop_
+      _enumeration_set.state
+      _enumeration_set.detail
+         gift
+;
+         Funds were drawn from an unobligated, discretionary source under the
+         control of one of the participants in the research program. This
+         includes prize money and personal funds.
+;
+         grant
+;
+         Funds were provided by an organization or person outside the research
+         program for the specific purpose of supporting the research, as
+         directed by the primary investigator
+;
+         contract
+;
+         Funds were provided as part of a contractual agreement not covered by
+         other award types.
+;
+         studentship
+;
+         Funds were provided specifically to support a student in conducting
+         research, whether directly or indirectly. This category includes
+         scholarships and bursaries where the student is expected to engage in
+         research.
+;
+         other
+;
+         Other type of support, including financial support not explicitly
+         directed towards research. This category includes scholarships and
+         bursaries for students that cover living expenses while pursuing
+         higher education with no requirement to conduct research.
+;
+
+save_
+
+save_audit_support.funding_organization
+
+    _definition.id                '_audit_support.funding_organization'
+    _definition.update            2023-02-02
+    _description.text
+;
+    The name of the organization providing funding support for
+    the data collected and analysed in the data block. The
+    recommended source for such names is the Open Funder Registry
+    (https://gitlab.com/crossref/open_funder_registry).
+;
+    _name.category_id             audit_support
+    _name.object_id               funding_organization
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+    _description_example.case
+        'National Center for Complementary and Alternative Medicine'
+
+save_
+
+save_audit_support.funding_organization_doi
+
+    _definition.id                '_audit_support.funding_organization_DOI'
+    _definition.update            2023-01-13
+    _description.text
+;
+    The Digital Object Identifier (DOI) associated with the
+    Organization providing funding support for
+    the data collected and analysed in the data block. In
+    accordance with CrossRef guidelines, the full URI of
+    the resolved page describing the funding organization
+    should be given (i.e. including the https://doi.org/
+    component).
+;
+    _name.category_id             audit_support
+    _name.object_id               funding_organization_DOI
+    _type.purpose                 Encode
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+    _description_example.case     https://doi.org/10.13039/100000064
+
+save_
+
+save_audit_support.funding_organization_url
+
+    _definition.id                '_audit_support.funding_organization_URL'
+    _definition.update            2024-10-21
+    _description.text
+;
+    The Uniform Resource Locator (URL) associated with the funding organisation.
+
+    The _audit_support.funding_organization_DOI data item should be provided
+    alongside this item when possible.
+;
+    _name.category_id             audit_support
+    _name.object_id               funding_organization_URL
+    _type.purpose                 Encode
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Uri
+    _description_example.case     https://www.nccih.nih.gov/
+
+save_
+
+save_audit_support.id
+
+    _definition.id                '_audit_support.id'
+    _definition.update            2023-02-02
+    _description.text
+;
+    An arbitrary unique identifier for each source of support for
+    the data collected and analysed in the data block.
+;
+    _name.category_id             audit_support
+    _name.object_id               id
+    _type.purpose                 Key
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Word
+
+save_
+
+save_audit_support.special_details
+
+    _definition.id                '_audit_support.special_details'
+    _definition.update            2024-10-21
+    _description.text
+;
+    Details of the funding support that cannot be specified by other data items
+    from the AUDIT_SUPPORT category.
+;
+    _name.category_id             audit_support
+    _name.object_id               special_details
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_CITATION
+
+    _definition.id                CITATION
+    _definition.scope             Category
+    _definition.class             Loop
+    _definition.update            2021-06-29
+    _description.text
+;
+    Data items in the CITATION category record details about the
+    literature cited as being relevant to the contents of the data
+    block.
+;
+    _name.category_id             PUBLICATION
+    _name.object_id               CITATION
+    _category_key.name            '_citation.id'
+
+save_
+
+save_citation.abstract
+
+    _definition.id                '_citation.abstract'
+    _alias.definition_id          '_citation_abstract'
+    _definition.update            2012-12-11
+    _description.text
+;
+    Abstract for the citation. This is used most when the
+    citation is extracted from a bibliographic database that
+    contains full text or abstract information.
+;
+    _name.category_id             citation
+    _name.object_id               abstract
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_citation.abstract_id_cas
+
+    _definition.id                '_citation.abstract_id_CAS'
+    _alias.definition_id          '_citation_abstract_id_CAS'
+    _definition.update            2012-12-11
+    _description.text
+;
+    Chemical Abstracts Service (CAS) abstract identifier.
+;
+    _name.category_id             citation
+    _name.object_id               abstract_id_CAS
+    _type.purpose                 Encode
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_citation.book_id_isbn
+
+    _definition.id                '_citation.book_id_ISBN'
+    _alias.definition_id          '_citation_book_id_ISBN'
+    _definition.update            2023-02-02
+    _description.text
+;
+    International Standard Book Number (ISBN) for book chapter cited.
+;
+    _name.category_id             citation
+    _name.object_id               book_id_ISBN
+    _type.purpose                 Encode
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Code
+
+save_
+
+save_citation.book_publisher
+
+    _definition.id                '_citation.book_publisher'
+    _alias.definition_id          '_citation_book_publisher'
+    _definition.update            2012-12-11
+    _description.text
+;
+    Publisher of the citation; relevant for book chapters.
+;
+    _name.category_id             citation
+    _name.object_id               book_publisher
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_citation.book_publisher_city
+
+    _definition.id                '_citation.book_publisher_city'
+    _alias.definition_id          '_citation_book_publisher_city'
+    _definition.update            2012-12-11
+    _description.text
+;
+    Location of publisher of the citation; relevant for book chapters.
+;
+    _name.category_id             citation
+    _name.object_id               book_publisher_city
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_citation.book_title
+
+    _definition.id                '_citation.book_title'
+    _alias.definition_id          '_citation_book_title'
+    _definition.update            2012-12-11
+    _description.text
+;
+    Title of the book in which the citation appeared.
+;
+    _name.category_id             citation
+    _name.object_id               book_title
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_citation.coordinate_linkage
+
+    _definition.id                '_citation.coordinate_linkage'
+    _alias.definition_id          '_citation_coordinate_linkage'
+    _definition.update            2012-12-11
+    _description.text
+;
+    Code specifies whether this citation is concerned with precisely
+    the set of coordinates given in the data block. If, for instance,
+    the publication described the same structure, but the coordinates
+    had undergone further refinement prior to creation of the data
+    block, the value of this data item would be 'no'.
+;
+    _name.category_id             citation
+    _name.object_id               coordinate_linkage
+    _type.purpose                 State
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Text
+
+    loop_
+      _enumeration_set.state
+      _enumeration_set.detail
+         no                       'Citation unrelated to current coordinates.'
+         n                        'Abbreviation for "no".'
+         yes                      'Citation related to current coordinates.'
+         y                        'Abbreviation for "yes".'
+
+save_
+
+save_citation.country
+
+    _definition.id                '_citation.country'
+    _alias.definition_id          '_citation_country'
+    _definition.update            2012-12-11
+    _description.text
+;
+    Country of publication; for journal articles and book chapters.
+;
+    _name.category_id             citation
+    _name.object_id               country
+    _type.purpose                 Encode
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_citation.database_id_csd
+
+    _definition.id                '_citation.database_id_CSD'
+    _alias.definition_id          '_citation_database_id_CSD'
+    _definition.update            2021-10-27
+    _description.text
+;
+    Identifier ('refcode') of the database record in the Cambridge
+    Structural Database containing details of the cited structure.
+;
+    _name.category_id             citation
+    _name.object_id               database_id_CSD
+    _type.purpose                 Encode
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Word
+
+save_
+
+save_citation.database_id_medline
+
+    _definition.id                '_citation.database_id_Medline'
+    _alias.definition_id          '_citation_database_id_Medline'
+    _definition.update            2021-03-03
+    _description.text
+;
+    MEDLINE accession number categorizing a bibliographic entry.
+;
+    _name.category_id             citation
+    _name.object_id               database_id_Medline
+    _type.purpose                 Encode
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Code
+
+save_
+
+save_citation.doi
+
+    _definition.id                '_citation.DOI'
+    _alias.definition_id          '_citation_DOI'
+    _definition.update            2023-02-02
+    _description.text
+;
+    The Digital Object Identifier (DOI) of the cited work.
+
+    A DOI is a unique character string identifying any
+    object of intellectual property. It provides a
+    persistent identifier for an object on a digital network
+    and permits the association of related current data in a
+    structured extensible way. A DOI is an implementation
+    of the Internet concepts of Uniform Resource Name and
+    Universal Resource Locator managed according to the
+    specifications of the International DOI Foundation
+    (see https://www.doi.org/).
+;
+    _name.category_id             citation
+    _name.object_id               DOI
+    _type.purpose                 Encode
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+    _description_example.case     10.5517/CC6V9DQ
+
+save_
+
+save_citation.id
+
+    _definition.id                '_citation.id'
+    _alias.definition_id          '_citation_id'
+    _definition.update            2023-04-04
+    _description.text
+;
+    Unique identifier to the CITATION list. A value of 'primary'
+    should be used to indicate the citation that the author(s)
+    consider to be the most pertinent to the contents of the data
+    block. Note that this item need not be a number; it can be
+    any unique identifier.
+;
+    _name.category_id             citation
+    _name.object_id               id
+    _type.purpose                 Encode
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Word
+
+    loop_
+      _description_example.case
+         primary
+         1
+         2
+         3
+
+    _method.purpose               Definition
+    _method.expression
+;
+    if (len(citation) == 1) {
+        _enumeration.default = "primary"
+    } else {
+        _enumeration.default = missing
+    }
+;
+
+save_
+
+save_citation.journal_abbrev
+
+    _definition.id                '_citation.journal_abbrev'
+    _alias.definition_id          '_citation_journal_abbrev'
+    _definition.update            2012-12-11
+    _description.text
+;
+    Abbreviated name of the journal cited as given in the Chemical
+    Abstracts Service Source Index.
+;
+    _name.category_id             citation
+    _name.object_id               journal_abbrev
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+    _description_example.case     'J. Mol. Biol.'
+
+save_
+
+save_citation.journal_full
+
+    _definition.id                '_citation.journal_full'
+    _alias.definition_id          '_citation_journal_full'
+    _definition.update            2012-12-11
+    _description.text
+;
+    Full name of the journal cited; relevant for journal articles.
+;
+    _name.category_id             citation
+    _name.object_id               journal_full
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+    _description_example.case     'Journal of Molecular Biology'
+
+save_
+
+save_citation.journal_id_astm
+
+    _definition.id                '_citation.journal_id_ASTM'
+    _alias.definition_id          '_citation_journal_id_ASTM'
+    _definition.update            2012-12-11
+    _description.text
+;
+    American Society for the Testing of Materials (ASTM) code assigned
+    to the journal cited (also referred to as the CODEN designator of
+    the Chemical Abstracts Service); relevant for journal articles.
+;
+    _name.category_id             citation
+    _name.object_id               journal_id_ASTM
+    _type.purpose                 Encode
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Code
+
+save_
+
+save_citation.journal_id_csd
+
+    _definition.id                '_citation.journal_id_CSD'
+    _alias.definition_id          '_citation_journal_id_CSD'
+    _definition.update            2012-12-11
+    _description.text
+;
+    The Cambridge Structural Database (CSD) code assigned to the
+    journal cited; relevant for journal articles. This is also the
+    system used at the Protein Data Bank (PDB).
+;
+    _name.category_id             citation
+    _name.object_id               journal_id_CSD
+    _type.purpose                 Encode
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Code
+    _description_example.case     0070
+
+save_
+
+save_citation.journal_id_issn
+
+    _definition.id                '_citation.journal_id_ISSN'
+    _alias.definition_id          '_citation_journal_id_ISSN'
+    _definition.update            2012-12-11
+    _description.text
+;
+    The International Standard Serial Number (ISSN) code assigned to
+    the journal cited. Relevant for journal articles.
+;
+    _name.category_id             citation
+    _name.object_id               journal_id_ISSN
+    _type.purpose                 Encode
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Code
+
+save_
+
+save_citation.journal_issue
+
+    _definition.id                '_citation.journal_issue'
+    _alias.definition_id          '_citation_journal_issue'
+    _definition.update            2021-11-12
+    _description.text
+;
+    Issue identifier of the journal cited; relevant for articles.
+;
+    _name.category_id             citation
+    _name.object_id               journal_issue
+    _type.purpose                 Encode
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+
+    loop_
+      _description_example.case
+         '2'
+         'Special Issue'
+
+save_
+
+save_citation.journal_volume
+
+    _definition.id                '_citation.journal_volume'
+    _alias.definition_id          '_citation_journal_volume'
+    _definition.update            2021-03-01
+    _description.text
+;
+    Volume number of the journal cited; relevant for articles.
+;
+    _name.category_id             citation
+    _name.object_id               journal_volume
+    _type.purpose                 Number
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Integer
+    _enumeration.range            1:
+    _units.code                   none
+    _description_example.case     174
+
+save_
+
+save_citation.language
+
+    _definition.id                '_citation.language'
+    _alias.definition_id          '_citation_language'
+    _definition.update            2012-12-11
+    _description.text
+;
+    Language in which the citation appears.
+;
+    _name.category_id             citation
+    _name.object_id               language
+    _type.purpose                 Encode
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+    _description_example.case     German
+
+save_
+
+save_citation.page_first
+
+    _definition.id                '_citation.page_first'
+    _alias.definition_id          '_citation_page_first'
+    _definition.update            2012-12-11
+    _description.text
+;
+    First page of citation; relevant for articles and book chapters.
+;
+    _name.category_id             citation
+    _name.object_id               page_first
+    _type.purpose                 Encode
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_citation.page_last
+
+    _definition.id                '_citation.page_last'
+    _alias.definition_id          '_citation_page_last'
+    _definition.update            2012-12-11
+    _description.text
+;
+    Last page of citation; relevant for articles and book chapters.
+;
+    _name.category_id             citation
+    _name.object_id               page_last
+    _type.purpose                 Encode
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_citation.publisher
+
+    _definition.id                '_citation.publisher'
+    _alias.definition_id          '_citation_publisher'
+    _definition.update            2017-09-23
+    _description.text
+;
+    The name of the publisher of the cited work. This should be used
+    for citations of journal articles or datasets (in the latter case
+    the publisher could be a curated database). For books or book chapters
+    use _citation.book_publisher.
+;
+    _name.category_id             citation
+    _name.object_id               publisher
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+    _description_example.case     'Cambridge Crystallographic Data Centre'
+
+save_
+
+save_citation.special_details
+
+    _definition.id                '_citation.special_details'
+
+    loop_
+      _alias.definition_id
+         '_citation_special_details'
+         '_citation.details'
+
+    _definition.update            2012-12-11
+    _description.text
+;
+    Special aspects of the relationship of the data block contents
+    to the literature item cited.
+;
+    _name.category_id             citation
+    _name.object_id               special_details
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_citation.title
+
+    _definition.id                '_citation.title'
+    _alias.definition_id          '_citation_title'
+    _definition.update            2012-12-11
+    _description.text
+;
+    Title of citation; relevant for articles and book chapters.
+;
+    _name.category_id             citation
+    _name.object_id               title
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_citation.url
+
+    _definition.id                '_citation.URL'
+    _definition.update            2023-01-26
+    _description.text
+;
+    The Uniform Resource Locator (URL) of the cited work.
+
+    The _citation.DOI data item should be used in preference to this item when
+    possible.
+;
+    _name.category_id             citation
+    _name.object_id               URL
+    _type.purpose                 Encode
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Uri
+    _description_example.case     https://arxiv.org/abs/1203.5146v4
+
+save_
+
+save_citation.year
+
+    _definition.id                '_citation.year'
+    _alias.definition_id          '_citation_year'
+    _definition.update            2021-11-14
+    _description.text
+;
+    Year of citation; relevant for articles and book chapters.
+;
+    _name.category_id             citation
+    _name.object_id               year
+    _type.purpose                 Number
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Integer
+    _units.code                   none
+
+save_
+
+save_CITATION_AUTHOR
+
+    _definition.id                CITATION_AUTHOR
+    _definition.scope             Category
+    _definition.class             Loop
+    _definition.update            2021-06-29
+    _description.text
+;
+    Category of items describing citation author(s) details.
+;
+    _name.category_id             PUBLICATION
+    _name.object_id               CITATION_AUTHOR
+
+    loop_
+      _category_key.name
+         '_citation_author.citation_id'
+         '_citation_author.ordinal'
+
+save_
+
+save_citation_author.citation_id
+
+    _definition.id                '_citation_author.citation_id'
+    _alias.definition_id          '_citation_author_citation_id'
+    _definition.update            2021-10-27
+    _description.text
+;
+    Code identifier in the CITATION data list. The value of must match
+    an identifier specified in the CITATION list.
+;
+    _name.category_id             citation_author
+    _name.object_id               citation_id
+    _name.linked_item_id          '_citation.id'
+    _type.purpose                 Link
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Word
+
+save_
+
+save_citation_author.name
+
+    _definition.id                '_citation_author.name'
+    _alias.definition_id          '_citation_author_name'
+    _definition.update            2023-01-10
+    _description.text
+;
+    Name of citation author; relevant for articles and book chapters.
+    The family name(s), followed by a comma and including any
+    dynastic components, precedes the first name(s) or initial(s).
+    For authors with only one name, provide the full name without
+    abbreviation.
+;
+    _name.category_id             citation_author
+    _name.object_id               name
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+
+    loop_
+      _description_example.case
+         "Bleary, Percival R."
+         "O'Neil, F.K."
+         "Van den Bossche, G."
+         "Yang, D.-L."
+         "Simonov, Yu.A"
+         "Müller, H.A."
+         "Ross II, C.R."
+         "Chandra"
+
+save_
+
+save_citation_author.ordinal
+
+    _definition.id                '_citation_author.ordinal'
+    _alias.definition_id          '_citation_author_ordinal'
+    _definition.update            2021-03-01
+    _description.text
+;
+    Ordinal code specifies the order of the author's name in the list
+    of authors of the citation.
+;
+    _name.category_id             citation_author
+    _name.object_id               ordinal
+    _type.purpose                 Number
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Integer
+    _enumeration.range            1:
+    _units.code                   none
+
+save_
+
+save_CITATION_EDITOR
+
+    _definition.id                CITATION_EDITOR
+    _definition.scope             Category
+    _definition.class             Loop
+    _definition.update            2021-06-29
+    _description.text
+;
+    Category of items describing citation editor(s) details.
+;
+    _name.category_id             PUBLICATION
+    _name.object_id               CITATION_EDITOR
+
+    loop_
+      _category_key.name
+         '_citation_editor.citation_id'
+         '_citation_editor.ordinal'
+
+save_
+
+save_citation_editor.citation_id
+
+    _definition.id                '_citation_editor.citation_id'
+    _alias.definition_id          '_citation_editor_citation_id'
+    _definition.update            2021-10-27
+    _description.text
+;
+    Code identifier in the CITATION list. The value must match an
+    identifier specified by _citation.id in the CITATION list.
+;
+    _name.category_id             citation_editor
+    _name.object_id               citation_id
+    _name.linked_item_id          '_citation.id'
+    _type.purpose                 Link
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Word
+
+save_
+
+save_citation_editor.name
+
+    _definition.id                '_citation_editor.name'
+
+    loop_
+      _alias.definition_id
+         '_citation_editor'
+         '_citation_editor_name'
+
+    _definition.update            2012-12-11
+    _description.text
+;
+    Name of citation editor; relevant for book chapters.
+    The family name(s), followed by a comma and including any
+    dynastic components, precedes the first name(s) or initial(s).
+;
+    _name.category_id             citation_editor
+    _name.object_id               name
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+
+    loop_
+      _description_example.case
+         "Bleary, Percival R."
+         "O'Neil, F.K."
+         "Van den Bossche, G."
+         "Yang, D.-L."
+         "Simonov, Yu.A"
+         "Müller, H.A."
+         "Ross II, C.R."
+
+save_
+
+save_citation_editor.ordinal
+
+    _definition.id                '_citation_editor.ordinal'
+    _alias.definition_id          '_citation_editor_ordinal'
+    _definition.update            2021-03-01
+    _description.text
+;
+    This data item defines the order of the editor's name in the
+    list of editors of a citation.
+;
+    _name.category_id             citation_editor
+    _name.object_id               ordinal
+    _type.purpose                 Number
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Integer
+    _enumeration.range            1:
+    _units.code                   none
+
+save_
+
+save_COMPUTING
+
+    _definition.id                COMPUTING
+    _definition.scope             Category
+    _definition.class             Set
+    _definition.update            2012-05-07
+    _description.text
+;
+    The CATEGORY of data items used to record details of the
+    computer programs used in the crystal structure analysis.
+;
+    _name.category_id             PUBLICATION
+    _name.object_id               COMPUTING
+
+save_
+
+save_computing.cell_refinement
+
+    _definition.id                '_computing.cell_refinement'
+    _alias.definition_id          '_computing_cell_refinement'
+    _definition.update            2019-01-09
+    _description.text
+;
+    Brief description of software used for cell refinement.
+;
+    _name.category_id             computing
+    _name.object_id               cell_refinement
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+    _description_example.case     'CAD-4 (Enraf-Nonius, 1989)'
+
+save_
+
+save_computing.diffrn_collection
+
+    _definition.id                '_computing.diffrn_collection'
+
+    loop_
+      _alias.definition_id
+         '_computing_data_collection'
+         '_computing.data_collection'
+
+    _definition.update            2012-12-11
+    _description.text
+;
+    Description of software used to measure diffraction data.
+;
+    _name.category_id             computing
+    _name.object_id               diffrn_collection
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+    _description_example.case     'CAD-4 (Enraf-Nonius, 1989)'
+
+save_
+
+save_computing.diffrn_reduction
+
+    _definition.id                '_computing.diffrn_reduction'
+
+    loop_
+      _alias.definition_id
+         '_computing_data_reduction'
+         '_computing.data_reduction'
+
+    _definition.update            2012-12-11
+    _description.text
+;
+    Description of software used to convert diffraction data
+    to measured structure factors.
+;
+    _name.category_id             computing
+    _name.object_id               diffrn_reduction
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+    _description_example.case
+        'DIFDAT, SORTRF, ADDREF (Hall & Stewart, 1990)'
+
+save_
+
+save_computing.molecular_graphics
+
+    _definition.id                '_computing.molecular_graphics'
+    _alias.definition_id          '_computing_molecular_graphics'
+    _definition.update            2019-01-09
+    _description.text
+;
+    Brief description of software used for molecular graphics.
+;
+    _name.category_id             computing
+    _name.object_id               molecular_graphics
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_computing.publication_material
+
+    _definition.id                '_computing.publication_material'
+    _alias.definition_id          '_computing_publication_material'
+    _definition.update            2019-01-09
+    _description.text
+;
+    Brief description of software used for publication material.
+;
+    _name.category_id             computing
+    _name.object_id               publication_material
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_computing.structure_refinement
+
+    _definition.id                '_computing.structure_refinement'
+    _alias.definition_id          '_computing_structure_refinement'
+    _definition.update            2019-01-09
+    _description.text
+;
+    Brief description of software used for structure refinement.
+;
+    _name.category_id             computing
+    _name.object_id               structure_refinement
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+    _description_example.case     'SHELXL93 (Sheldrick, 1993)'
+
+save_
+
+save_computing.structure_solution
+
+    _definition.id                '_computing.structure_solution'
+    _alias.definition_id          '_computing_structure_solution'
+    _definition.update            2019-01-09
+    _description.text
+;
+    Brief description of software used for structure solution.
+;
+    _name.category_id             computing
+    _name.object_id               structure_solution
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+    _description_example.case     'SHELXS86 (Sheldrick, 1990)'
+
+save_
+
+save_DATABASE
+
+    _definition.id                DATABASE
+    _definition.scope             Category
+    _definition.class             Set
+    _definition.update            2012-12-13
+    _description.text
+;
+    The CATEGORY of data items recording database deposition.
+;
+    _name.category_id             PUBLICATION
+    _name.object_id               DATABASE
+
+save_
+
+save_database.csd_history
+
+    _definition.id                '_database.CSD_history'
+    _alias.definition_id          '_database_CSD_history'
+    _definition.update            2012-12-13
+    _description.text
+;
+    The history of changes made by the Cambridge Crystallographic Data
+    Centre and incorporated into the Cambridge Structural Database (CSD).
+;
+    _name.category_id             database
+    _name.object_id               CSD_history
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_database.dataset_doi
+
+    _definition.id                '_database.dataset_DOI'
+    _alias.definition_id          '_database_dataset_DOI'
+    _definition.update            2023-02-02
+    _description.text
+;
+    The digital object identifier (DOI) registered to identify
+    a data set publication associated with the structure
+    described in the current data block. This should be used
+    for a dataset obtained from a curated database such as
+    CSD or PDB.
+
+    A DOI is a unique character string identifying any
+    object of intellectual property. It provides a
+    persistent identifier for an object on a digital network
+    and permits the association of related current data in a
+    structured extensible way. A DOI is an implementation
+    of the Internet concepts of Uniform Resource Name and
+    Universal Resource Locator managed according to the
+    specifications of the International DOI Foundation
+    (see https://www.doi.org/).
+;
+    _name.category_id             database
+    _name.object_id               dataset_DOI
+    _type.purpose                 Encode
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+    _description_example.case     10.2210/pdb4hhb/pdb
+
+save_
+
+save_database.journal_astm
+
+    _definition.id                '_database.journal_ASTM'
+    _alias.definition_id          '_database_journal_ASTM'
+    _definition.update            2012-12-13
+    _description.text
+;
+    ASTM CODEN designator for a journal as given in the Chemical
+    Source List maintained by the Chemical Abstracts Service.
+;
+    _name.category_id             database
+    _name.object_id               journal_ASTM
+    _type.purpose                 Encode
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Code
+
+save_
+
+save_database.journal_csd
+
+    _definition.id                '_database.journal_CSD'
+    _alias.definition_id          '_database_journal_CSD'
+    _definition.update            2012-12-13
+    _description.text
+;
+    The journal code used in the Cambridge Structural Database.
+;
+    _name.category_id             database
+    _name.object_id               journal_CSD
+    _type.purpose                 Encode
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Code
+
+save_
+
+save_DATABASE_CODE
+
+    _definition.id                DATABASE_CODE
+    _definition.scope             Category
+    _definition.class             Set
+    _definition.update            2012-12-13
+    _description.text
+;
+    The CATEGORY of data items recording database deposition. These data items
+    are assigned by database managers and should only appear in a CIF if they
+    originate from that source.
+;
+    _name.category_id             DATABASE
+    _name.object_id               DATABASE_CODE
+
+save_
+
+save_database_code.bincstrdb
+
+    _definition.id                '_database_code.BIncStrDB'
+
+    _definition.update            2024-03-27
+    _description.text
+;
+    Code assigned by the Bilbao Modulated Structures Database
+    (B-IncStrDB).
+;
+    _name.category_id             database_code
+    _name.object_id               BIncStrDB
+    _type.purpose                 Encode
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Code
+
+save_
+
+save_database_code.cas
+
+    _definition.id                '_database_code.CAS'
+
+    loop_
+      _alias.definition_id
+         '_database_code_CAS'
+         '_database.code_CAS'
+
+    _definition.update            2012-12-13
+    _description.text
+;
+    Code assigned by the Chemical Abstracts Service.
+;
+    _name.category_id             database_code
+    _name.object_id               CAS
+    _type.purpose                 Encode
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Code
+
+save_
+
+save_database_code.cod
+
+    _definition.id                '_database_code.COD'
+
+    loop_
+      _alias.definition_id
+         '_database_code_COD'
+         '_database.code_COD'
+
+    _definition.update            2021-03-03
+    _description.text
+;
+    Code assigned by the Crystallography Open Database (COD).
+;
+    _name.category_id             database_code
+    _name.object_id               COD
+    _type.purpose                 Encode
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Code
+
+save_
+
+save_database_code.csd
+
+    _definition.id                '_database_code.CSD'
+
+    loop_
+      _alias.definition_id
+         '_database_code_CSD'
+         '_database.code_CSD'
+
+    _definition.update            2021-11-04
+    _description.text
+;
+    Code assigned by the Cambridge Structural Database.
+;
+    _name.category_id             database_code
+    _name.object_id               CSD
+    _type.purpose                 Encode
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Word
+
+save_
+
+save_database_code.depnum_ccdc_archive
+
+    _definition.id                '_database_code.depnum_CCDC_archive'
+
+    loop_
+      _alias.definition_id
+         '_database_code_depnum_CCDC_archive'
+         '_database.code_depnum_CCDC_archive'
+
+    _definition.update            2021-09-24
+    _description.text
+;
+    Deposition numbers assigned by the Cambridge Crystallographic
+    Data Centre (CCDC) to files containing structural information
+    archived by the CCDC.
+;
+    _name.category_id             database_code
+    _name.object_id               depnum_CCDC_archive
+    _type.purpose                 Encode
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Code
+
+save_
+
+save_database_code.depnum_ccdc_fiz
+
+    _definition.id                '_database_code.depnum_CCDC_fiz'
+
+    loop_
+      _alias.definition_id
+         '_database_code_depnum_CCDC_fiz'
+         '_database.code_depnum_CCDC_fiz'
+
+    _definition.update            2021-09-24
+    _description.text
+;
+    Deposition numbers assigned by the Fachinformationszentrum
+    Karlsruhe (FIZ) to files containing structural information
+    archived by the Cambridge Crystallographic Data Centre (CCDC).
+;
+    _name.category_id             database_code
+    _name.object_id               depnum_CCDC_fiz
+    _type.purpose                 Encode
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Code
+
+save_
+
+save_database_code.depnum_ccdc_journal
+
+    _definition.id                '_database_code.depnum_CCDC_journal'
+
+    loop_
+      _alias.definition_id
+         '_database_code_depnum_CCDC_journal'
+         '_database.code_depnum_CCDC_journal'
+
+    _definition.update            2021-09-24
+    _description.text
+;
+    Deposition numbers assigned by various journals to files
+    containing structural information archived by the Cambridge
+    Crystallographic Data Centre (CCDC).
+;
+    _name.category_id             database_code
+    _name.object_id               depnum_CCDC_journal
+    _type.purpose                 Encode
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Code
+
+save_
+
+save_database_code.icsd
+
+    _definition.id                '_database_code.ICSD'
+
+    loop_
+      _alias.definition_id
+         '_database_code_ICSD'
+         '_database.code_ICSD'
+
+    _definition.update            2012-12-13
+    _description.text
+;
+    Code assigned by the Inorganic Crystal Structure Database.
+;
+    _name.category_id             database_code
+    _name.object_id               ICSD
+    _type.purpose                 Encode
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Code
+
+save_
+
+save_database_code.mdf
+
+    _definition.id                '_database_code.MDF'
+
+    loop_
+      _alias.definition_id
+         '_database_code_MDF'
+         '_database.code_MDF'
+
+    _definition.update            2012-12-13
+    _description.text
+;
+    Code assigned in the Metals Data File.
+;
+    _name.category_id             database_code
+    _name.object_id               MDF
+    _type.purpose                 Encode
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Code
+
+save_
+
+save_database_code.nbs
+
+    _definition.id                '_database_code.NBS'
+
+    loop_
+      _alias.definition_id
+         '_database_code_NBS'
+         '_database.code_NBS'
+
+    _definition.update            2012-12-13
+    _description.text
+;
+    Code assigned by the NBS (NIST) Crystal Data Database.
+;
+    _name.category_id             database_code
+    _name.object_id               NBS
+    _type.purpose                 Encode
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Code
+
+save_
+
+save_database_code.pdb
+
+    _definition.id                '_database_code.PDB'
+
+    loop_
+      _alias.definition_id
+         '_database_code_PDB'
+         '_database.code_PDB'
+
+    _definition.update            2021-11-04
+    _description.text
+;
+    Code assigned by the Protein Data Bank.
+;
+    _name.category_id             database_code
+    _name.object_id               PDB
+    _type.purpose                 Encode
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Word
+
+save_
+
+save_database_code.pdf
+
+    _definition.id                '_database_code.PDF'
+
+    loop_
+      _alias.definition_id
+         '_database_code_PDF'
+         '_database.code_PDF'
+
+    _definition.update            2012-12-13
+    _description.text
+;
+    Code assigned in the Powder Diffraction File.
+;
+    _name.category_id             database_code
+    _name.object_id               PDF
+    _type.purpose                 Encode
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Code
+
+save_
+
+save_DATABASE_RELATED
+
+    _definition.id                DATABASE_RELATED
+    _definition.scope             Category
+    _definition.class             Loop
+    _definition.update            2019-01-08
+    _description.text
+;
+    A category of items recording entries in databases that describe
+    the same or related data. Databases wishing to insert their own
+    canonical codes when archiving and delivering data blocks should
+    use items from the DATABASE category.
+;
+    _name.category_id             PUBLICATION
+    _name.object_id               DATABASE_RELATED
+    _category_key.name            '_database_related.id'
+    _description_example.case
+;
+    loop_
+      _database_related.id
+      _database_related.database_id
+      _database_related.entry_code
+      _database_related.relation
+      _database_related.special_details
+       1 CAS 58-55-9  Other     'Describes the same compound.'
+       2 COD 2006182  Identical .
+       3 CSD BAPLOT01 Identical .
+;
+    _description_example.detail
+;
+    The loop relates a specific instance of a theophylline crystal structure
+    to corresponding entries in the COD and CSD crystallographic databases
+    as well as to the general description of the theophyline compound in the
+    CAS registry.
+
+    This example loop could potentially be added to the CIF file that is
+    provided as supplementary material for the following publication:
+      Ebisuzaki, Y. et al. (1997). Acta Crystallographica, Section C:
+      Crystal Structure Communications, 53(6), 777-779.
+      https://doi.org/10.1107/S0108270197001960
+;
+
+save_
+
+save_database_related.database_id
+
+    _definition.id                '_database_related.database_id'
+    _definition.update            2023-02-02
+    _description.text
+;
+    An identifier for the database that contains the related dataset.
+;
+    _name.category_id             database_related
+    _name.object_id               database_id
+    _type.purpose                 State
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Word
+
+    _import.get
+        [{'file':templ_enum.cif  'save':database_list}]
+
+save_
+
+save_database_related.entry_code
+
+    _definition.id                '_database_related.entry_code'
+    _definition.update            2019-01-08
+    _description.text
+;
+    The code used by the database referred to in
+    _database_related.database_id to identify the
+    related dataset.
+;
+    _name.category_id             database_related
+    _name.object_id               entry_code
+    _type.purpose                 Encode
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_database_related.id
+
+    _definition.id                '_database_related.id'
+    _definition.update            2023-02-02
+    _description.text
+;
+    An identifier for this database reference.
+;
+    _name.category_id             database_related
+    _name.object_id               id
+    _type.purpose                 Key
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Word
+
+save_
+
+save_database_related.relation
+
+    _definition.id                '_database_related.relation'
+    _definition.update            2023-02-03
+    _description.text
+;
+    The general relationship of the data in the data block
+    to the dataset referred to in the database.
+;
+    _name.category_id             database_related
+    _name.object_id               relation
+    _type.purpose                 State
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+
+    loop_
+      _enumeration_set.state
+      _enumeration_set.detail
+         Identical
+;
+         The dataset contents are identical.
+;
+         Subset
+;
+         The dataset contents are a proper subset of the contents of the data
+         block.
+;
+         Superset
+;
+         The dataset contents include the contents of the data block.
+;
+         Derived
+;
+         The dataset contents are derivable from the contents of the data block.
+;
+         Common
+;
+         The dataset contents share a common source.
+;
+         Other
+;
+         The dataset contents are related to the contents of the data block in
+         a way not included elsewhere in this list. In case this value is used,
+         it is strongly recommended to also provide the specifics of the
+         relationship using the _database_related.special_details data item.
+;
+
+save_
+
+save_database_related.special_details
+
+    _definition.id                '_database_related.special_details'
+    _definition.update            2019-01-08
+    _description.text
+;
+    Information about the external dataset and relationship not encoded
+    elsewhere.
+;
+    _name.category_id             database_related
+    _name.object_id               special_details
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_DISPLAY
+
+    _definition.id                DISPLAY
+    _definition.scope             Category
+    _definition.class             Set
+    _definition.update            2012-05-07
+    _description.text
+;
+    The CATEGORY of data items used to enumerate the display
+    parameters used in the discipline.
+;
+    _name.category_id             PUBLICATION
+    _name.object_id               DISPLAY
+
+save_
+
+save_DISPLAY_COLOUR
+
+    _definition.id                DISPLAY_COLOUR
+    _definition.scope             Category
+    _definition.class             Loop
+    _definition.update            2021-06-29
+    _description.text
+;
+    The CATEGORY of data items used to enumerate the display
+    colour codes used in the discipline.
+;
+    _name.category_id             DISPLAY
+    _name.object_id               DISPLAY_COLOUR
+    _category_key.name            '_display_colour.hue'
+
+save_
+
+save_display_colour.blue
+
+    _definition.id                '_display_colour.blue'
+    _name.category_id             display_colour
+    _name.object_id               blue
+
+    _import.get
+        [{'file':templ_attr.cif  'save':display_colour}]
+
+save_
+
+save_display_colour.green
+
+    _definition.id                '_display_colour.green'
+    _name.category_id             display_colour
+    _name.object_id               green
+
+    _import.get
+        [{'file':templ_attr.cif  'save':display_colour}]
+
+save_
+
+save_display_colour.hue
+
+    _definition.id                '_display_colour.hue'
+    _definition.update            2023-02-06
+    _description.text
+;
+    Colour hue as an enumerated code.
+;
+    _name.category_id             display_colour
+    _name.object_id               hue
+    _type.purpose                 State
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Word
+
+    _import.get                   [{'file':templ_enum.cif  'save':colour_rgb}]
+
+save_
+
+save_display_colour.red
+
+    _definition.id                '_display_colour.red'
+    _name.category_id             display_colour
+    _name.object_id               red
+
+    _import.get
+        [{'file':templ_attr.cif  'save':display_colour}]
+
+save_
+
+save_display_colour.rgb
+
+    _definition.id                '_display_colour.RGB'
+    _definition.update            2021-03-01
+    _description.text
+;
+    The red-green-blue intensities, bases 256, for each colour code.
+;
+    _name.category_id             display_colour
+    _name.object_id               RGB
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               List
+    _type.dimension               '[3]'
+    _type.contents                Integer
+    _units.code                   none
+    _method.purpose               Evaluation
+    _method.expression
+;
+    With c  as  display_colour
+
+               _display_colour.RGB  =  [ c.red, c.green, c.blue ]
+;
+
+save_
+
+save_JOURNAL
+
+    _definition.id                JOURNAL
+    _definition.scope             Category
+    _definition.class             Set
+    _definition.update            2012-12-11
+    _description.text
+;
+    Category of items recording details about the book-keeping
+    by the journal staff when processing a CIF submitted for
+    publication.  The creator of a CIF will not normally specify
+    these data items.
+;
+    _name.category_id             PUBLICATION
+    _name.object_id               JOURNAL
+
+save_
+
+save_journal.coden_astm
+
+    _definition.id                '_journal.coden_ASTM'
+    _alias.definition_id          '_journal_coden_ASTM'
+    _definition.update            2012-12-11
+    _description.text
+;
+    ASTM code assigned to journal.
+;
+    _name.category_id             journal
+    _name.object_id               coden_ASTM
+    _type.purpose                 Encode
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Code
+
+save_
+
+save_journal.coden_cambridge
+
+    _definition.id                '_journal.coden_Cambridge'
+    _alias.definition_id          '_journal_coden_Cambridge'
+    _definition.update            2012-12-11
+    _description.text
+;
+    Cambridge Cryst. Data Centre code assigned to journal.
+;
+    _name.category_id             journal
+    _name.object_id               coden_Cambridge
+    _type.purpose                 Encode
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Code
+
+save_
+
+save_journal.data_validation_number
+
+    _definition.id                '_journal.data_validation_number'
+    _alias.definition_id          '_journal_data_validation_number'
+    _definition.update            2021-10-27
+    _description.text
+;
+    Journal data items are defined by the journal staff.
+;
+    _name.category_id             journal
+    _name.object_id               'data_validation_number'
+    _type.purpose                 Encode
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Word
+
+save_
+
+save_journal.issue
+
+    _definition.id                '_journal.issue'
+    _alias.definition_id          '_journal_issue'
+    _definition.update            2021-11-12
+    _description.text
+;
+    Issue identifier within the journal.
+;
+    _name.category_id             journal
+    _name.object_id               issue
+    _type.purpose                 Encode
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+
+    loop_
+      _description_example.case
+         '2'
+         'Special Issue'
+
+save_
+
+save_journal.language
+
+    _definition.id                '_journal.language'
+    _alias.definition_id          '_journal_language'
+    _definition.update            2012-12-11
+    _description.text
+;
+    Language of the publication.
+;
+    _name.category_id             journal
+    _name.object_id               language
+    _type.purpose                 Encode
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_journal.name_full
+
+    _definition.id                '_journal.name_full'
+    _alias.definition_id          '_journal_name_full'
+    _definition.update            2012-12-11
+    _description.text
+;
+    Full name of the journal.
+;
+    _name.category_id             journal
+    _name.object_id               name_full
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_journal.page_first
+
+    _definition.id                '_journal.page_first'
+    _alias.definition_id          '_journal_page_first'
+    _definition.update            2012-12-11
+    _description.text
+;
+    First page of the publication in the journal.
+;
+    _name.category_id             journal
+    _name.object_id               page_first
+    _type.purpose                 Encode
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_journal.page_last
+
+    _definition.id                '_journal.page_last'
+    _alias.definition_id          '_journal_page_last'
+    _definition.update            2012-12-11
+    _description.text
+;
+    Last page of the publication in the journal.
+;
+    _name.category_id             journal
+    _name.object_id               page_last
+    _type.purpose                 Encode
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_journal.paper_category
+
+    _definition.id                '_journal.paper_category'
+    _alias.definition_id          '_journal_paper_category'
+    _definition.update            2021-11-04
+    _description.text
+;
+    Category of the publication in the journal.
+;
+    _name.category_id             journal
+    _name.object_id               paper_category
+    _type.purpose                 Encode
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_journal.paper_doi
+
+    _definition.id                '_journal.paper_DOI'
+    _alias.definition_id          '_journal_paper_DOI'
+    _definition.update            2021-12-01
+    _description.text
+;
+    DOI of the publication in the journal.
+;
+    _name.category_id             journal
+    _name.object_id               paper_DOI
+    _type.purpose                 Encode
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+    _description_example.case     10.5555/12345678
+
+save_
+
+save_journal.paper_number
+
+    _definition.id                '_journal.paper_number'
+    _definition.update            2023-02-02
+    _description.text
+;
+    Article number that is used by some journals instead of a page range.
+    Usually applies to electronic-only journals.
+;
+    _name.category_id             journal
+    _name.object_id               paper_number
+    _type.purpose                 Encode
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+
+    loop_
+      _description_example.case
+         e0222394
+         L041303
+         044501
+
+save_
+
+save_journal.paper_pages
+
+    _definition.id                '_journal.paper_pages'
+    _definition.update            2023-02-02
+    _description.text
+;
+    Number of pages in the journal article.
+;
+    _name.category_id             journal
+    _name.object_id               paper_pages
+    _type.purpose                 Number
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Integer
+    _enumeration.range            1:
+    _units.code                   none
+
+    loop_
+      _description_example.case
+         1
+         4
+         13
+
+save_
+
+save_journal.paper_url
+
+    _definition.id                '_journal.paper_URL'
+    _definition.update            2023-01-26
+    _description.text
+;
+    The Uniform Resource Locator (URL) of the publication.
+
+    The _journal.paper_DOI data item should be used in preference to this item
+    when possible.
+;
+    _name.category_id             journal
+    _name.object_id               paper_URL
+    _type.purpose                 Encode
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Uri
+    _description_example.case     https://arxiv.org/abs/1203.5146v4
+
+save_
+
+save_journal.suppl_publ_number
+
+    _definition.id                '_journal.suppl_publ_number'
+    _alias.definition_id          '_journal_suppl_publ_number'
+    _definition.update            2021-11-04
+    _description.text
+;
+    Number of the supplementary publication.
+;
+    _name.category_id             journal
+    _name.object_id               suppl_publ_number
+    _type.purpose                 Encode
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_journal.suppl_publ_pages
+
+    _definition.id                '_journal.suppl_publ_pages'
+    _alias.definition_id          '_journal_suppl_publ_pages'
+    _definition.update            2021-03-01
+    _description.text
+;
+    Number of pages in the supplementary publication.
+;
+    _name.category_id             journal
+    _name.object_id               suppl_publ_pages
+    _type.purpose                 Number
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Integer
+    _enumeration.range            1:
+    _units.code                   none
+
+save_
+
+save_journal.validation_number
+
+    _definition.id                '_journal.validation_number'
+    _definition.update            2013-01-23
+    _description.text
+;
+    Data validation number assigned to journal.
+;
+    _name.category_id             journal
+    _name.object_id               validation_number
+    _type.purpose                 Encode
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Code
+
+save_
+
+save_journal.volume
+
+    _definition.id                '_journal.volume'
+    _alias.definition_id          '_journal_volume'
+    _definition.update            2021-03-01
+    _description.text
+;
+    Volume number of the publication.
+;
+    _name.category_id             journal
+    _name.object_id               volume
+    _type.purpose                 Number
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Integer
+    _enumeration.range            1:
+    _units.code                   none
+
+save_
+
+save_journal.year
+
+    _definition.id                '_journal.year'
+    _alias.definition_id          '_journal_year'
+    _definition.update            2021-11-14
+    _description.text
+;
+    Year of the publication.
+;
+    _name.category_id             journal
+    _name.object_id               year
+    _type.purpose                 Number
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Integer
+    _units.code                   none
+
+save_
+
+save_JOURNAL_COEDITOR
+
+    _definition.id                JOURNAL_COEDITOR
+    _definition.scope             Category
+    _definition.class             Set
+    _definition.update            2021-08-18
+    _description.text
+;
+    Category of items recording coeditor details.
+;
+    _name.category_id             JOURNAL
+    _name.object_id               JOURNAL_COEDITOR
+
+save_
+
+save_journal_coeditor.address
+
+    _definition.id                '_journal_coeditor.address'
+
+    loop_
+      _alias.definition_id
+         '_journal_coeditor_address'
+         '_journal.coeditor_address'
+
+    _definition.update            2012-12-11
+    _description.text
+;
+    The postal address of the coeditor.
+;
+    _name.category_id             journal_coeditor
+    _name.object_id               address
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_journal_coeditor.code
+
+    _definition.id                '_journal_coeditor.code'
+
+    loop_
+      _alias.definition_id
+         '_journal_coeditor_code'
+         '_journal.coeditor_code'
+
+    _definition.update            2012-12-11
+    _description.text
+;
+    The coeditor identifier.
+;
+    _name.category_id             journal_coeditor
+    _name.object_id               code
+    _type.purpose                 Encode
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Code
+
+save_
+
+save_journal_coeditor.email
+
+    _definition.id                '_journal_coeditor.email'
+
+    loop_
+      _alias.definition_id
+         '_journal_coeditor_email'
+         '_journal.coeditor_email'
+
+    _definition.update            2012-12-11
+    _description.text
+;
+    The email address of the coeditor.
+;
+    _name.category_id             journal_coeditor
+    _name.object_id               email
+    _type.purpose                 Encode
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_journal_coeditor.fax
+
+    _definition.id                '_journal_coeditor.fax'
+
+    loop_
+      _alias.definition_id
+         '_journal_coeditor_fax'
+         '_journal.coeditor_fax'
+
+    _definition.update            2012-12-11
+    _description.text
+;
+    The fax number of the coeditor.
+;
+    _name.category_id             journal_coeditor
+    _name.object_id               fax
+    _type.purpose                 Encode
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_journal_coeditor.name
+
+    _definition.id                '_journal_coeditor.name'
+
+    loop_
+      _alias.definition_id
+         '_journal_coeditor_name'
+         '_journal.coeditor_name'
+
+    _definition.update            2012-12-11
+    _description.text
+;
+    The name of the coeditor.
+;
+    _name.category_id             journal_coeditor
+    _name.object_id               name
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_journal_coeditor.notes
+
+    _definition.id                '_journal_coeditor.notes'
+
+    loop_
+      _alias.definition_id
+         '_journal_coeditor_notes'
+         '_journal.coeditor_notes'
+
+    _definition.update            2012-12-11
+    _description.text
+;
+    Notes on coeditor interaction wrt this publication.
+;
+    _name.category_id             journal_coeditor
+    _name.object_id               notes
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_journal_coeditor.phone
+
+    _definition.id                '_journal_coeditor.phone'
+
+    loop_
+      _alias.definition_id
+         '_journal_coeditor_phone'
+         '_journal.coeditor_phone'
+
+    _definition.update            2012-12-11
+    _description.text
+;
+    The phone number of the coeditor.
+;
+    _name.category_id             journal_coeditor
+    _name.object_id               phone
+    _type.purpose                 Encode
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_JOURNAL_DATE
+
+    _definition.id                JOURNAL_DATE
+    _definition.scope             Category
+    _definition.class             Set
+    _definition.update            2012-12-11
+    _description.text
+;
+    Category of items recording dates of publication processing.
+;
+    _name.category_id             JOURNAL
+    _name.object_id               JOURNAL_DATE
+
+save_
+
+save_journal_date.accepted
+
+    _definition.id                '_journal_date.accepted'
+
+    loop_
+      _alias.definition_id
+         '_journal_date_accepted'
+         '_journal.date_accepted'
+
+    _definition.update            2021-03-03
+    _description.text
+;
+    Date when the publication was accepted.
+;
+    _name.category_id             journal_date
+    _name.object_id               accepted
+    _type.purpose                 Encode
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Date
+
+save_
+
+save_journal_date.from_coeditor
+
+    _definition.id                '_journal_date.from_coeditor'
+
+    loop_
+      _alias.definition_id
+         '_journal_date_from_coeditor'
+         '_journal.date_from_coeditor'
+
+    _definition.update            2021-03-03
+    _description.text
+;
+    Date when the publication was received from the coeditor.
+;
+    _name.category_id             journal_date
+    _name.object_id               from_coeditor
+    _type.purpose                 Encode
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Date
+
+save_
+
+save_journal_date.printers_final
+
+    _definition.id                '_journal_date.printers_final'
+
+    loop_
+      _alias.definition_id
+         '_journal_date_printers_final'
+         '_journal.date_printers_final'
+
+    _definition.update            2021-03-03
+    _description.text
+;
+    Date when the publication was last sent to the printers.
+;
+    _name.category_id             journal_date
+    _name.object_id               printers_final
+    _type.purpose                 Encode
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Date
+
+save_
+
+save_journal_date.printers_first
+
+    _definition.id                '_journal_date.printers_first'
+
+    loop_
+      _alias.definition_id
+         '_journal_date_printers_first'
+         '_journal.date_printers_first'
+
+    _definition.update            2021-03-03
+    _description.text
+;
+    Date when the publication was first sent to the printers.
+;
+    _name.category_id             journal_date
+    _name.object_id               printers_first
+    _type.purpose                 Encode
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Date
+
+save_
+
+save_journal_date.proofs_in
+
+    _definition.id                '_journal_date.proofs_in'
+
+    loop_
+      _alias.definition_id
+         '_journal_date_proofs_in'
+         '_journal.date_proofs_in'
+
+    _definition.update            2021-03-03
+    _description.text
+;
+    Date when the publication proofs were received.
+;
+    _name.category_id             journal_date
+    _name.object_id               proofs_in
+    _type.purpose                 Encode
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Date
+
+save_
+
+save_journal_date.proofs_out
+
+    _definition.id                '_journal_date.proofs_out'
+
+    loop_
+      _alias.definition_id
+         '_journal_date_proofs_out'
+         '_journal.date_proofs_out'
+
+    _definition.update            2021-03-03
+    _description.text
+;
+    Date when the publication proofs were sent out.
+;
+    _name.category_id             journal_date
+    _name.object_id               proofs_out
+    _type.purpose                 Encode
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Date
+
+save_
+
+save_journal_date.recd_copyright
+
+    _definition.id                '_journal_date.recd_copyright'
+
+    loop_
+      _alias.definition_id
+         '_journal_date_recd_copyright'
+         '_journal.date_recd_copyright'
+
+    _definition.update            2021-03-03
+    _description.text
+;
+    Date when the completed copyright was received.
+;
+    _name.category_id             journal_date
+    _name.object_id               recd_copyright
+    _type.purpose                 Encode
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Date
+
+save_
+
+save_journal_date.recd_electronic
+
+    _definition.id                '_journal_date.recd_electronic'
+
+    loop_
+      _alias.definition_id
+         '_journal_date_recd_electronic'
+         '_journal.date_recd_electronic'
+
+    _definition.update            2021-03-03
+    _description.text
+;
+    Date when the publication was received electronically.
+;
+    _name.category_id             journal_date
+    _name.object_id               recd_electronic
+    _type.purpose                 Encode
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Date
+
+save_
+
+save_journal_date.recd_hard_copy
+
+    _definition.id                '_journal_date.recd_hard_copy'
+
+    loop_
+      _alias.definition_id
+         '_journal_date_recd_hard_copy'
+         '_journal.date_recd_hard_copy'
+
+    _definition.update            2021-03-03
+    _description.text
+;
+    Date when the publication was received as hard copy.
+;
+    _name.category_id             journal_date
+    _name.object_id               recd_hard_copy
+    _type.purpose                 Encode
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Date
+
+save_
+
+save_journal_date.to_coeditor
+
+    _definition.id                '_journal_date.to_coeditor'
+
+    loop_
+      _alias.definition_id
+         '_journal_date_to_coeditor'
+         '_journal.date_to_coeditor'
+
+    _definition.update            2021-03-03
+    _description.text
+;
+    Date when the publication was sent to the coeditor.
+;
+    _name.category_id             journal_date
+    _name.object_id               to_coeditor
+    _type.purpose                 Encode
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Date
+
+save_
+
+save_JOURNAL_INDEX
+
+    _definition.id                JOURNAL_INDEX
+    _definition.scope             Category
+    _definition.class             Loop
+    _definition.update            2021-06-29
+    _description.text
+;
+    Category of items describing publication indices.
+;
+    _name.category_id             JOURNAL
+    _name.object_id               JOURNAL_INDEX
+    _category_key.name            '_journal_index.id'
+
+save_
+
+save_journal_index.id
+
+    _definition.id                '_journal_index.id'
+    _definition.update            2023-07-13
+    _description.text
+;
+    Unique identifier for a journal index entry.
+;
+    _name.category_id             journal_index
+    _name.object_id               id
+    _type.purpose                 Key
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Word
+
+save_
+
+save_journal_index.subterm
+
+    _definition.id                '_journal_index.subterm'
+    _alias.definition_id          '_journal_index_subterm'
+    _definition.update            2012-12-11
+    _description.text
+;
+    Sub-term index assigned for the publication.
+;
+    _name.category_id             journal_index
+    _name.object_id               subterm
+    _type.purpose                 Encode
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_journal_index.term
+
+    _definition.id                '_journal_index.term'
+    _alias.definition_id          '_journal_index_term'
+    _definition.update            2012-12-11
+    _description.text
+;
+    Term index assigned for the publication.
+;
+    _name.category_id             journal_index
+    _name.object_id               term
+    _type.purpose                 Encode
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_journal_index.type
+
+    _definition.id                '_journal_index.type'
+    _alias.definition_id          '_journal_index_type'
+    _definition.update            2021-07-07
+    _description.text
+;
+    Type of index assigned for the publication.
+;
+    _name.category_id             journal_index
+    _name.object_id               type
+    _type.purpose                 State
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Text
+
+    loop_
+      _enumeration_set.state
+      _enumeration_set.detail
+         O                        'Organic formula index.'
+         I                        'Inorganic formula index.'
+         M                        'Metal-organic formula index.'
+         S                        'Subject index.'
+
+    _enumeration.default          O
+
+save_
+
+save_JOURNAL_TECHEDITOR
+
+    _definition.id                JOURNAL_TECHEDITOR
+    _definition.scope             Category
+    _definition.class             Set
+    _definition.update            2012-12-11
+    _description.text
+;
+    Category of items recording details of the technical editor
+    processing this publication.
+;
+    _name.category_id             JOURNAL
+    _name.object_id               JOURNAL_TECHEDITOR
+
+save_
+
+save_journal_techeditor.address
+
+    _definition.id                '_journal_techeditor.address'
+
+    loop_
+      _alias.definition_id
+         '_journal_techeditor_address'
+         '_journal.techeditor_address'
+
+    _definition.update            2012-12-11
+    _description.text
+;
+    Postal address of the technical editor for this publication.
+;
+    _name.category_id             journal_techeditor
+    _name.object_id               address
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_journal_techeditor.code
+
+    _definition.id                '_journal_techeditor.code'
+
+    loop_
+      _alias.definition_id
+         '_journal_techeditor_code'
+         '_journal.techeditor_code'
+
+    _definition.update            2021-11-04
+    _description.text
+;
+    Code of the technical editor for this publication.
+;
+    _name.category_id             journal_techeditor
+    _name.object_id               code
+    _type.purpose                 Encode
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_journal_techeditor.email
+
+    _definition.id                '_journal_techeditor.email'
+
+    loop_
+      _alias.definition_id
+         '_journal_techeditor_email'
+         '_journal.techeditor_email'
+
+    _definition.update            2012-12-11
+    _description.text
+;
+    Email address of the technical editor for this publication.
+;
+    _name.category_id             journal_techeditor
+    _name.object_id               email
+    _type.purpose                 Encode
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_journal_techeditor.fax
+
+    _definition.id                '_journal_techeditor.fax'
+
+    loop_
+      _alias.definition_id
+         '_journal_techeditor_fax'
+         '_journal.techeditor_fax'
+
+    _definition.update            2012-12-11
+    _description.text
+;
+    Fax number of the technical editor for this publication.
+;
+    _name.category_id             journal_techeditor
+    _name.object_id               fax
+    _type.purpose                 Encode
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_journal_techeditor.name
+
+    _definition.id                '_journal_techeditor.name'
+
+    loop_
+      _alias.definition_id
+         '_journal_techeditor_name'
+         '_journal.techeditor_name'
+
+    _definition.update            2012-12-11
+    _description.text
+;
+    Name of the technical editor for this publication.
+;
+    _name.category_id             journal_techeditor
+    _name.object_id               name
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_journal_techeditor.notes
+
+    _definition.id                '_journal_techeditor.notes'
+
+    loop_
+      _alias.definition_id
+         '_journal_techeditor_notes'
+         '_journal.techeditor_notes'
+
+    _definition.update            2012-12-11
+    _description.text
+;
+    Notes of the technical editor for this publication.
+;
+    _name.category_id             journal_techeditor
+    _name.object_id               notes
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_journal_techeditor.phone
+
+    _definition.id                '_journal_techeditor.phone'
+
+    loop_
+      _alias.definition_id
+         '_journal_techeditor_phone'
+         '_journal.techeditor_phone'
+
+    _definition.update            2012-12-11
+    _description.text
+;
+    Phone number of the technical editor for this publication.
+;
+    _name.category_id             journal_techeditor
+    _name.object_id               phone
+    _type.purpose                 Encode
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_PUBL
+
+    _definition.id                PUBL
+    _definition.scope             Category
+    _definition.class             Set
+    _definition.update            2012-05-07
+    _description.text
+;
+    Data items in the PUBL category are used when submitting a
+    manuscript for publication. They refer either to the paper as
+    a whole, or to specific named elements within a paper (such as
+    the title and abstract, or the Comment and Experimental
+    sections of Acta Crystallographica Section C). The data items
+    in the PUBL_BODY category should be used for the textual
+    content of other submissions. Typically, each journal will
+    supply a list of the specific items it requires in its Notes
+    for Authors.
+;
+    _name.category_id             PUBLICATION
+    _name.object_id               PUBL
+
+save_
+
+save_publ.contact_letter
+
+    _definition.id                '_publ.contact_letter'
+    _alias.definition_id          '_publ_contact_letter'
+    _definition.update            2012-11-29
+    _description.text
+;
+    A letter submitted to the journal editor by the contact author.
+;
+    _name.category_id             publ
+    _name.object_id               contact_letter
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_PUBL_AUTHOR
+
+    _definition.id                PUBL_AUTHOR
+    _definition.scope             Category
+    _definition.class             Loop
+    _definition.update            2021-06-29
+    _description.text
+;
+    Category of data items recording the author information.
+;
+    _name.category_id             PUBL
+    _name.object_id               PUBL_AUTHOR
+    _category_key.name            '_publ_author.id'
+
+save_
+
+save_publ_author.address
+
+    _definition.id                '_publ_author.address'
+    _alias.definition_id          '_publ_author_address'
+    _definition.update            2019-01-09
+    _description.text
+;
+    The address of a publication author. If there is more than one
+    author, this will be looped with _publ_author.name.
+;
+    _name.category_id             publ_author
+    _name.object_id               address
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+    _description_example.case
+;
+    Department
+    Institute
+    Street
+    City and postcode
+    COUNTRY
+;
+
+save_
+
+save_publ_author.email
+
+    _definition.id                '_publ_author.email'
+    _alias.definition_id          '_publ_author_email'
+    _definition.update            2019-01-09
+    _description.text
+;
+    The e-mail address of a publication author. If there is more
+    than one author, this will be looped with _publ_author.name.
+    The format of e-mail addresses is given in Section 3.4, Address
+    Specification, of Internet Message Format, RFC 2822, P. Resnick
+    (Editor), Network Standards Group, April 2001.
+;
+    _name.category_id             publ_author
+    _name.object_id               email
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_publ_author.footnote
+
+    _definition.id                '_publ_author.footnote'
+    _alias.definition_id          '_publ_author_footnote'
+    _definition.update            2012-12-13
+    _description.text
+;
+    A footnote accompanying an author's name in the list of authors
+    of a paper. Typically indicates sabbatical address, additional
+    affiliations or date of decease.
+;
+    _name.category_id             publ_author
+    _name.object_id               footnote
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_publ_author.id
+
+    _definition.id                '_publ_author.id'
+    _definition.update            2023-02-02
+    _description.text
+;
+    Arbitrary identifier for this author.
+;
+    _name.category_id             publ_author
+    _name.object_id               id
+    _type.purpose                 Key
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Word
+    _method.purpose               Definition
+    _method.expression
+;
+    _enumeration.default = Unique_id(publ_author.id)
+;
+
+save_
+
+save_publ_author.id_audit
+
+    _definition.id                '_publ_author.id_audit'
+    _definition.update            2023-02-02
+    _description.text
+;
+    Identifier corresponding to this author in the AUDIT_AUTHOR category list,
+    if present.
+;
+    _name.category_id             publ_author
+    _name.object_id               id_audit
+    _name.linked_item_id          '_audit_author.id'
+    _type.purpose                 Link
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Word
+
+save_
+
+save_publ_author.id_iucr
+
+    _definition.id                '_publ_author.id_IUCr'
+    _alias.definition_id          '_publ_author_id_IUCr'
+    _definition.update            2023-02-02
+    _description.text
+;
+    Identifier in the IUCr contact database of a publication
+    author. This identifier may be available from the World
+    Directory of Crystallographers (http://wdc.iucr.org).
+;
+    _name.category_id             publ_author
+    _name.object_id               id_IUCr
+    _type.purpose                 Encode
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Word
+
+save_
+
+save_publ_author.id_orcid
+
+    _definition.id                '_publ_author.id_ORCID'
+    _alias.definition_id          '_publ_author_id_ORCID'
+    _definition.update            2023-02-02
+    _description.text
+;
+    Identifier in the ORCID Registry of a publication
+    author. ORCID is an open, non-profit, community-driven
+    service to provide a registry of unique researcher
+    identifiers (https://orcid.org/).
+;
+    _name.category_id             publ_author
+    _name.object_id               id_ORCID
+    _type.purpose                 Encode
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Code
+    _description_example.case     0000-0003-0391-0002
+
+save_
+
+save_publ_author.name
+
+    _definition.id                '_publ_author.name'
+    _alias.definition_id          '_publ_author_name'
+    _definition.update            2023-01-10
+    _description.text
+;
+    The name of a publication author. If there are multiple authors,
+    this will be looped with _publ_author.address. The family
+    name(s), followed by a comma and including any dynastic
+    components, precedes the first names or initials. For authors
+    with only one name, provide the full name without abbreviation.
+;
+    _name.category_id             publ_author
+    _name.object_id               name
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+
+    loop_
+      _description_example.case
+         "Bleary, Percival R."
+         "O'Neil, F.K."
+         "Van den Bossche, G."
+         "Yang, D.-L."
+         "Simonov, Yu.A"
+         "Müller, H.A."
+         "Ross II, C.R."
+         "Chandra"
+
+save_
+
+save_publ_author.phone
+
+    _definition.id                '_publ_author.phone'
+    _alias.definition_id          '_publ_author_phone'
+    _definition.update            2014-06-12
+    _description.text
+;
+    Telephone number of the author submitting the manuscript and
+    data block.
+
+    The recommended style starts with the international dialing
+    prefix, followed by the area code in parentheses, followed by the
+    local number and any extension number prefixed by 'x',
+    with no spaces. The earlier convention of including
+    the international dialing prefix in parentheses is no longer
+    recommended.
+;
+    _name.category_id             publ_author
+    _name.object_id               phone
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+
+    loop_
+      _description_example.case
+         12(34)9477330
+         12()349477330
+         12(34)9477330x5543
+
+save_
+
+save_PUBL_BODY
+
+    _definition.id                PUBL_BODY
+    _definition.scope             Category
+    _definition.class             Loop
+    _definition.update            2021-06-29
+    _description.text
+;
+    Data items in the PUBL_BODY category permit labelling of
+    different text sections within the body of a submitted paper.
+    Note that these should not be used in a paper which has
+    a standard format with sections tagged by specific data names
+    (such as in Acta Crystallographica Section C). Typically,
+    each journal will supply a list of the specific items it
+    requires in its Notes for Authors.
+;
+    _name.category_id             PUBL
+    _name.object_id               PUBL_BODY
+    _category_key.name            '_publ_body.label'
+
+save_
+
+save_publ_body.contents
+
+    _definition.id                '_publ_body.contents'
+    _alias.definition_id          '_publ_body_contents'
+    _definition.update            2012-12-13
+    _description.text
+;
+    A text section of a submitted paper.
+;
+    _name.category_id             publ_body
+    _name.object_id               contents
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_publ_body.element
+
+    _definition.id                '_publ_body.element'
+    _alias.definition_id          '_publ_body_element'
+    _definition.update            2012-12-13
+    _description.text
+;
+    The functional role of the associated text section.
+;
+    _name.category_id             publ_body
+    _name.object_id               element
+    _type.purpose                 State
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Text
+
+    loop_
+      _enumeration_set.state
+         section
+         subsection
+         subsubsection
+         appendix
+         footnote
+
+    _enumeration.default          section
+
+save_
+
+save_publ_body.format
+
+    _definition.id                '_publ_body.format'
+    _alias.definition_id          '_publ_body_format'
+    _definition.update            2012-12-13
+    _description.text
+;
+    Enumerated state indicating the appropriate typesetting
+    conventions for accented characters and special symbols
+    in the text section.
+;
+    _name.category_id             publ_body
+    _name.object_id               format
+    _type.purpose                 State
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Text
+
+    loop_
+      _enumeration_set.state
+      _enumeration_set.detail
+         ascii                    'No coding for special symbols.'
+         cif                      'CIF convention.'
+         latex                    'LaTeX.'
+         rtf                      'Rich Text Format.'
+         sgml                     'SGML (ISO 8879).'
+         tex                      'TeX.'
+         troff                    'troff or nroff.'
+
+    _enumeration.default          cif
+
+save_
+
+save_publ_body.label
+
+    _definition.id                '_publ_body.label'
+    _alias.definition_id          '_publ_body_label'
+    _definition.update            2021-10-27
+    _description.text
+;
+    Unique identifier for each part of the body of the paper.
+;
+    _name.category_id             publ_body
+    _name.object_id               label
+    _type.purpose                 Encode
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Word
+
+    loop_
+      _description_example.case
+         1
+         1.1
+         2.1.3
+
+save_
+
+save_publ_body.title
+
+    _definition.id                '_publ_body.title'
+    _alias.definition_id          '_publ_body_title'
+    _definition.update            2012-12-13
+    _description.text
+;
+    Title of the associated section of text.
+;
+    _name.category_id             publ_body
+    _name.object_id               title
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_PUBL_CONTACT_AUTHOR
+
+    _definition.id                PUBL_CONTACT_AUTHOR
+    _definition.scope             Category
+    _definition.class             Loop
+    _definition.update            2021-06-29
+    _description.text
+;
+    Category of items describing contact author(s) details.
+;
+    _name.category_id             PUBL
+    _name.object_id               PUBL_CONTACT_AUTHOR
+    _category_key.name            '_publ_contact_author.id'
+
+save_
+
+save_publ_contact_author.address
+
+    _definition.id                '_publ_contact_author.address'
+
+    loop_
+      _alias.definition_id
+         '_publ_contact_author_address'
+         '_publ.contact_author_address'
+
+    _definition.update            2012-11-29
+    _description.text
+;
+    The address of the author submitting the manuscript and
+    data block. This is the person contacted by the journal
+    editorial staff.
+;
+    _name.category_id             publ_contact_author
+    _name.object_id               address
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+    _description_example.case
+;
+    Department of Chemistry and Biochemistry
+    University of Guelph
+    Ontario
+    Canada
+    N1G 2W1
+;
+
+save_
+
+save_publ_contact_author.contact_details
+
+    _definition.id                '_publ_contact_author.contact_details'
+
+    loop_
+      _definition_replaced.id
+      _definition_replaced.by
+         1                        '_publ_contact_author.name'
+         2                        '_publ_contact_author.address'
+
+    loop_
+      _alias.definition_id
+         '_publ_contact_author'
+         '_publ.contact_author'
+
+    _definition.update            2024-08-28
+    _description.text
+;
+    DEPRECATED. The _publ_contact_author.name and _publ_contact_author.address
+    data items should be used instead of this item.
+
+    The name and address of the author submitting the manuscript and data block.
+    This is the person contacted by the journal editorial staff.
+;
+    _name.category_id             publ_contact_author
+    _name.object_id               contact_details
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+    _description_example.case
+;
+    Professor George Ferguson
+    Department of Chemistry and Biochemistry
+    University of Guelph
+    Ontario
+    Canada
+    N1G 2W1
+;
+
+save_
+
+save_publ_contact_author.email
+
+    _definition.id                '_publ_contact_author.email'
+
+    loop_
+      _alias.definition_id
+         '_publ_contact_author_email'
+         '_publ.contact_author_email'
+
+    _definition.update            2014-06-12
+    _description.text
+;
+    E-mail address in a form recognizable to international networks.
+    The format of e-mail addresses is given in Section 3.4, Address
+    Specification, of Internet Message Format, RFC 2822, P. Resnick
+    (Editor), Network Standards Group, April 2001.
+;
+    _name.category_id             publ_contact_author
+    _name.object_id               email
+    _type.purpose                 Encode
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+
+    loop_
+      _description_example.case
+         name@host.domain.country
+         banjo.patterson@gulgong.edu.au
+
+save_
+
+save_publ_contact_author.fax
+
+    _definition.id                '_publ_contact_author.fax'
+
+    loop_
+      _alias.definition_id
+         '_publ_contact_author_fax'
+         '_publ.contact_author_fax'
+
+    _definition.update            2012-11-29
+    _description.text
+;
+    Facsimile telephone number of the author submitting the manuscript
+    and data block.
+    The recommended style is the international dialing prefix, followed
+    by the area code in parentheses, followed by the local number with
+    no spaces. The earlier convention of including the international
+    dialing prefix in parentheses is no longer recommended.
+;
+    _name.category_id             publ_contact_author
+    _name.object_id               fax
+    _type.purpose                 Encode
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_publ_contact_author.id
+
+    _definition.id                '_publ_contact_author.id'
+    _definition.update            2023-02-02
+    _description.text
+;
+    Arbitrary identifier for this author.
+;
+    _name.category_id             publ_contact_author
+    _name.object_id               id
+    _name.linked_item_id          '_publ_author.id'
+    _type.purpose                 Link
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Word
+    _method.purpose               Definition
+    _method.expression
+;
+    with pca as publ_contact_author
+    count = 0
+    target = ''
+    loop pa as publ_author {
+        if (pca.name == pa.name) {
+            count++
+            target = pa.id
+            }
+        }
+    if (count == 1) {
+        _enumeration.default = target
+        }
+    else {
+        _enumeration.default = missing
+    }
+;
+
+save_
+
+save_publ_contact_author.id_iucr
+
+    _definition.id                '_publ_contact_author.id_IUCr'
+    _alias.definition_id          '_publ_contact_author_id_IUCr'
+    _definition.update            2023-02-02
+    _description.text
+;
+    Identifier in the IUCr contact database of the author submitting
+    the manuscript and data block. This identifier may be available
+    from the World Directory of Crystallographers (https://wdc.iucr.org/).
+;
+    _name.category_id             publ_contact_author
+    _name.object_id               id_IUCr
+    _type.purpose                 Encode
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Word
+
+save_
+
+save_publ_contact_author.id_orcid
+
+    _definition.id                '_publ_contact_author.id_ORCID'
+    _alias.definition_id          '_publ_contact_author_id_ORCID'
+    _definition.update            2023-02-02
+    _description.text
+;
+    Identifier in the ORCID Registry of the author submitting
+    the manuscript and data block. ORCID is an open, non-profit,
+    community-driven service to provide a registry of unique
+    researcher identifiers (https://orcid.org/).
+;
+    _name.category_id             publ_contact_author
+    _name.object_id               id_ORCID
+    _type.purpose                 Encode
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Code
+    _description_example.case     0000-0003-0391-0002
+
+save_
+
+save_publ_contact_author.name
+
+    _definition.id                '_publ_contact_author.name'
+
+    loop_
+      _alias.definition_id
+         '_publ_contact_author_name'
+         '_publ.contact_author_name'
+
+    _definition.update            2012-11-29
+    _description.text
+;
+    The name of the author(s) submitting the manuscript and
+    data block. This is the person contacted by the journal
+    editorial staff.
+;
+    _name.category_id             publ_contact_author
+    _name.object_id               name
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+    _description_example.case     'Professor George Ferguson'
+
+save_
+
+save_publ_contact_author.phone
+
+    _definition.id                '_publ_contact_author.phone'
+
+    loop_
+      _alias.definition_id
+         '_publ_contact_author_phone'
+         '_publ.contact_author_phone'
+
+    _definition.update            2012-11-29
+    _description.text
+;
+    Telephone number of author submitting the manuscript and data block.
+    The recommended style is the international dialing prefix,
+    followed by the area code in parentheses, followed by the
+    local number and any extension number prefixed by 'x', with
+    no spaces. The earlier convention of including the international
+    dialing prefix in parentheses is no longer recommended.
+;
+    _name.category_id             publ_contact_author
+    _name.object_id               phone
+    _type.purpose                 Encode
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+
+    loop_
+      _description_example.case
+         12(34)9477330
+         12()349477330
+         12(34)9477330x5543
+
+save_
+
+save_PUBL_MANUSCRIPT
+
+    _definition.id                PUBL_MANUSCRIPT
+    _definition.scope             Category
+    _definition.class             Set
+    _definition.update            2012-12-13
+    _description.text
+;
+    Category of items describing the publication manuscript.
+;
+    _name.category_id             PUBL
+    _name.object_id               PUBL_MANUSCRIPT
+
+save_
+
+save_publ_manuscript.creation
+
+    _definition.id                '_publ_manuscript.creation'
+
+    loop_
+      _alias.definition_id
+         '_publ_manuscript_creation'
+         '_publ.manuscript_creation'
+
+    _definition.update            2023-01-13
+    _description.text
+;
+    A description of the word processor package and computer used to
+    create the manuscript stored as _publ_manuscript.processed.
+;
+    _name.category_id             publ_manuscript
+    _name.object_id               creation
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_publ_manuscript.processed
+
+    _definition.id                '_publ_manuscript.processed'
+
+    loop_
+      _alias.definition_id
+         '_publ_manuscript_processed'
+         '_publ.manuscript_processed'
+
+    _definition.update            2012-11-29
+    _description.text
+;
+    The full manuscript of a paper (excluding possibly the figures
+    and the tables) output in ASCII characters from a word processor.
+    Information about the generation of this data item must be
+    specified in the data item _publ_manuscript.creation.
+;
+    _name.category_id             publ_manuscript
+    _name.object_id               processed
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_publ_manuscript.text
+
+    _definition.id                '_publ_manuscript.text'
+
+    loop_
+      _alias.definition_id
+         '_publ_manuscript_text'
+         '_publ.manuscript_text'
+
+    _definition.update            2012-11-29
+    _description.text
+;
+    The full manuscript of a paper (excluding figures and possibly
+    the tables) output as standard ASCII text.
+;
+    _name.category_id             publ_manuscript
+    _name.object_id               text
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_PUBL_MANUSCRIPT_INCL_EXTRA
+
+    _definition.id                PUBL_MANUSCRIPT_INCL_EXTRA
+    _definition.scope             Category
+    _definition.class             Loop
+    _definition.update            2021-06-29
+    _description.text
+;
+    Category of data items that allow the authors of a manuscript to
+    submit for publication data names that should be added to the
+    standard request list employed by journal printing software.
+    Although these fields are primarily intended to identify CIF data
+    items that the author wishes to include in a published paper, they
+    can also be used to identify data names created so that non-CIF items
+    can be included in the publication. Note that *.item names MUST be
+    enclosed in single quotes.
+;
+    _name.category_id             PUBL_MANUSCRIPT
+    _name.object_id               PUBL_MANUSCRIPT_INCL_EXTRA
+    _category_key.name            '_publ_manuscript_incl_extra.item'
+
+save_
+
+save_publ_manuscript_incl_extra.defn
+
+    _definition.id                '_publ_manuscript_incl_extra.defn'
+
+    loop_
+      _alias.definition_id
+         '_publ_manuscript_incl_extra_defn'
+         '_publ_manuscript_incl.extra_defn'
+
+    _definition.update            2012-12-13
+    _description.text
+;
+    Yes/No flags whether the corresponding data item marked for inclusion
+    in a journal request list is a standard CIF definition or not.
+;
+    _name.category_id             publ_manuscript_incl_extra
+    _name.object_id               defn
+    _type.purpose                 State
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Text
+
+    loop_
+      _enumeration_set.state
+      _enumeration_set.detail
+         yes                      'Include item in journal request list.'
+         y                        'Include item in journal request list.'
+         no                       'Exclude item in journal request list.'
+         n                        'Exclude item in journal request list.'
+
+    _enumeration.default          yes
+
+save_
+
+save_publ_manuscript_incl_extra.info
+
+    _definition.id                '_publ_manuscript_incl_extra.info'
+
+    loop_
+      _alias.definition_id
+         '_publ_manuscript_incl_extra_info'
+         '_publ_manuscript_incl.extra_info'
+
+    _definition.update            2012-12-13
+    _description.text
+;
+    A short note indicating the reason why the author wishes the
+    corresponding data item marked for inclusion in the journal
+    request list to be published.
+;
+    _name.category_id             publ_manuscript_incl_extra
+    _name.object_id               info
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_publ_manuscript_incl_extra.item
+
+    _definition.id                '_publ_manuscript_incl_extra.item'
+
+    loop_
+      _alias.definition_id
+         '_publ_manuscript_incl_extra_item'
+         '_publ_manuscript_incl.extra_item'
+
+    _definition.update            2012-12-13
+    _description.text
+;
+    The data name (i.e. Tag) of a specific data item included in the
+    manuscript which is not normally requested by the journal. The values
+    of this item are the extra data names (which MUST be enclosed
+    in single quotes) that will be added to the journal request list.
+;
+    _name.category_id             publ_manuscript_incl_extra
+    _name.object_id               item
+    _type.purpose                 Encode
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Tag
+
+save_
+
+save_PUBL_REQUESTED
+
+    _definition.id                PUBL_REQUESTED
+    _definition.scope             Category
+    _definition.class             Set
+    _definition.update            2012-12-13
+    _description.text
+;
+    CATEGORY of data items that enable the author to make
+    specific requests to the journal office for processing.
+;
+    _name.category_id             PUBL
+    _name.object_id               PUBL_REQUESTED
+
+save_
+
+save_publ_requested.category
+
+    _definition.id                '_publ_requested.category'
+
+    loop_
+      _alias.definition_id
+         '_publ_requested_category'
+         '_publ.requested_category'
+
+    _definition.update            2012-12-13
+    _description.text
+;
+    The category of paper submitted. For submission to Acta
+    Crystallographica Section C or Acta Crystallographica
+    Section E, ONLY those codes indicated for use with those
+    journals should be used.
+;
+    _name.category_id             publ_requested
+    _name.object_id               category
+    _type.purpose                 State
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Text
+
+    loop_
+      _enumeration_set.state
+      _enumeration_set.detail
+         AD     'Addenda and Errata (Acta C, Acta E).'
+         CI     'CIF-access paper - inorganic (Acta C) (no longer in use).'
+         CM     'CIF-access paper - metal-organic (Acta C) (no longer in use).'
+         CO     'CIF-access paper - organic (Acta C)  (no longer in use).'
+         EI     'Electronic submission - inorganic (Acta E).'
+         EM     'Electronic submission - metal-organic (Acta E).'
+         EO     'Electronic submission - organic (Acta E).'
+         FA     'Full article.'
+         FI     'Full submission - inorganic (Acta C).'
+         FM     'Full submission - metal-organic (Acta C).'
+         FO     'Full submission - organic (Acta C).'
+         GI     'Research communications - inorganic compounds (Acta E).'
+         GM     'Research communications - metal-organic compounds (Acta E).'
+         GO     'Research communications - organic compounds (Acta E).'
+         HI     'Data reports - inorganic compounds (Acta E).'
+         HM     'Data reports - metal-organic compounds (Acta E).'
+         HO     'Data reports - organic compounds (Acta E).'
+         QI     'Inorganic compounds (Acta E).'
+         QM     'Metal-organic compounds (Acta E).'
+         QO     'Organic compounds (Acta E).'
+         SC     'Short communication.'
+
+    _enumeration.default          FA
+
+save_
+
+save_publ_requested.coeditor_name
+
+    _definition.id                '_publ_requested.coeditor_name'
+
+    loop_
+      _alias.definition_id
+         '_publ_requested_coeditor_name'
+         '_publ.requested_coeditor_name'
+
+    _definition.update            2021-08-18
+    _description.text
+;
+    The name of the coeditor whom the authors would like to
+    process the submitted manuscript.
+;
+    _name.category_id             publ_requested
+    _name.object_id               coeditor_name
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_publ_requested.journal
+
+    _definition.id                '_publ_requested.journal'
+
+    loop_
+      _alias.definition_id
+         '_publ_requested_journal'
+         '_publ.requested_journal'
+
+    _definition.update            2012-12-13
+    _description.text
+;
+    Name of the journal to which the manuscript is being submitted.
+;
+    _name.category_id             publ_requested
+    _name.object_id               journal
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_PUBL_SECTION
+
+    _definition.id                PUBL_SECTION
+    _definition.scope             Category
+    _definition.class             Set
+    _definition.update            2012-05-07
+    _description.text
+;
+    Manuscript section data if submitted in parts. See also
+    _publ_manuscript.text and _publ_manuscript.processed.
+    The _publ_section.exptl_prep, _publ_section.exptl_refinement
+    and _publ_section.exptl_solution items are preferred for
+    separating the chemical preparation, refinement and structure
+    solution aspects of the experimental description.
+;
+    _name.category_id             PUBL
+    _name.object_id               PUBL_SECTION
+
+save_
+
+save_publ_section.abstract
+
+    _definition.id                '_publ_section.abstract'
+
+    loop_
+      _alias.definition_id
+         '_publ_section_abstract'
+         '_publ.section_abstract'
+
+    _definition.update            2012-11-29
+    _description.text
+;
+    The abstract of the submitted paper.
+;
+    _name.category_id             publ_section
+    _name.object_id               abstract
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_publ_section.acknowledgements
+
+    _definition.id                '_publ_section.acknowledgements'
+
+    loop_
+      _alias.definition_id
+         '_publ_section_acknowledgements'
+         '_publ.section_acknowledgements'
+
+    _definition.update            2012-11-29
+    _description.text
+;
+    The acknowledgements section of the submitted paper.
+;
+    _name.category_id             publ_section
+    _name.object_id               acknowledgements
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_publ_section.comment
+
+    _definition.id                '_publ_section.comment'
+
+    loop_
+      _alias.definition_id
+         '_publ_section_comment'
+         '_publ.section_comment'
+
+    _definition.update            2013-02-22
+    _description.text
+;
+    The comment section of the submitted paper.
+;
+    _name.category_id             publ_section
+    _name.object_id               comment
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_publ_section.discussion
+
+    _definition.id                '_publ_section.discussion'
+
+    loop_
+      _alias.definition_id
+         '_publ_section_discussion'
+         '_publ.section_discussion'
+
+    _definition.update            2012-11-29
+    _description.text
+;
+    The discussion section of the submitted paper.
+;
+    _name.category_id             publ_section
+    _name.object_id               discussion
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_publ_section.experimental
+
+    _definition.id                '_publ_section.experimental'
+
+    loop_
+      _alias.definition_id
+         '_publ_section_experimental'
+         '_publ.section_experimental'
+
+    _definition.update            2012-11-29
+    _description.text
+;
+    The experimental section of the submitted paper.
+;
+    _name.category_id             publ_section
+    _name.object_id               experimental
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_publ_section.exptl_prep
+
+    _definition.id                '_publ_section.exptl_prep'
+
+    loop_
+      _alias.definition_id
+         '_publ_section_exptl_prep'
+         '_publ.section_exptl_prep'
+
+    _definition.update            2012-11-29
+    _description.text
+;
+    The experimental preparation section of the submitted paper.
+;
+    _name.category_id             publ_section
+    _name.object_id               exptl_prep
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_publ_section.exptl_refinement
+
+    _definition.id                '_publ_section.exptl_refinement'
+
+    loop_
+      _alias.definition_id
+         '_publ_section_exptl_refinement'
+         '_publ.section_exptl_refinement'
+
+    _definition.update            2012-11-29
+    _description.text
+;
+    The experimental refinement section of the submitted paper.
+;
+    _name.category_id             publ_section
+    _name.object_id               exptl_refinement
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_publ_section.exptl_solution
+
+    _definition.id                '_publ_section.exptl_solution'
+
+    loop_
+      _alias.definition_id
+         '_publ_section_exptl_solution'
+         '_publ.section_exptl_solution'
+
+    _definition.update            2012-11-29
+    _description.text
+;
+    The experimental solution section of the submitted paper.
+;
+    _name.category_id             publ_section
+    _name.object_id               exptl_solution
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_publ_section.figure_captions
+
+    _definition.id                '_publ_section.figure_captions'
+
+    loop_
+      _alias.definition_id
+         '_publ_section_figure_captions'
+         '_publ.section_figure_captions'
+
+    _definition.update            2012-11-29
+    _description.text
+;
+    The figure captions of the submitted paper.
+;
+    _name.category_id             publ_section
+    _name.object_id               figure_captions
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_publ_section.introduction
+
+    _definition.id                '_publ_section.introduction'
+
+    loop_
+      _alias.definition_id
+         '_publ_section_introduction'
+         '_publ.section_introduction'
+
+    _definition.update            2012-11-29
+    _description.text
+;
+    The introduction section of the submitted paper.
+;
+    _name.category_id             publ_section
+    _name.object_id               introduction
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_publ_section.keywords
+
+    _definition.id                '_publ_section.keywords'
+
+    loop_
+      _alias.definition_id
+         '_publ_section_keywords'
+         '_publ.section_keywords'
+
+    _definition.update            2012-11-29
+    _description.text
+;
+    The keywords of the submitted paper.
+;
+    _name.category_id             publ_section
+    _name.object_id               keywords
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_publ_section.references
+
+    _definition.id                '_publ_section.references'
+
+    loop_
+      _alias.definition_id
+         '_publ_section_references'
+         '_publ.section_references'
+
+    _definition.update            2012-11-29
+    _description.text
+;
+    The references section of the submitted paper.
+;
+    _name.category_id             publ_section
+    _name.object_id               references
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_publ_section.related_literature
+
+    _definition.id                '_publ_section.related_literature'
+
+    loop_
+      _alias.definition_id
+         '_publ_section_related_literature'
+         '_publ.section_related_literature'
+
+    _definition.update            2012-11-29
+    _description.text
+;
+    The related literature section of the submitted paper.
+;
+    _name.category_id             publ_section
+    _name.object_id               related_literature
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_publ_section.synopsis
+
+    _definition.id                '_publ_section.synopsis'
+
+    loop_
+      _alias.definition_id
+         '_publ_section_synopsis'
+         '_publ.section_synopsis'
+
+    _definition.update            2012-11-29
+    _description.text
+;
+    The synopsis of the submitted paper.
+;
+    _name.category_id             publ_section
+    _name.object_id               synopsis
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_publ_section.table_legends
+
+    _definition.id                '_publ_section.table_legends'
+
+    loop_
+      _alias.definition_id
+         '_publ_section_table_legends'
+         '_publ.section_table_legends'
+
+    _definition.update            2012-11-29
+    _description.text
+;
+    The table legends of the submitted paper.
+;
+    _name.category_id             publ_section
+    _name.object_id               table_legends
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_publ_section.title
+
+    _definition.id                '_publ_section.title'
+
+    loop_
+      _alias.definition_id
+         '_publ_section_title'
+         '_publ.section_title'
+
+    _definition.update            2012-11-29
+    _description.text
+;
+    The full title of the submitted paper.
+;
+    _name.category_id             publ_section
+    _name.object_id               title
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_publ_section.title_footnote
+
+    _definition.id                '_publ_section.title_footnote'
+
+    loop_
+      _alias.definition_id
+         '_publ_section_title_footnote'
+         '_publ.section_title_footnote'
+
+    _definition.update            2012-11-29
+    _description.text
+;
+    Footnote (if any) to the title of the submitted paper.
+;
+    _name.category_id             publ_section
+    _name.object_id               title_footnote
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_STRUCTURE
+
+    _definition.id                STRUCTURE
+    _definition.scope             Category
+    _definition.class             Set
+    _definition.update            2024-05-15
+    _description.text
+;
+    The DICTIONARY group encompassing the CORE STRUCTURE data items defined
+    and used within the Crystallographic Information Framework (CIF).
+;
+    _name.category_id             CIF_CORE_HEAD
+    _name.object_id               STRUCTURE
+
+save_
+
+save_ATOM
+
+    _definition.id                ATOM
+    _definition.scope             Category
+    _definition.class             Set
+    _definition.update            2012-11-20
+    _description.text
+;
+    The CATEGORY of data items used to describe atomic information
+    used in crystallographic structure studies.
+;
+    _name.category_id             STRUCTURE
+    _name.object_id               ATOM
+
+save_
+
+save_ATOM_ANALYTICAL
+
+    _definition.id                ATOM_ANALYTICAL
+    _definition.scope             Category
+    _definition.class             Loop
+    _definition.update            2022-11-19
+    _description.text
+;
+    The CATEGORY of data items used to describe elemental
+    composition information used in crystallographic
+    structure studies.
+;
+    _name.category_id             ATOM
+    _name.object_id               ATOM_ANALYTICAL
+    _category_key.name            '_atom_analytical.id'
+    _description_example.case
+;
+    loop_
+    _atom_analytical.id
+    _atom_analytical.analyte
+    _atom_analytical.meas_id
+    _atom_analytical.chemical_species
+    _atom_analytical.analyte_mass_percent
+    _atom_analytical.chemical_species_mass_percent
+    1 Si  a 'Si O2'   ?     22.7
+    2 Al  a 'Al2 O3'  ?     27.4
+    3 Ti  b 'Ti O2'   ?      2.7
+    4 Si  c .         10.5  .
+    5 Si  d Si        11.7  11.7
+;
+    _description_example.detail
+;
+    There are three separate determinations of Si content, and one each
+    of Al and Ti. The amount of Al is reported as the mass percent of
+    Al2O3. The equivalent amount of Al is not given. There are four
+    different measurements presented in this table.
+;
+
+save_
+
+save_atom_analytical.analyte
+
+    _definition.id                '_atom_analytical.analyte'
+    _definition.update            2022-11-19
+    _description.text
+;
+    Symbol of the element for which a particular composition
+    refers to, as given by _atom_analytical.analyte_mass_percent.
+;
+    _name.category_id             atom_analytical
+    _name.object_id               analyte
+    _type.purpose                 State
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Word
+
+    _import.get
+        [{'file':templ_enum.cif  'save':element_symbol}]
+
+save_
+
+save_atom_analytical.analyte_mass_percent
+
+    _definition.id                '_atom_analytical.analyte_mass_percent'
+    _definition.update            2022-11-19
+    _description.text
+;
+    Mass percentage of the analyte element derived from elemental analysis.
+;
+    _name.category_id             atom_analytical
+    _name.object_id               analyte_mass_percent
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:100.0
+    _units.code                   none
+
+save_
+
+save_atom_analytical.analyte_mass_percent_su
+
+    _definition.id                '_atom_analytical.analyte_mass_percent_su'
+    _definition.update            2023-07-01
+    _description.text
+;
+    Standard uncertainty of _atom_analytical.analyte_mass_percent.
+;
+    _name.category_id             atom_analytical
+    _name.object_id               analyte_mass_percent_su
+    _name.linked_item_id          '_atom_analytical.analyte_mass_percent'
+    _units.code                   none
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+save_
+
+save_atom_analytical.chemical_species
+
+    _definition.id                '_atom_analytical.chemical_species'
+    _definition.update            2023-01-13
+    _description.text
+;
+    Chemical formula of the species for which the corresponding
+    _atom_analytical.chemical_species_mass_percent refers.
+
+    The following rules apply in the construction of the formula:
+
+    1. Only recognized element symbols may be used.
+
+    2. The first element corresponds to the analyte. The remaining
+       elements should be given in alphabetical order by symbol.
+
+    3. Each element symbol is followed by a 'count' number. A count of
+       '1' may be omitted.
+
+    4. A space or parenthesis must separate each cluster of (element
+       symbol + count). A formula cannot begin with a paranthesis.
+
+    5. Where a group of elements is enclosed in parentheses, the
+       multiplier for the group must follow the closing parentheses.
+       That is, all element and group multipliers are assumed to be
+       printed as subscripted numbers.
+;
+    _name.category_id             atom_analytical
+    _name.object_id               chemical_species
+    _type.purpose                 Encode
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Text
+
+    loop_
+      _description_example.case
+         'Fe2 O3'
+         'Li'
+         'Si O2'
+         'Ca S O4 (H2 O)2'
+
+save_
+
+save_atom_analytical.chemical_species_mass_percent
+
+    _definition.id
+        '_atom_analytical.chemical_species_mass_percent'
+    _definition.update            2022-11-19
+    _description.text
+;
+    Mass percentage of the chemical species given in
+    _atom_analytical.chemical_species as derived from elemental analysis.
+
+    This is most often used in elemental compositions determined by XRF,
+    where elements are reported as equivalent mass percentages of their
+    relevant oxide. For example: Al is reported as Al2O3, P is reported
+    as P2O5.
+;
+    _name.category_id             atom_analytical
+    _name.object_id               chemical_species_mass_percent
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:100.0
+    _units.code                   none
+
+save_
+
+save_atom_analytical.chemical_species_mass_percent_su
+
+    _definition.id
+        '_atom_analytical.chemical_species_mass_percent_su'
+    _definition.update            2023-07-01
+    _description.text
+;
+    Standard uncertainty of _atom_analytical.chemical_species_mass_percent.
+;
+    _name.category_id             atom_analytical
+    _name.object_id               chemical_species_mass_percent_su
+    _name.linked_item_id
+        '_atom_analytical.chemical_species_mass_percent'
+    _units.code                   none
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+save_
+
+save_atom_analytical.id
+
+    _definition.id                '_atom_analytical.id'
+    _definition.update            2022-11-18
+    _description.text
+;
+    Arbitrary label uniquely identifying a single composition value.
+;
+    _name.category_id             atom_analytical
+    _name.object_id               id
+    _type.purpose                 Key
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Word
+
+save_
+
+save_atom_analytical.meas_id
+
+    _definition.id                '_atom_analytical.meas_id'
+    _definition.update            2022-11-18
+    _description.text
+;
+    Arbitrary label identifying the source of an elemental composition.
+    This code must match the _atom_analytical_source.id of the associated
+    technique in the analytical source list.
+;
+    _name.category_id             atom_analytical
+    _name.object_id               meas_id
+    _name.linked_item_id          '_atom_analytical_source.id'
+    _type.purpose                 Link
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Word
+
+save_
+
+save_ATOM_ANALYTICAL_MASS_LOSS
+
+    _definition.id                ATOM_ANALYTICAL_MASS_LOSS
+    _definition.scope             Category
+    _definition.class             Loop
+    _definition.update            2022-11-21
+    _description.text
+;
+    The CATEGORY of data items used to describe information
+    pertaining to mass loss during specimen preparation for
+    the purposes of determining elemental composition
+    information for use in crystallographic structure studies.
+;
+    _name.category_id             ATOM
+    _name.object_id               ATOM_ANALYTICAL_MASS_LOSS
+    _category_key.name            '_atom_analytical_mass_loss.id'
+    _description_example.case
+;
+    loop_
+    _atom_analytical_mass_loss.id
+    _atom_analytical_mass_loss.meas_id
+    _atom_analytical_mass_loss.percent
+    _atom_analytical_mass_loss.temperature
+    LOD1 a   2  328
+    LOI1 a   5  623
+    LOI2 a  10 1023
+    LOI3 a  15 1373
+    LOI4 b   5  673
+    LOI5 b  10 1123
+;
+    _description_example.detail
+;
+    Four mass-loss percentages are given for measurement 'a', and two
+    for measurement 'b'. The mass losses were recorded after exposing
+    the specimen to the listed temperatures. The mass lost at a lower
+    temperature for the same measurement should be included in the
+    higher temperatures; that is, for measurement 'a', the total mass
+    loss after four measurements is 15 wt%, not (2+5+10+15) wt%.
+;
+
+save_
+
+save_atom_analytical_mass_loss.id
+
+    _definition.id                '_atom_analytical_mass_loss.id'
+    _definition.update            2022-11-21
+    _description.text
+;
+    Arbitrary label uniquely identifying the source of an elemental
+    composition value. This value is used by _atom_analytical.meas_id
+    to link individual composition values to their corresponding
+    technique of determination.
+;
+    _name.category_id             atom_analytical_mass_loss
+    _name.object_id               id
+    _type.purpose                 Key
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Word
+
+save_
+
+save_atom_analytical_mass_loss.meas_id
+
+    _definition.id                '_atom_analytical_mass_loss.meas_id'
+    _definition.update            2022-11-18
+    _description.text
+;
+    Arbitrary label identifying the source of an elemental composition.
+    This code must match the _atom_analytical_source.id of the associated
+    technique in the analytical source list.
+;
+    _name.category_id             atom_analytical_mass_loss
+    _name.object_id               meas_id
+    _name.linked_item_id          '_atom_analytical_source.id'
+    _type.purpose                 Link
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Word
+
+save_
+
+save_atom_analytical_mass_loss.percent
+
+    _definition.id                '_atom_analytical_mass_loss.percent'
+    _definition.update            2022-11-21
+    _description.text
+;
+    Mass lost by the specimen during specimen preparation expressed
+    as a percentage. The temperature at which the mass loss was recorded
+    is given by _atom_analytical_mass_loss.temperature. A mass gain
+    is represented by a negative value.
+
+    This data name would be used to record mass loss on drying, or mass
+    loss on ignition, during, for example, fusion bead preparation for
+    XRF analysis.
+;
+    _name.category_id             atom_analytical_mass_loss
+    _name.object_id               percent
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _units.code                   none
+
+    loop_
+      _description_example.case
+      _description_example.detail
+         12.5
+;
+         Represents a mass loss of 12.5 wt% upon exposure of the specimen
+         to the temperature given in _atom_analytical_mass_loss.temperature.
+;
+         -7.2
+;
+         Represents a mass gain of 7.2 wt% upon exposure of the specimen
+         to the temperature given in _atom_analytical_mass_loss.temperature.
+;
+
+save_
+
+save_atom_analytical_mass_loss.percent_su
+
+    _definition.id                '_atom_analytical_mass_loss.percent_su'
+    _definition.update            2023-07-01
+    _description.text
+;
+    Standard uncertainty of _atom_analytical_mass_loss.percent.
+;
+    _name.category_id             atom_analytical_mass_loss
+    _name.object_id               percent_su
+    _name.linked_item_id          '_atom_analytical_mass_loss.percent'
+    _units.code                   none
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+save_
+
+save_atom_analytical_mass_loss.special_details
+
+    _definition.id                '_atom_analytical_mass_loss.special_details'
+    _definition.update            2022-11-21
+    _description.text
+;
+    Text describing the conditions under which the data were collected
+    that are not able to be captured using other data names
+    within the ATOM_ANALYTICAL_MASS_LOSS category.
+;
+    _name.category_id             atom_analytical_mass_loss
+    _name.object_id               special_details
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_atom_analytical_mass_loss.temperature
+
+    _definition.id                '_atom_analytical_mass_loss.temperature'
+    _definition.update            2022-11-21
+    _description.text
+;
+    The temperature, in kelvin, at which the mass loss was recorded
+    as given by _atom_analytical_mass_loss.percent.
+
+    This would be used to record the temperature of drying or ignition,
+    during, for example, fusion bead preparation for XRF analysis.
+;
+    _name.category_id             atom_analytical_mass_loss
+    _name.object_id               temperature
+    _type.purpose                 Measurand
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   kelvins
+
+save_
+
+save_atom_analytical_mass_loss.temperature_su
+
+    _definition.id                '_atom_analytical_mass_loss.temperature_su'
+    _definition.update            2023-07-01
+    _description.text
+;
+    Standard uncertainty of _atom_analytical_mass_loss.temperature.
+;
+    _name.category_id             atom_analytical_mass_loss
+    _name.object_id               analysis_temperature_su
+    _name.linked_item_id          '_atom_analytical_mass_loss.temperature'
+    _units.code                   kelvins
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+save_
+
+save_ATOM_ANALYTICAL_SOURCE
+
+    _definition.id                ATOM_ANALYTICAL_SOURCE
+    _definition.scope             Category
+    _definition.class             Loop
+    _definition.update            2022-11-19
+    _description.text
+;
+    The CATEGORY of data items used to describe the source
+    of elemental composition information used in crystallographic
+    structure studies.
+;
+    _name.category_id             ATOM
+    _name.object_id               ATOM_ANALYTICAL_SOURCE
+    _category_key.name            '_atom_analytical_source.id'
+    _description_example.case
+;
+    loop_
+    _atom_analytical_source.id
+    _atom_analytical_source.technique
+    _atom_analytical_source.equipment_make
+    a  XRF 'Hitachi Lab-X5000'
+    b  'X-ray fluorescence EDS' 'Hitachi Lab-X5000'
+    c  ICP .
+    d  EDS .
+;
+    _description_example.detail
+;
+    Four different measurements of elemental composition are enumerated.
+;
+
+save_
+
+save_atom_analytical_source.equipment_make
+
+    _definition.id                '_atom_analytical_source.equipment_make'
+    _definition.update            2022-11-18
+    _description.text
+;
+    The make, model or name of the equipment used to determine the
+    elemental composition.
+;
+    _name.category_id             atom_analytical_source
+    _name.object_id               equipment_make
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+
+    loop_
+      _description_example.case
+         'Bruker'
+         'ELEMISSION'
+         'Thermo Fisher Scientific'
+
+save_
+
+save_atom_analytical_source.id
+
+    _definition.id                '_atom_analytical_source.id'
+    _definition.update            2022-11-18
+    _description.text
+;
+    Arbitrary label uniquely identifying the source of an elemental
+    composition value. This value is used by _atom_analytical.meas_id
+    to link individual composition values to their corresponding
+    technique of determination.
+;
+    _name.category_id             atom_analytical_source
+    _name.object_id               id
+    _type.purpose                 Key
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Word
+
+save_
+
+save_atom_analytical_source.special_details
+
+    _definition.id                '_atom_analytical_source.special_details'
+    _definition.update            2022-11-18
+    _description.text
+;
+    Text describing the equipment or conditions under which the
+    data were collected that are not able to be captured using
+    _atom_analytical_source.equipment_make or
+    _atom_analytical_source.technique.
+;
+    _name.category_id             atom_analytical_source
+    _name.object_id               special_details
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+
+    loop_
+      _description_example.case
+;
+       XRF utilising a WDS detector system calibrated for the analysis
+       of iron ores.
+;
+;
+       Laser Induced Breakdown Spectroscopy. Measurements carried out
+       by commercial laboratory, report #P90.
+;
+;
+       Detector calibrated following Smith (2018).
+;
+
+save_
+
+save_atom_analytical_source.technique
+
+    _definition.id                '_atom_analytical_source.technique'
+    _definition.update            2022-11-18
+    _description.text
+;
+    Succinct text or acronym describing the experimental technique used
+    to find the elemental composition.
+
+    If further details are required to properly describe the experimental
+    technique, or the given acronym is not in common use, use
+    _atom_analytical_source.special_details.
+;
+    _name.category_id             atom_analytical_source
+    _name.object_id               technique
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+
+    loop_
+      _description_example.case
+         'XRF'
+         'LIBS'
+         'ICP OES'
+
+save_
+
+save_ATOM_SCAT_VERSUS_STOL
+
+    _definition.id                ATOM_SCAT_VERSUS_STOL
+    _definition.scope             Category
+    _definition.class             Loop
+    _definition.update            2023-07-05
+    _description.text
+;
+    The CATEGORY of data items used to list atomic scattering factor values for
+    use in crystallographic structure studies.
+;
+    _name.category_id             ATOM
+    _name.object_id               ATOM_SCAT_VERSUS_STOL
+
+    loop_
+      _category_key.name
+         '_atom_scat_versus_stol.atom_type'
+         '_atom_scat_versus_stol.stol_value'
+
+    _description_example.case
+;
+        loop_
+        _atom_scat_versus_stol.atom_type
+        _atom_scat_versus_stol.stol_value
+        _atom_scat_versus_stol.scat_value
+        Ac  0.00  89.00000
+        Ac  0.01  88.91457
+        Ac  0.02  88.66288
+        #...
+        Ac  4.00   8.24987
+        Ac  5.00   5.98858
+        Ac  6.00   4.90623
+        O   0.00   8.00000
+        O   0.01   7.99171
+        O   0.02   7.96693
+        #...
+        O   4.00   0.13431
+        O   5.00   0.06740
+        O   6.00   0.03670
+;
+    _description_example.detail
+;
+        A listing of the scattering factors for Ac and O in the range
+        (0, 6.00) reciprocal angstroms.
+;
+save_
+
+save_atom_scat_versus_stol.atom_type
+
+    _definition.id                '_atom_scat_versus_stol.atom_type'
+    _definition.update            2023-07-05
+    _description.text
+;
+    The identity of the atom specie(s) representing this atom type.
+    See _atom_type.symbol for further details.
+;
+    _name.category_id             atom_scat_versus_stol
+    _name.object_id               atom_type
+    _name.linked_item_id          '_atom_type.symbol'
+    _type.purpose                 Link
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Word
+
+save_
+
+save_atom_scat_versus_stol.scat_value
+
+    _definition.id                '_atom_scat_versus_stol.scat_value'
+    _definition.update            2024-05-15
+    _description.text
+;
+    The value of the scattering factor of a particular atom type at a particular
+    stol value.
+;
+    _name.category_id             atom_scat_versus_stol
+    _name.object_id               scat_value
+    _type.purpose                 Measurand
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   electrons
+
+save_
+
+save_atom_scat_versus_stol.scat_value_su
+
+    _definition.id                '_atom_scat_versus_stol.scat_value_su'
+    _definition.update            2023-07-05
+    _description.text
+;
+    Standard uncertainty of _atom_scat_versus_stol.scat_value.
+;
+    _name.category_id             atom_scat_versus_stol
+    _name.object_id               scat_value_su
+    _name.linked_item_id          '_atom_scat_versus_stol.scat_value'
+    _units.code                   electrons
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+save_
+
+save_atom_scat_versus_stol.stol_value
+
+    _definition.id                '_atom_scat_versus_stol.stol_value'
+    _definition.update            2024-05-15
+    _description.text
+;
+    The value of sin(θ)/λ (sin theta over lambda, stol) to which the
+    accompanying atom symbol and scattering factor value correspond to.
+
+    A regularly spaced grid is strongly recommended.
+;
+    _name.category_id             atom_scat_versus_stol
+    _name.object_id               stol_value
+    _type.purpose                 Number
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   reciprocal_angstroms
+
+save_
+
+save_ATOM_SITE
+
+    _definition.id                ATOM_SITE
+    _definition.scope             Category
+    _definition.class             Loop
+    _definition.update            2023-02-03
+    _description.text
+;
+    The CATEGORY of data items used to describe atom site information
+    used in crystallographic structure studies.
+;
+    _name.category_id             ATOM
+    _name.object_id               ATOM_SITE
+    _category_key.name            '_atom_site.label'
+
+    loop_
+      _description_example.case
+      _description_example.detail
+;
+         loop_
+           _atom_site.label
+           _atom_site.occupancy
+           _atom_site.disorder_assembly
+           _atom_site.disorder_group
+            C1     1      .     .
+            H11A   .5     M     1
+            H12A   .5     M     1
+            H13A   .5     M     1
+            H11B   .5     M     2
+            H12B   .5     M     2
+            H13B   .5     M     2
+;
+;
+         A hypothetical example of a positional disorder description. Disorder
+         assembly 'M' describes a methyl group with two alternative
+         configurations '1' and '2':
+
+                            H11B    H11A      H13B
+                              .      |      .
+                                .    |    .
+                                  .  |  .
+                                     C1 --------C2---
+                                   / .  \
+                                 /   .    \
+                               /     .      \
+                            H12A    H12B    H13A
+;
+;
+         loop_
+           _atom_site.label
+           _atom_site.type_symbol
+           _atom_site.fract_x
+           _atom_site.fract_y
+           _atom_site.fract_z
+           _atom_site.occupancy
+           _atom_site.disorder_assembly
+           _atom_site.disorder_group
+            Cu1 Cu 0.78443(2) 0.88297(4) 0.37825(2)  1       . .
+            Co1 Co 0.77504(2) 0.66957(4) 0.54249(2)  0.78(3) A 1
+            Mn1 Mn 0.77504(2) 0.66957(4) 0.54249(2)  0.22(3) A 2
+            O1   O 0.85532(9) 0.95747(19) 0.28965(9) 1       . .
+            O2   O 0.84868(9) 0.94662(19) 0.14953(8) 1       . .
+            # ...
+;
+;
+         An example of a compositional disorder description. Disorder assembly
+         'A' describes a site that is simultaneously occupied by Co and Mn
+         atoms which are assigned to disorder group '1' and disorder group '2'
+         respectively.
+
+         The example was created based on data from:
+             Li, Ang et al. (2021). Dalton Transactions, 50(2), 681-688.
+             https://doi.org/10.1039/d0dt03269g
+;
+
+save_
+
+save_atom_site.adp_type
+
+    _definition.id                '_atom_site.ADP_type'
+
+    loop_
+      _alias.definition_id
+      _alias.deprecation_date
+         '_atom_site_ADP_type'                                       .
+         '_atom_site_thermal_displace_type'                          1999-03-24
+         '_atom_site.thermal_displace_type'                          .
+
+    _definition.update            2024-02-14
+    _description.text
+;
+    Code for type of atomic displacement parameters used for the site.
+;
+    _name.category_id             atom_site
+    _name.object_id               ADP_type
+    _type.purpose                 State
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Text
+
+    loop_
+      _enumeration_set.state
+      _enumeration_set.detail
+         Uani                     'Anisotropic Uij.'
+         Uiso                     'Isotropic U.'
+         Uovl                     'Overall U.'
+         Umpe                     'Multipole expansion U.'
+         Bani                     'Anisotropic Bij.'
+         Biso                     'Isotropic B.'
+         Bovl                     'Overall B.'
+         betaani                  'Anisotropic betaij.'
+
+save_
+
+save_atom_site.attached_hydrogens
+
+    _definition.id                '_atom_site.attached_hydrogens'
+    _alias.definition_id          '_atom_site_attached_hydrogens'
+    _definition.update            2021-03-01
+    _description.text
+;
+    Number of hydrogen atoms attached to the atom at this site
+    excluding any H atoms for which coordinates (measured or calculated)
+    are given.
+;
+    _name.category_id             atom_site
+    _name.object_id               attached_hydrogens
+    _type.purpose                 Number
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Integer
+    _enumeration.range            0:8
+    _units.code                   none
+
+    loop_
+      _description_example.case
+      _description_example.detail
+         2                        'Water oxygen.'
+         1                        'Hydroxyl oxygen.'
+         4                        'Ammonium nitrogen.'
+
+save_
+
+save_atom_site.b_equiv_geom_mean
+
+    _definition.id                '_atom_site.B_equiv_geom_mean'
+    _alias.definition_id          '_atom_site_B_equiv_geom_mean'
+    _definition.update            2012-11-20
+    _description.text
+;
+    Equivalent isotropic atomic displacement parameter, B(equiv),
+    in angstroms squared, calculated as the geometric mean of
+    the anisotropic atomic displacement parameters.
+
+                B(equiv) = (B~i~ B~j~ B~k~)^1/3^
+
+    B~n~  = the principal components of the orthogonalised B^ij^
+
+    The IUCr Commission on Nomenclature recommends against the use
+    of B for reporting atomic displacement parameters. U, being
+    directly proportional to B, is preferred.
+;
+    _name.category_id             atom_site
+    _name.object_id               B_equiv_geom_mean
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   angstrom_squared
+
+save_
+
+save_atom_site.b_equiv_geom_mean_su
+
+    _definition.id                '_atom_site.B_equiv_geom_mean_su'
+
+    loop_
+      _alias.definition_id
+         '_atom_site_B_equiv_geom_mean_su'
+         '_atom_site.B_equiv_geom_mean_esd'
+
+    _definition.update            2021-03-03
+    _description.text
+;
+    Standard uncertainty of _atom_site.B_equiv_geom_mean.
+;
+    _name.category_id             atom_site
+    _name.object_id               B_equiv_geom_mean_su
+    _name.linked_item_id          '_atom_site.B_equiv_geom_mean'
+    _units.code                   angstrom_squared
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+save_
+
+save_atom_site.b_iso_or_equiv
+
+    _definition.id                '_atom_site.B_iso_or_equiv'
+    _alias.definition_id          '_atom_site_B_iso_or_equiv'
+    _definition.update            2023-01-16
+    _description.text
+;
+    Isotropic atomic displacement parameter, or equivalent isotropic
+    atomic displacement parameter, B(equiv), in angstroms squared,
+    calculated from anisotropic atomic displacement parameters.
+
+        B(equiv) = (1/3) sum~i~[sum~j~(B^ij^ a*~i~ a*~j~ a~i~.a~j~)]
+
+    a     = the real-space cell vectors
+    a*    = the reciprocal-space cell lengths
+    B^ij^ = 8 π^2^ U^ij^
+    Ref: Fischer, R. X. & Tillmanns, E. (1988). Acta Cryst. C44, 775-776.
+
+    The IUCr Commission on Nomenclature recommends against the use
+    of B for reporting atomic displacement parameters. U, being
+    directly proportional to B, is preferred.
+;
+    _name.category_id             atom_site
+    _name.object_id               B_iso_or_equiv
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   angstrom_squared
+
+save_
+
+save_atom_site.b_iso_or_equiv_su
+
+    _definition.id                '_atom_site.B_iso_or_equiv_su'
+
+    loop_
+      _alias.definition_id
+         '_atom_site_B_iso_or_equiv_su'
+         '_atom_site.B_iso_or_equiv_esd'
+
+    _definition.update            2023-01-16
+    _description.text
+;
+    Standard uncertainty of _atom_site.B_iso_or_equiv.
+;
+    _name.category_id             atom_site
+    _name.object_id               B_iso_or_equiv_su
+    _name.linked_item_id          '_atom_site.B_iso_or_equiv'
+    _units.code                   angstrom_squared
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+save_
+
+save_atom_site.calc_attached_atom
+
+    _definition.id                '_atom_site.calc_attached_atom'
+    _alias.definition_id          '_atom_site_calc_attached_atom'
+    _definition.update            2023-01-13
+    _description.text
+;
+    The _atom_site.label of the atom site to which the 'geometry-calculated'
+    atom site is attached.
+;
+    _name.category_id             atom_site
+    _name.object_id               calc_attached_atom
+    _name.linked_item_id          '_atom_site.label'
+    _type.purpose                 Link
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Word
+
+save_
+
+save_atom_site.calc_flag
+
+    _definition.id                '_atom_site.calc_flag'
+    _alias.definition_id          '_atom_site_calc_flag'
+    _definition.update            2012-11-20
+    _description.text
+;
+    A standard code to signal if the site coordinates have been
+    determined from the intensities or calculated from the geometry
+    of surrounding sites, or have been assigned dummy coordinates.
+;
+    _name.category_id             atom_site
+    _name.object_id               calc_flag
+    _type.purpose                 State
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Text
+
+    loop_
+      _enumeration_set.state
+      _enumeration_set.detail
+         d                        'Determined from diffraction measurements.'
+         calc                     'Calculated from molecular geometry.'
+         c                        'Abbreviation for "calc".'
+         dum                      'Dummy site with meaningless coordinates.'
+
+save_
+
+save_atom_site.cartn_x
+
+    _definition.id                '_atom_site.Cartn_x'
+    _alias.definition_id          '_atom_site_Cartn_x'
+    _name.category_id             atom_site
+    _name.object_id               Cartn_x
+
+    _import.get                   [{'file':templ_attr.cif  'save':cartn_coord}]
+
+save_
+
+save_atom_site.cartn_x_su
+
+    _definition.id                '_atom_site.Cartn_x_su'
+
+    loop_
+      _alias.definition_id
+         '_atom_site_Cartn_x_su'
+         '_atom_site.Cartn_x_esd'
+
+    _name.category_id             atom_site
+    _name.object_id               Cartn_x_su
+    _name.linked_item_id          '_atom_site.Cartn_x'
+
+    _import.get
+        [{'file':templ_attr.cif  'save':cartn_coord_su}]
+
+save_
+
+save_atom_site.cartn_xyz
+
+    _definition.id                '_atom_site.Cartn_xyz'
+    _definition.update            2021-07-07
+    _description.text
+;
+    Vector of Cartesian (orthogonal angstrom) atom site coordinates.
+;
+    _name.category_id             atom_site
+    _name.object_id               Cartn_xyz
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               Matrix
+    _type.dimension               '[3]'
+    _type.contents                Real
+    _units.code                   angstroms
+    _method.purpose               Evaluation
+    _method.expression
+;
+    With a  as  atom_site
+
+    _atom_site.Cartn_xyz =   [a.Cartn_x, a.Cartn_y, a.Cartn_z]
+;
+
+save_
+
+save_atom_site.cartn_xyz_su
+
+    _definition.id                '_atom_site.Cartn_xyz_su'
+    _definition.update            2023-07-01
+    _description.text
+;
+    Standard uncertainty of _atom_site.Cartn_xyz.
+;
+    _name.category_id             atom_site
+    _name.object_id               Cartn_xyz_su
+    _name.linked_item_id          '_atom_site.Cartn_xyz'
+    _type.purpose                 SU
+    _type.source                  Related
+    _type.container               Matrix
+    _type.dimension               '[3]'
+    _type.contents                Real
+    _units.code                   angstroms
+
+save_
+
+save_atom_site.cartn_y
+
+    _definition.id                '_atom_site.Cartn_y'
+    _alias.definition_id          '_atom_site_Cartn_y'
+    _name.category_id             atom_site
+    _name.object_id               Cartn_y
+
+    _import.get                   [{'file':templ_attr.cif  'save':cartn_coord}]
+
+save_
+
+save_atom_site.cartn_y_su
+
+    _definition.id                '_atom_site.Cartn_y_su'
+
+    loop_
+      _alias.definition_id
+         '_atom_site_Cartn_y_su'
+         '_atom_site.Cartn_y_esd'
+
+    _name.category_id             atom_site
+    _name.object_id               Cartn_y_su
+    _name.linked_item_id          '_atom_site.Cartn_y'
+
+    _import.get
+        [{'file':templ_attr.cif  'save':cartn_coord_su}]
+
+save_
+
+save_atom_site.cartn_z
+
+    _definition.id                '_atom_site.Cartn_z'
+    _alias.definition_id          '_atom_site_Cartn_z'
+    _name.category_id             atom_site
+    _name.object_id               Cartn_z
+
+    _import.get                   [{'file':templ_attr.cif  'save':cartn_coord}]
+
+save_
+
+save_atom_site.cartn_z_su
+
+    _definition.id                '_atom_site.Cartn_z_su'
+
+    loop_
+      _alias.definition_id
+         '_atom_site_Cartn_z_su'
+         '_atom_site.Cartn_z_esd'
+
+    _name.category_id             atom_site
+    _name.object_id               Cartn_z_su
+    _name.linked_item_id          '_atom_site.Cartn_z'
+
+    _import.get
+        [{'file':templ_attr.cif  'save':cartn_coord_su}]
+
+save_
+
+save_atom_site.chemical_conn_number
+
+    _definition.id                '_atom_site.chemical_conn_number'
+    _alias.definition_id          '_atom_site_chemical_conn_number'
+    _definition.update            2021-03-01
+    _description.text
+;
+    This number links an atom site to the chemical connectivity list.
+    It must match a number specified by _chemical_conn_atom.number.
+;
+    _name.category_id             atom_site
+    _name.object_id               chemical_conn_number
+    _name.linked_item_id          '_chemical_conn_atom.number'
+    _type.purpose                 Link
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Integer
+    _enumeration.range            1:
+    _units.code                   none
+
+save_
+
+save_atom_site.constraints
+
+    _definition.id                '_atom_site.constraints'
+    _alias.definition_id          '_atom_site_constraints'
+    _definition.update            2012-11-20
+    _description.text
+;
+    A description of the constraints applied to parameters at this
+    site during refinement. See also _atom_site.refinement_flags_*
+    and _refine_ls.number_constraints.
+;
+    _name.category_id             atom_site
+    _name.object_id               constraints
+    _type.purpose                 Encode
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+    _description_example.case     pop=1.0-pop(Zn3)
+
+save_
+
+save_atom_site.description
+
+    _definition.id                '_atom_site.description'
+
+    loop_
+      _alias.definition_id
+         '_atom_site_description'
+         '_atom_site.details'
+
+    _definition.update            2023-01-13
+    _description.text
+;
+    A description of special aspects of this site. See also
+    _atom_site.refinement_flags_*.
+;
+    _name.category_id             atom_site
+    _name.object_id               description
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+    _description_example.case     'Ag/Si disordered'
+
+save_
+
+save_atom_site.disorder_assembly
+
+    _definition.id                '_atom_site.disorder_assembly'
+    _alias.definition_id          '_atom_site_disorder_assembly'
+    _definition.update            2023-01-29
+    _description.text
+;
+    A code which identifies a cluster of atoms that show long range disorder
+    but are locally ordered. Within each such cluster of atoms,
+    _atom_site.disorder_group is used to identify the sites that are
+    simultaneously occupied. This field is only needed if there is more than
+    one cluster of disordered atoms showing independent local order.
+;
+    _name.category_id             atom_site
+    _name.object_id               disorder_assembly
+    _type.purpose                 Encode
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Word
+
+    loop_
+      _description_example.case
+      _description_example.detail
+         A
+;
+         Disordered methyl assembly with groups 1 and 2.
+;
+         B
+;
+         Disordered sites related by a mirror.
+;
+         C
+;
+         Assembly with groups that describe alternative compositions of a
+         compositionally disordered site.
+;
+         S
+;
+         Disordered sites independent of symmetry.
+;
+
+save_
+
+save_atom_site.disorder_group
+
+    _definition.id                '_atom_site.disorder_group'
+    _alias.definition_id          '_atom_site_disorder_group'
+    _definition.update            2023-01-29
+    _description.text
+;
+    A code that identifies a group of disordered atom sites that are locally
+    simultaneously occupied. Atoms that are positionally disordered over two or
+    more sites (e.g. the H atoms of a methyl group that exists in two
+    orientations) should be assigned to two or more groups. Similarly, atoms
+    that describe a specific alternative composition of a compositionally
+    disordered site should be assigned to a distinct disorder group (e.g. a site
+    that is partially occupied by Mg and Mn atoms should be described by
+    assigning the Mg atom to one group and the Mn atom to another group). Sites
+    belonging to the same group are simultaneously occupied, but those belonging
+    to different groups are not. A minus prefix (e.g. "-1") is used to indicate
+    sites disordered about a special position.
+;
+    _name.category_id             atom_site
+    _name.object_id               disorder_group
+    _type.purpose                 Encode
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Word
+
+    loop_
+      _description_example.case
+      _description_example.detail
+         1
+;
+         Unique disordered site in group 1.
+;
+         2
+;
+         Unique disordered site in group 2.
+;
+         3
+;
+         Group describes a specific alternative composition of a compositionally
+         disordered site.
+;
+         -1
+;
+         Symmetry-independent disordered site.'
+;
+
+save_
+
+save_atom_site.fract_symmform
+
+    _definition.id                '_atom_site.fract_symmform'
+    _alias.definition_id          '_atom_site_fract_symmform'
+    _definition.update            2024-02-20
+    _description.text
+;
+    A symbolic expression that indicates the symmetry-restricted form of the
+    components of the positional coordinates of an atom.
+;
+    _name.category_id             atom_site
+    _name.object_id               symmform
+    _type.purpose                 Encode
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Text
+
+    loop_
+      _description_example.case
+      _description_example.detail
+         Dx,Dy,Dz
+;
+         No symmetry restrictions.
+;
+         Dx,-Dx,0
+;
+         y component equal and opposite to x component with z component zero.
+;
+         Dx,0,Dz
+;
+         y component zero.
+;
+
+save_
+
+save_atom_site.fract_x
+
+    _definition.id                '_atom_site.fract_x'
+    _alias.definition_id          '_atom_site_fract_x'
+    _name.category_id             atom_site
+    _name.object_id               fract_x
+
+    _import.get                   [{'file':templ_attr.cif  'save':fract_coord}]
+
+save_
+
+save_atom_site.fract_x_su
+
+    _definition.id                '_atom_site.fract_x_su'
+
+    loop_
+      _alias.definition_id
+         '_atom_site_fract_x_su'
+         '_atom_site.fract_x_esd'
+
+    _name.category_id             atom_site
+    _name.object_id               fract_x_su
+    _name.linked_item_id          '_atom_site.fract_x'
+
+    _import.get
+        [{'file':templ_attr.cif  'save':fract_coord_su}]
+
+save_
+
+save_atom_site.fract_xyz
+
+    _definition.id                '_atom_site.fract_xyz'
+    _definition.update            2021-03-01
+    _description.text
+;
+    Vector of atom site coordinates projected onto the crystal unit
+    cell as fractions of the cell lengths.
+;
+    _name.category_id             atom_site
+    _name.object_id               fract_xyz
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               Matrix
+    _type.dimension               '[3]'
+    _type.contents                Real
+    _units.code                   none
+    _method.purpose               Evaluation
+    _method.expression
+;
+    With a  as  atom_site
+
+    _atom_site.fract_xyz =  [a.fract_x, a.fract_y, a.fract_z]
+;
+
+save_
+
+save_atom_site.fract_xyz_su
+
+    _definition.id                '_atom_site.fract_xyz_su'
+    _definition.update            2023-07-01
+    _description.text
+;
+    Standard uncertainty of _atom_site.fract_xyz.
+;
+    _name.category_id             atom_site
+    _name.object_id               fract_xyz_su
+    _name.linked_item_id          '_atom_site.fract_xyz'
+    _type.purpose                 SU
+    _type.source                  Related
+    _type.container               Matrix
+    _type.dimension               '[3]'
+    _type.contents                Real
+    _units.code                   none
+
+save_
+
+save_atom_site.fract_y
+
+    _definition.id                '_atom_site.fract_y'
+    _alias.definition_id          '_atom_site_fract_y'
+    _name.category_id             atom_site
+    _name.object_id               fract_y
+
+    _import.get                   [{'file':templ_attr.cif  'save':fract_coord}]
+
+save_
+
+save_atom_site.fract_y_su
+
+    _definition.id                '_atom_site.fract_y_su'
+
+    loop_
+      _alias.definition_id
+         '_atom_site_fract_y_su'
+         '_atom_site.fract_y_esd'
+
+    _name.category_id             atom_site
+    _name.object_id               fract_y_su
+    _name.linked_item_id          '_atom_site.fract_y'
+
+    _import.get
+        [{'file':templ_attr.cif  'save':fract_coord_su}]
+
+save_
+
+save_atom_site.fract_z
+
+    _definition.id                '_atom_site.fract_z'
+    _alias.definition_id          '_atom_site_fract_z'
+    _name.category_id             atom_site
+    _name.object_id               fract_z
+
+    _import.get                   [{'file':templ_attr.cif  'save':fract_coord}]
+
+save_
+
+save_atom_site.fract_z_su
+
+    _definition.id                '_atom_site.fract_z_su'
+
+    loop_
+      _alias.definition_id
+         '_atom_site_fract_z_su'
+         '_atom_site.fract_z_esd'
+
+    _name.category_id             atom_site
+    _name.object_id               fract_z_su
+    _name.linked_item_id          '_atom_site.fract_z'
+
+    _import.get
+        [{'file':templ_attr.cif  'save':fract_coord_su}]
+
+save_
+
+save_atom_site.label
+
+    _definition.id                '_atom_site.label'
+
+    loop_
+      _alias.definition_id
+         '_atom_site_label'
+         '_atom_site.id'
+
+    _name.category_id             atom_site
+    _name.object_id               label
+
+    _import.get
+        [{'file':templ_attr.cif  'save':atom_site_label}]
+
+save_
+
+save_atom_site.label_component_0
+
+    _definition.id                '_atom_site.label_component_0'
+    _alias.definition_id          '_atom_site_label_component_0'
+    _name.category_id             atom_site
+    _name.object_id               label_component_0
+
+    _import.get
+        [{'file':templ_attr.cif  'save':label_component}]
+
+save_
+
+save_atom_site.label_component_1
+
+    _definition.id                '_atom_site.label_component_1'
+    _alias.definition_id          '_atom_site_label_component_1'
+    _name.category_id             atom_site
+    _name.object_id               label_component_1
+
+    _import.get                   [{'file':templ_attr.cif  'save':label_comp}]
+
+save_
+
+save_atom_site.label_component_2
+
+    _definition.id                '_atom_site.label_component_2'
+    _alias.definition_id          '_atom_site_label_component_2'
+    _name.category_id             atom_site
+    _name.object_id               label_component_2
+
+    _import.get                   [{'file':templ_attr.cif  'save':label_comp}]
+
+save_
+
+save_atom_site.label_component_3
+
+    _definition.id                '_atom_site.label_component_3'
+    _alias.definition_id          '_atom_site_label_component_3'
+    _name.category_id             atom_site
+    _name.object_id               label_component_3
+
+    _import.get                   [{'file':templ_attr.cif  'save':label_comp}]
+
+save_
+
+save_atom_site.label_component_4
+
+    _definition.id                '_atom_site.label_component_4'
+    _alias.definition_id          '_atom_site_label_component_4'
+    _name.category_id             atom_site
+    _name.object_id               label_component_4
+
+    _import.get                   [{'file':templ_attr.cif  'save':label_comp}]
+
+save_
+
+save_atom_site.label_component_5
+
+    _definition.id                '_atom_site.label_component_5'
+    _alias.definition_id          '_atom_site_label_component_5'
+    _name.category_id             atom_site
+    _name.object_id               label_component_5
+
+    _import.get                   [{'file':templ_attr.cif  'save':label_comp}]
+
+save_
+
+save_atom_site.label_component_6
+
+    _definition.id                '_atom_site.label_component_6'
+    _alias.definition_id          '_atom_site_label_component_6'
+    _name.category_id             atom_site
+    _name.object_id               label_component_6
+
+    _import.get                   [{'file':templ_attr.cif  'save':label_comp}]
+
+save_
+
+save_atom_site.occupancy
+
+    _definition.id                '_atom_site.occupancy'
+    _alias.definition_id          '_atom_site_occupancy'
+    _definition.update            2012-11-20
+    _description.text
+;
+    The fraction of the atom type present at this site.
+    The sum of the occupancies of all the atom types at this site
+    may not significantly exceed 1.0 unless it is a dummy site. The
+    value must lie in the 99.97% Gaussian confidence interval
+    -3u =< x =< 1 + 3u. The _enumeration.range of 0.0:1.0 is thus
+    correctly interpreted as meaning (0.0 - 3u) =< x =< (1.0 + 3u).
+;
+    _name.category_id             atom_site
+    _name.object_id               occupancy
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:1.0
+    _units.code                   none
+
+save_
+
+save_atom_site.occupancy_su
+
+    _definition.id                '_atom_site.occupancy_su'
+
+    loop_
+      _alias.definition_id
+         '_atom_site_occupancy_su'
+         '_atom_site.occupancy_esd'
+
+    _definition.update            2021-03-03
+    _description.text
+;
+    Standard uncertainty of _atom_site.occupancy.
+;
+    _name.category_id             atom_site
+    _name.object_id               occupancy_su
+    _name.linked_item_id          '_atom_site.occupancy'
+    _units.code                   none
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+save_
+
+save_atom_site.refinement_flags
+
+    _definition.id                '_atom_site.refinement_flags'
+
+    loop_
+      _definition_replaced.id
+      _definition_replaced.by
+         1                        '_atom_site.refinement_flags_posn'
+         2                        '_atom_site.refinement_flags_ADP'
+         3                        '_atom_site.refinement_flags_occupancy'
+
+    _alias.definition_id          '_atom_site_refinement_flags'
+    _definition.update            2021-09-24
+    _description.text
+;
+    A concatenated series of single-letter codes which indicate the
+    refinement restraints or constraints applied to this site. This
+    item should not be used. It has been replaced by
+    _atom_site.refinement_flags_posn, _ADP and _occupancy. It is
+    retained in this dictionary only to provide compatibility with
+    legacy CIFs.
+;
+    _name.category_id             atom_site
+    _name.object_id               refinement_flags
+    _type.purpose                 State
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Text
+
+    loop_
+      _enumeration_set.state
+      _enumeration_set.detail
+         S                      'Special position constraint on site.'
+         G                      'Rigid group refinement of site.'
+         R                      'Riding-atom site attached to non-riding atom.'
+         D                      'Distance or angle restraint on site.'
+         T                      'Thermal displacement constraints.'
+         U                      'Uiso or Uij restraint (rigid bond).'
+         P                      'Partial occupancy constraint.'
+         .                      'No refinement constraints.'
+
+save_
+
+save_atom_site.refinement_flags_adp
+
+    _definition.id                '_atom_site.refinement_flags_ADP'
+    _alias.definition_id          '_atom_site_refinement_flags_ADP'
+    _definition.update            2021-09-24
+    _description.text
+;
+    A code which indicates the refinement restraints or constraints
+    applied to the atomic displacement parameters of this site.
+;
+    _name.category_id             atom_site
+    _name.object_id               refinement_flags_ADP
+    _type.purpose                 State
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Text
+
+    loop_
+      _enumeration_set.state
+      _enumeration_set.detail
+         .    'No constraints on atomic displacement parameters.'
+         T    'Special-position constraints on atomic displacement parameters.'
+         U    'Uiso or Uij restraint (rigid bond).'
+         TU   'Both constraints applied.'
+
+save_
+
+save_atom_site.refinement_flags_occupancy
+
+    _definition.id                '_atom_site.refinement_flags_occupancy'
+    _alias.definition_id          '_atom_site_refinement_flags_occupancy'
+    _definition.update            2012-11-20
+    _description.text
+;
+    A code which indicates the refinement restraints or constraints
+    applied to the occupancy of this site.
+;
+    _name.category_id             atom_site
+    _name.object_id               refinement_flags_occupancy
+    _type.purpose                 State
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Text
+
+    loop_
+      _enumeration_set.state
+      _enumeration_set.detail
+         .                       'No constraints on site-occupancy parameters.'
+         P                       'Site-occupancy constraint.'
+
+save_
+
+save_atom_site.refinement_flags_posn
+
+    _definition.id                '_atom_site.refinement_flags_posn'
+    _alias.definition_id          '_atom_site_refinement_flags_posn'
+    _definition.update            2012-11-20
+    _description.text
+;
+    A code which indicates the refinement restraints or constraints
+    applied to the positional coordinates of this site.
+;
+    _name.category_id             atom_site
+    _name.object_id               refinement_flags_posn
+    _type.purpose                 State
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Text
+
+    loop_
+      _enumeration_set.state
+      _enumeration_set.detail
+         .             'No constraints on positional coordinates.'
+         D             'Distance or angle restraint on positional coordinates.'
+         G             'Rigid-group refinement of positional coordinates.'
+         R             'Riding-atom site attached to non-riding atom.'
+         S             'Special-position constraint on positional coordinates.'
+         DG            'Combination of the above constraints.'
+         DR            'Combination of the above constraints.'
+         DS            'Combination of the above constraints.'
+         GR            'Combination of the above constraints.'
+         GS            'Combination of the above constraints.'
+         RS            'Combination of the above constraints.'
+         DGR           'Combination of the above constraints.'
+         DGS           'Combination of the above constraints.'
+         DRS           'Combination of the above constraints.'
+         GRS           'Combination of the above constraints.'
+         DGRS          'Combination of the above constraints.'
+
+save_
+
+save_atom_site.restraints
+
+    _definition.id                '_atom_site.restraints'
+    _alias.definition_id          '_atom_site_restraints'
+    _definition.update            2023-01-13
+    _description.text
+;
+    A description of restraints applied to specific parameters at
+    this site during refinement. See also _atom_site.refinement_flags_*
+    and _refine_ls.number_restraints.
+;
+    _name.category_id             atom_site
+    _name.object_id               restraints
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+    _description_example.case     'restrained to planar ring'
+
+save_
+
+save_atom_site.site_symmetry_multiplicity
+
+    _definition.id                '_atom_site.site_symmetry_multiplicity'
+
+    loop_
+      _alias.definition_id
+      _alias.deprecation_date
+         '_atom_site_site_symmetry_multiplicity'                     .
+         '_atom_site_symmetry_multiplicity'                          2014-05-20
+         '_atom_site.symmetry_multiplicity'                          .
+
+    _definition.update            2024-02-14
+    _description.text
+;
+    The number of different sites that are generated by the
+    application of the space-group symmetry to the coordinates
+    given for this site. It is equal to the multiplicity given
+    for this Wyckoff site in International Tables for Cryst.
+    Vol. A (2002). It is equal to the multiplicity of the general
+    position divided by the order of the site symmetry given in
+    _atom_site.site_symmetry_order.
+
+    The _atom_site_symmetry_multiplicity form of this data name is
+    deprecated because of historical inconsistencies in practice among
+    structure refinement software packages and should not be used.
+;
+    _name.category_id             atom_site
+    _name.object_id               site_symmetry_multiplicity
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Integer
+    _enumeration.range            1:192
+    _units.code                   none
+    _method.purpose               Evaluation
+    _method.expression
+;
+     With  a  as  atom_site
+
+        mul  =   0
+        xyz  =   a.fract_xyz
+
+          Loop  s  as  space_group_symop  {
+             sxyz  =   s.R * xyz + s.T
+             diff  =   Mod( 99.5 + xyz - sxyz, 1.0) - 0.5
+             If ( Norm ( diff ) < 0.1 ) mul +=  1
+       }
+    _atom_site.site_symmetry_multiplicity =  _space_group.multiplicity / mul
+;
+
+save_
+
+save_atom_site.site_symmetry_order
+
+    _definition.id                '_atom_site.site_symmetry_order'
+    _alias.definition_id          '_atom_site_site_symmetry_order'
+    _definition.update            2021-03-01
+    _description.text
+;
+    The number of times application of the crystallographic symmetry
+    to the coordinates for this site generates the same coordinates.
+    That is:
+            multiplicity of the general position
+            ------------------------------------
+            _atom_site.site_symmetry_multiplicity
+;
+    _name.category_id             atom_site
+    _name.object_id               site_symmetry_order
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Integer
+    _enumeration.range            1:48
+    _units.code                   none
+
+save_
+
+save_atom_site.type_symbol
+
+    _definition.id                '_atom_site.type_symbol'
+    _alias.definition_id          '_atom_site_type_symbol'
+    _definition.update            2021-10-27
+    _description.text
+;
+    A code to identify the atom specie(s) occupying this site.
+    This code must match a corresponding _atom_type.symbol. The
+    specification of this code is optional if component_0 of the
+    _atom_site.label is used for this purpose. See _atom_type.symbol.
+;
+    _name.category_id             atom_site
+    _name.object_id               type_symbol
+    _name.linked_item_id          '_atom_type.symbol'
+    _type.purpose                 Link
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Word
+
+    loop_
+      _description_example.case
+         Cu
+         Cu2+
+         S
+         O1-
+
+    _method.purpose               Evaluation
+    _method.expression
+;
+    _atom_site.type_symbol  =   AtomType ( _atom_site.label )
+;
+
+save_
+
+save_atom_site.u_equiv_geom_mean
+
+    _definition.id                '_atom_site.U_equiv_geom_mean'
+    _alias.definition_id          '_atom_site_U_equiv_geom_mean'
+    _definition.update            2012-11-20
+    _description.text
+;
+    Equivalent isotropic atomic displacement parameter, U(equiv),
+    in angstroms squared, calculated as the geometric mean of
+    the anisotropic atomic displacement parameters.
+
+               U(equiv) = (U~i~ U~j~ U~k~)^1/3^
+
+    U~n~ = the principal components of the orthogonalised U^ij^
+;
+    _name.category_id             atom_site
+    _name.object_id               U_equiv_geom_mean
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   angstrom_squared
+
+save_
+
+save_atom_site.u_equiv_geom_mean_su
+
+    _definition.id                '_atom_site.U_equiv_geom_mean_su'
+
+    loop_
+      _alias.definition_id
+         '_atom_site_U_equiv_geom_mean_su'
+         '_atom_site.U_equiv_geom_mean_esd'
+
+    _definition.update            2012-11-20
+    _description.text
+;
+    Standard uncertainty of _atom_site.U_equiv_geom_mean.
+;
+    _name.category_id             atom_site
+    _name.object_id               U_equiv_geom_mean_su
+    _name.linked_item_id          '_atom_site.U_equiv_geom_mean'
+    _units.code                   angstrom_squared
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+save_
+
+save_atom_site.u_iso_or_equiv
+
+    _definition.id                '_atom_site.U_iso_or_equiv'
+    _alias.definition_id          '_atom_site_U_iso_or_equiv'
+    _definition.update            2023-01-13
+    _description.text
+;
+    Isotropic atomic displacement parameter, or equivalent isotropic
+    atomic displacement parameter, U(equiv), in angstroms squared,
+    calculated from anisotropic atomic displacement parameters.
+
+       U(equiv) = (1/3) sum~i~[sum~j~(U^ij^ a*~i~ a*~j~ a~i~.a~j~)]
+
+    a  = the real-space cell vectors
+    a* = the reciprocal-space cell lengths
+    Ref: Fischer, R. X. & Tillmanns, E. (1988). Acta Cryst. C44, 775-776.
+;
+    _name.category_id             atom_site
+    _name.object_id               U_iso_or_equiv
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   angstrom_squared
+
+save_
+
+save_atom_site.u_iso_or_equiv_su
+
+    _definition.id                '_atom_site.U_iso_or_equiv_su'
+
+    loop_
+      _alias.definition_id
+         '_atom_site_U_iso_or_equiv_su'
+         '_atom_site.U_iso_or_equiv_esd'
+
+    _definition.update            2012-11-20
+    _description.text
+;
+    Standard uncertainty of _atom_site.U_iso_or_equiv.
+;
+    _name.category_id             atom_site
+    _name.object_id               U_iso_or_equiv_su
+    _name.linked_item_id          '_atom_site.U_iso_or_equiv'
+    _units.code                   angstrom_squared
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+save_
+
+save_atom_site.wyckoff_symbol
+
+    _definition.id                '_atom_site.Wyckoff_symbol'
+    _alias.definition_id          '_atom_site_Wyckoff_symbol'
+    _definition.update            2021-09-23
+    _description.text
+;
+    The Wyckoff symbol (letter) as listed in the space-group section
+    of International Tables for Crystallography, Vol. A (1987).
+;
+    _name.category_id             atom_site
+    _name.object_id               Wyckoff_symbol
+    _type.purpose                 State
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Text
+
+    _import.get
+        [{'file':templ_enum.cif  'save':wyckoff_letter}]
+
+save_
+
+save_ATOM_SITE_ANISO
+
+    _definition.id                ATOM_SITE_ANISO
+    _definition.scope             Category
+    _definition.class             Loop
+    _definition.update            2023-01-16
+    _description.text
+;
+    The CATEGORY of data items used to describe the anisotropic atomic
+    displacement parameters of the atomic sites in a crystal structure.
+;
+    _name.category_id             ATOM_SITE
+    _name.object_id               ATOM_SITE_ANISO
+    _category_key.name            '_atom_site_aniso.label'
+
+save_
+
+save_atom_site_aniso.b_11
+
+    _definition.id                '_atom_site_aniso.B_11'
+
+    loop_
+      _alias.definition_id
+         '_atom_site_aniso_B_11'
+         '_atom_site.aniso_B[1][1]'
+         '_atom_site_anisotrop.B[1][1]'
+
+    _name.category_id             atom_site_aniso
+    _name.object_id               B_11
+
+    _import.get                   [{'file':templ_attr.cif  'save':aniso_bij}]
+
+save_
+
+save_atom_site_aniso.b_11_su
+
+    _definition.id                '_atom_site_aniso.B_11_su'
+
+    loop_
+      _alias.definition_id
+         '_atom_site_aniso_B_11_su'
+         '_atom_site.aniso_B[1][1]_esd'
+         '_atom_site_anisotrop.B[1][1]_esd'
+
+    _name.category_id             atom_site_aniso
+    _name.object_id               B_11_su
+    _name.linked_item_id          '_atom_site_aniso.B_11'
+
+    _import.get                   [{'file':templ_attr.cif  'save':aniso_bij_su}]
+
+save_
+
+save_atom_site_aniso.b_12
+
+    _definition.id                '_atom_site_aniso.B_12'
+
+    loop_
+      _alias.definition_id
+         '_atom_site_aniso_B_12'
+         '_atom_site.aniso_B[1][2]'
+         '_atom_site_anisotrop.B[1][2]'
+
+    _name.category_id             atom_site_aniso
+    _name.object_id               B_12
+
+    _import.get                   [{'file':templ_attr.cif  'save':aniso_bij}]
+
+save_
+
+save_atom_site_aniso.b_12_su
+
+    _definition.id                '_atom_site_aniso.B_12_su'
+
+    loop_
+      _alias.definition_id
+         '_atom_site_aniso_B_12_su'
+         '_atom_site.aniso_B[1][2]_esd'
+         '_atom_site_anisotrop.B[1][2]_esd'
+
+    _name.category_id             atom_site_aniso
+    _name.object_id               B_12_su
+    _name.linked_item_id          '_atom_site_aniso.B_12'
+
+    _import.get                   [{'file':templ_attr.cif  'save':aniso_bij_su}]
+
+save_
+
+save_atom_site_aniso.b_13
+
+    _definition.id                '_atom_site_aniso.B_13'
+
+    loop_
+      _alias.definition_id
+         '_atom_site_aniso_B_13'
+         '_atom_site.aniso_B[1][3]'
+         '_atom_site_anisotrop.B[1][3]'
+
+    _name.category_id             atom_site_aniso
+    _name.object_id               B_13
+
+    _import.get                   [{'file':templ_attr.cif  'save':aniso_bij}]
+
+save_
+
+save_atom_site_aniso.b_13_su
+
+    _definition.id                '_atom_site_aniso.B_13_su'
+
+    loop_
+      _alias.definition_id
+         '_atom_site_aniso_B_13_su'
+         '_atom_site.aniso_B[1][3]_esd'
+         '_atom_site_anisotrop.B[1][3]_esd'
+
+    _name.category_id             atom_site_aniso
+    _name.object_id               B_13_su
+    _name.linked_item_id          '_atom_site_aniso.B_13'
+
+    _import.get                   [{'file':templ_attr.cif  'save':aniso_bij_su}]
+
+save_
+
+save_atom_site_aniso.b_22
+
+    _definition.id                '_atom_site_aniso.B_22'
+
+    loop_
+      _alias.definition_id
+         '_atom_site_aniso_B_22'
+         '_atom_site.aniso_B[2][2]'
+         '_atom_site_anisotrop.B[2][2]'
+
+    _name.category_id             atom_site_aniso
+    _name.object_id               B_22
+
+    _import.get                   [{'file':templ_attr.cif  'save':aniso_bij}]
+
+save_
+
+save_atom_site_aniso.b_22_su
+
+    _definition.id                '_atom_site_aniso.B_22_su'
+
+    loop_
+      _alias.definition_id
+         '_atom_site_aniso_B_22_su'
+         '_atom_site.aniso_B[2][2]_esd'
+         '_atom_site_anisotrop.B[2][2]_esd'
+
+    _name.category_id             atom_site_aniso
+    _name.object_id               B_22_su
+    _name.linked_item_id          '_atom_site_aniso.B_22'
+
+    _import.get                   [{'file':templ_attr.cif  'save':aniso_bij_su}]
+
+save_
+
+save_atom_site_aniso.b_23
+
+    _definition.id                '_atom_site_aniso.B_23'
+
+    loop_
+      _alias.definition_id
+         '_atom_site_aniso_B_23'
+         '_atom_site.aniso_B[2][3]'
+         '_atom_site_anisotrop.B[2][3]'
+
+    _name.category_id             atom_site_aniso
+    _name.object_id               B_23
+
+    _import.get                   [{'file':templ_attr.cif  'save':aniso_bij}]
+
+save_
+
+save_atom_site_aniso.b_23_su
+
+    _definition.id                '_atom_site_aniso.B_23_su'
+
+    loop_
+      _alias.definition_id
+         '_atom_site_aniso_B_23_su'
+         '_atom_site.aniso_B[2][3]_esd'
+         '_atom_site_anisotrop.B[2][3]_esd'
+
+    _name.category_id             atom_site_aniso
+    _name.object_id               B_23_su
+    _name.linked_item_id          '_atom_site_aniso.B_23'
+
+    _import.get                   [{'file':templ_attr.cif  'save':aniso_bij_su}]
+
+save_
+
+save_atom_site_aniso.b_33
+
+    _definition.id                '_atom_site_aniso.B_33'
+
+    loop_
+      _alias.definition_id
+         '_atom_site_aniso_B_33'
+         '_atom_site.aniso_B[3][3]'
+         '_atom_site_anisotrop.B[3][3]'
+
+    _name.category_id             atom_site_aniso
+    _name.object_id               B_33
+
+    _import.get                   [{'file':templ_attr.cif  'save':aniso_bij}]
+
+save_
+
+save_atom_site_aniso.b_33_su
+
+    _definition.id                '_atom_site_aniso.B_33_su'
+
+    loop_
+      _alias.definition_id
+         '_atom_site_aniso_B_33_su'
+         '_atom_site.aniso_B[3][3]_esd'
+         '_atom_site_anisotrop.B[3][3]_esd'
+
+    _name.category_id             atom_site_aniso
+    _name.object_id               B_33_su
+    _name.linked_item_id          '_atom_site_aniso.B_33'
+
+    _import.get                   [{'file':templ_attr.cif  'save':aniso_bij_su}]
+
+save_
+
+save_atom_site_aniso.beta_11
+
+    _definition.id                '_atom_site_aniso.beta_11'
+    _alias.definition_id          '_atom_site_aniso_beta_11'
+    _name.category_id             atom_site_aniso
+    _name.object_id               beta_11
+
+    _import.get                   [{'file':templ_attr.cif  'save':aniso_betaij}]
+
+save_
+
+save_atom_site_aniso.beta_11_su
+
+    _definition.id                '_atom_site_aniso.beta_11_su'
+    _alias.definition_id          '_atom_site_aniso_beta_11_su'
+    _name.category_id             atom_site_aniso
+    _name.object_id               beta_11_su
+    _name.linked_item_id          '_atom_site_aniso.beta_11'
+
+    _import.get
+        [{'file':templ_attr.cif  'save':aniso_betaij_su}]
+
+save_
+
+save_atom_site_aniso.beta_12
+
+    _definition.id                '_atom_site_aniso.beta_12'
+    _alias.definition_id          '_atom_site_aniso_beta_12'
+    _name.category_id             atom_site_aniso
+    _name.object_id               beta_12
+
+    _import.get                   [{'file':templ_attr.cif  'save':aniso_betaij}]
+
+save_
+
+save_atom_site_aniso.beta_12_su
+
+    _definition.id                '_atom_site_aniso.beta_12_su'
+    _alias.definition_id          '_atom_site_aniso_beta_12_su'
+    _name.category_id             atom_site_aniso
+    _name.object_id               beta_12_su
+    _name.linked_item_id          '_atom_site_aniso.beta_12'
+
+    _import.get
+        [{'file':templ_attr.cif  'save':aniso_betaij_su}]
+
+save_
+
+save_atom_site_aniso.beta_13
+
+    _definition.id                '_atom_site_aniso.beta_13'
+    _alias.definition_id          '_atom_site_aniso_beta_13'
+    _name.category_id             atom_site_aniso
+    _name.object_id               beta_13
+
+    _import.get                   [{'file':templ_attr.cif  'save':aniso_betaij}]
+
+save_
+
+save_atom_site_aniso.beta_13_su
+
+    _definition.id                '_atom_site_aniso.beta_13_su'
+    _alias.definition_id          '_atom_site_aniso_beta_13_su'
+    _name.category_id             atom_site_aniso
+    _name.object_id               beta_13_su
+    _name.linked_item_id          '_atom_site_aniso.beta_13'
+
+    _import.get
+        [{'file':templ_attr.cif  'save':aniso_betaij_su}]
+
+save_
+
+save_atom_site_aniso.beta_22
+
+    _definition.id                '_atom_site_aniso.beta_22'
+    _alias.definition_id          '_atom_site_aniso_beta_22'
+    _name.category_id             atom_site_aniso
+    _name.object_id               beta_22
+
+    _import.get                   [{'file':templ_attr.cif  'save':aniso_betaij}]
+
+save_
+
+save_atom_site_aniso.beta_22_su
+
+    _definition.id                '_atom_site_aniso.beta_22_su'
+    _alias.definition_id          '_atom_site_aniso_beta_22_su'
+    _name.category_id             atom_site_aniso
+    _name.object_id               beta_22_su
+    _name.linked_item_id          '_atom_site_aniso.beta_22'
+
+    _import.get
+        [{'file':templ_attr.cif  'save':aniso_betaij_su}]
+
+save_
+
+save_atom_site_aniso.beta_23
+
+    _definition.id                '_atom_site_aniso.beta_23'
+    _alias.definition_id          '_atom_site_aniso_beta_23'
+    _name.category_id             atom_site_aniso
+    _name.object_id               beta_23
+
+    _import.get                   [{'file':templ_attr.cif  'save':aniso_betaij}]
+
+save_
+
+save_atom_site_aniso.beta_23_su
+
+    _definition.id                '_atom_site_aniso.beta_23_su'
+    _alias.definition_id          '_atom_site_aniso_beta_23_su'
+    _name.category_id             atom_site_aniso
+    _name.object_id               beta_23_su
+    _name.linked_item_id          '_atom_site_aniso.beta_23'
+
+    _import.get
+        [{'file':templ_attr.cif  'save':aniso_betaij_su}]
+
+save_
+
+save_atom_site_aniso.beta_33
+
+    _definition.id                '_atom_site_aniso.beta_33'
+    _alias.definition_id          '_atom_site_aniso_beta_33'
+    _name.category_id             atom_site_aniso
+    _name.object_id               beta_33
+
+    _import.get                   [{'file':templ_attr.cif  'save':aniso_betaij}]
+
+save_
+
+save_atom_site_aniso.beta_33_su
+
+    _definition.id                '_atom_site_aniso.beta_33_su'
+    _alias.definition_id          '_atom_site_aniso_beta_33_su'
+    _name.category_id             atom_site_aniso
+    _name.object_id               beta_33_su
+    _name.linked_item_id          '_atom_site_aniso.beta_33'
+
+    _import.get
+        [{'file':templ_attr.cif  'save':aniso_betaij_su}]
+
+save_
+
+save_atom_site_aniso.label
+
+    _definition.id                '_atom_site_aniso.label'
+
+    loop_
+      _alias.definition_id
+         '_atom_site_aniso_label'
+         '_atom_site_anisotrop.id'
+
+    _definition.update            2019-04-03
+    _description.text
+;
+    Anisotropic atomic displacement parameters are usually looped in
+    a separate list. If this is the case, this code must match the
+    _atom_site.label of the associated atom in the atom coordinate
+    list and conform with the same rules described in _atom_site.label.
+;
+    _name.category_id             atom_site_aniso
+    _name.object_id               label
+    _name.linked_item_id          '_atom_site.label'
+    _type.purpose                 Link
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Word
+
+save_
+
+save_atom_site_aniso.matrix_b
+
+    _definition.id                '_atom_site_aniso.matrix_B'
+    _definition.update            2021-07-07
+    _description.text
+;
+    The symmetric anisotropic atomic displacement matrix B.
+;
+    _name.category_id             atom_site_aniso
+    _name.object_id               matrix_B
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               Matrix
+    _type.dimension               '[3,3]'
+    _type.contents                Real
+    _units.code                   angstrom_squared
+    _method.purpose               Evaluation
+    _method.expression
+;
+    With a as atom_site_aniso
+
+     a.matrix_B =  [[ a.B_11, a.B_12, a.B_13 ],
+                    [ a.B_12, a.B_22, a.B_23 ],
+                    [ a.B_13, a.B_23, a.B_33 ]]
+;
+
+save_
+
+save_atom_site_aniso.matrix_b_su
+
+    _definition.id                '_atom_site_aniso.matrix_B_su'
+    _definition.update            2023-07-01
+    _description.text
+;
+    Standard uncertainty of _atom_site_aniso.matrix_B.
+;
+    _name.category_id             atom_site_aniso
+    _name.object_id               matrix_B_su
+    _name.linked_item_id          '_atom_site_aniso.matrix_B'
+    _type.purpose                 SU
+    _type.source                  Related
+    _type.container               Matrix
+    _type.dimension               '[3,3]'
+    _type.contents                Real
+    _units.code                   angstrom_squared
+
+save_
+
+save_atom_site_aniso.matrix_beta
+
+    _definition.id                '_atom_site_aniso.matrix_beta'
+    _alias.definition_id          '_atom_site.tensor_beta'
+    _definition.update            2023-06-16
+    _description.text
+;
+    The symmetric anisotropic atomic displacement parameter (ADP) matrix, β,
+    which appears in a structure factor expression.
+
+    The contribution of the ADPs to the calculation of the structure factor is
+    given as:
+
+        T = exp(-1 * Sum(Sum(β^ij^ * h~i~ * h~j~, j=1:3), i=1:3))
+
+    where β^ij^ are the matrix elements, and h~m~ are the Miller indices.
+
+    The ADP matrix β, is related to the ADP matrices U and B, as follows:
+
+                |a~1~*   0     0  |   |t^11^ t^12^ t^13^|   |a~1~*   0     0  |
+        β = C * |  0   a~2~*   0  | * |t^12^ t^22^ t^23^| * |  0   a~2~*   0  |
+                |  0     0   a~3~*|   |t^13^ t^23^ t^33^|   |  0     0   a~3~*|
+
+    where C is a constant (2 * π^2^ for U, and 0.25 for B), a~i~* is the
+    length of the respective reciprocal unit cell vector, and t represents
+    the individual anisotropic values, U^ij^ or B^ij^.
+;
+    _name.category_id             atom_site_aniso
+    _name.object_id               matrix_beta
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               Matrix
+    _type.dimension               '[3,3]'
+    _type.contents                Real
+    _units.code                   none
+    _method.purpose               Evaluation
+    _method.expression
+;
+    With a as atom_site_aniso
+
+        label = a.label
+
+        If (a.ADP_type == 'betaani')
+        {
+            a.matrix_beta =  [[ a.beta_11, a.beta_12, a.beta_13 ],
+                              [ a.beta_12, a.beta_22, a.beta_23 ],
+                              [ a.beta_13, a.beta_23, a.beta_33 ]]
+        }
+        Else
+        {
+            If (a.ADP_type == 'Uani')
+            {
+                UIJ = b.matrix_U
+            }
+            Else If (a.ADP_type == 'Bani')
+            {
+                UIJ = b.matrix_B / (8 * Pi**2)
+            }
+            Else {
+                If (a.ADP_type == 'Uiso')
+                {
+                    Loop b as atom_site
+                    {
+                        If(label == b.label)
+                        {
+                            U  =  b.U_iso_or_equiv
+                            Break
+                        }
+                    }
+                }
+                Else If (a.ADP_type == 'Biso')
+                {
+                    Loop b as atom_site
+                    {
+                        If(label == b.label)
+                        {
+                            U  = b.B_iso_or_equiv / (8 * Pi**2)
+                            Break
+                        }
+                    }
+                }
+                UIJ = U * _cell.convert_Uiso_to_Uij
+            }
+            CUB = _cell.convert_Uij_to_betaij
+            a.matrix_beta =  CUB * UIJ * CUB
+        }
+;
+
+save_
+
+save_atom_site_aniso.matrix_beta_su
+
+    _definition.id                '_atom_site_aniso.matrix_beta_su'
+    _alias.definition_id          '_atom_site.tensor_beta_su'
+    _definition.update            2023-07-01
+    _description.text
+;
+    Standard uncertainty of _atom_site_aniso.matrix_beta.
+;
+    _name.category_id             atom_site_aniso
+    _name.object_id               matrix_beta_su
+    _name.linked_item_id          '_atom_site_aniso.matrix_beta'
+    _type.purpose                 SU
+    _type.source                  Related
+    _type.container               Matrix
+    _type.dimension               '[3,3]'
+    _type.contents                Real
+    _units.code                   none
+
+save_
+
+save_atom_site_aniso.matrix_u
+
+    _definition.id                '_atom_site_aniso.matrix_U'
+    _definition.update            2021-07-07
+    _description.text
+;
+    The symmetric anisotropic atomic displacement matrix U.
+;
+    _name.category_id             atom_site_aniso
+    _name.object_id               matrix_U
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               Matrix
+    _type.dimension               '[3,3]'
+    _type.contents                Real
+    _units.code                   angstrom_squared
+    _method.purpose               Evaluation
+    _method.expression
+;
+    With a as atom_site_aniso
+
+       a.matrix_U =  [[ a.U_11, a.U_12, a.U_13 ],
+                      [ a.U_12, a.U_22, a.U_23 ],
+                      [ a.U_13, a.U_23, a.U_33 ]]
+;
+
+save_
+
+save_atom_site_aniso.matrix_u_su
+
+    _definition.id                '_atom_site_aniso.matrix_U_su'
+    _definition.update            2023-07-01
+    _description.text
+;
+    Standard uncertainty of _atom_site_aniso.matrix_U.
+;
+    _name.category_id             atom_site_aniso
+    _name.object_id               matrix_U_su
+    _name.linked_item_id          '_atom_site_aniso.matrix_U'
+    _type.purpose                 SU
+    _type.source                  Related
+    _type.container               Matrix
+    _type.dimension               '[3,3]'
+    _type.contents                Real
+    _units.code                   angstrom_squared
+
+save_
+
+save_atom_site_aniso.ratio
+
+    _definition.id                '_atom_site_aniso.ratio'
+
+    loop_
+      _alias.definition_id
+         '_atom_site_aniso_ratio'
+         '_atom_site_anisotrop.ratio'
+         '_atom_site.aniso_ratio'
+
+    _definition.update            2023-01-16
+    _description.text
+;
+    Ratio of the maximum to minimum eigenvalues of the atomic displacement
+    ellipsoids.
+;
+    _name.category_id             atom_site_aniso
+    _name.object_id               ratio
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            1.0:
+    _units.code                   none
+
+save_
+
+save_atom_site_aniso.symmform
+
+    _definition.id                '_atom_site_aniso.symmform'
+    _alias.definition_id          '_atom_site_aniso_symmform'
+    _definition.update            2024-02-20
+    _description.text
+;
+    A symbolic expression that indicates the symmetry-restricted form of the
+    components of the anisotropic displacement parameters of an atom, where the
+    tensor components are ordered as A11, A22, A33, A23, A13, A12.
+;
+    _name.category_id             atom_site_aniso
+    _name.object_id               symmform
+    _type.purpose                 Encode
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Text
+
+    loop_
+      _description_example.case
+      _description_example.detail
+         A11,A22,A33,A23,A13,A12
+;
+             No symmetry restrictions.
+;
+         A11,A11,A11
+;
+             Diagonal terms equal, zeros off-diagonal.
+;
+         A11,A22,A33,0,0,0
+;
+             Diagonal terms distinct, zeros off-diagonal.
+;
+
+save_
+
+save_atom_site_aniso.type_symbol
+
+    _definition.id                '_atom_site_aniso.type_symbol'
+
+    loop_
+      _alias.definition_id
+         '_atom_site_aniso_type_symbol'
+         '_atom_site_anisotrop.type_symbol'
+
+    _definition.update            2023-01-16
+    _description.text
+;
+    This _atom_type.symbol code links the anisotropic atomic displacement
+    parameters to the atom type data associated with this site and must match
+    one of the _atom_type.symbol codes in this list.
+;
+    _name.category_id             atom_site_aniso
+    _name.object_id               type_symbol
+    _name.linked_item_id          '_atom_type.symbol'
+    _type.purpose                 Link
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Word
+    _method.purpose               Evaluation
+    _method.expression
+;
+    _atom_site_aniso.type_symbol  =   AtomType ( _atom_site_aniso.label )
+;
+
+save_
+
+save_atom_site_aniso.u_11
+
+    _definition.id                '_atom_site_aniso.U_11'
+
+    loop_
+      _alias.definition_id
+         '_atom_site_aniso_U_11'
+         '_atom_site.aniso_U[1][1]'
+         '_atom_site_anisotrop.U[1][1]'
+
+    _name.category_id             atom_site_aniso
+    _name.object_id               U_11
+
+    _import.get                   [{'file':templ_attr.cif  'save':aniso_uij}]
+
+save_
+
+save_atom_site_aniso.u_11_su
+
+    _definition.id                '_atom_site_aniso.U_11_su'
+
+    loop_
+      _alias.definition_id
+         '_atom_site_aniso_U_11_su'
+         '_atom_site.aniso_U[1][1]_esd'
+         '_atom_site_anisotrop.U[1][1]_esd'
+
+    _name.category_id             atom_site_aniso
+    _name.object_id               U_11_su
+    _name.linked_item_id          '_atom_site_aniso.U_11'
+
+    _import.get                   [{'file':templ_attr.cif  'save':aniso_uij_su}]
+
+save_
+
+save_atom_site_aniso.u_12
+
+    _definition.id                '_atom_site_aniso.U_12'
+
+    loop_
+      _alias.definition_id
+         '_atom_site_aniso_U_12'
+         '_atom_site.aniso_U[1][2]'
+         '_atom_site_anisotrop.U[1][2]'
+
+    _name.category_id             atom_site_aniso
+    _name.object_id               U_12
+
+    _import.get                   [{'file':templ_attr.cif  'save':aniso_uij}]
+
+save_
+
+save_atom_site_aniso.u_12_su
+
+    _definition.id                '_atom_site_aniso.U_12_su'
+
+    loop_
+      _alias.definition_id
+         '_atom_site_aniso_U_12_su'
+         '_atom_site.aniso_U[1][2]_esd'
+         '_atom_site_anisotrop.U[1][2]_esd'
+
+    _name.category_id             atom_site_aniso
+    _name.object_id               U_12_su
+    _name.linked_item_id          '_atom_site_aniso.U_12'
+
+    _import.get                   [{'file':templ_attr.cif  'save':aniso_uij_su}]
+
+save_
+
+save_atom_site_aniso.u_13
+
+    _definition.id                '_atom_site_aniso.U_13'
+
+    loop_
+      _alias.definition_id
+         '_atom_site_aniso_U_13'
+         '_atom_site.aniso_U[1][3]'
+         '_atom_site_anisotrop.U[1][3]'
+
+    _name.category_id             atom_site_aniso
+    _name.object_id               U_13
+
+    _import.get                   [{'file':templ_attr.cif  'save':aniso_uij}]
+
+save_
+
+save_atom_site_aniso.u_13_su
+
+    _definition.id                '_atom_site_aniso.U_13_su'
+
+    loop_
+      _alias.definition_id
+         '_atom_site_aniso_U_13_su'
+         '_atom_site.aniso_U[1][3]_esd'
+         '_atom_site_anisotrop.U[1][3]_esd'
+
+    _name.category_id             atom_site_aniso
+    _name.object_id               U_13_su
+    _name.linked_item_id          '_atom_site_aniso.U_13'
+
+    _import.get                   [{'file':templ_attr.cif  'save':aniso_uij_su}]
+
+save_
+
+save_atom_site_aniso.u_22
+
+    _definition.id                '_atom_site_aniso.U_22'
+
+    loop_
+      _alias.definition_id
+         '_atom_site_aniso_U_22'
+         '_atom_site.aniso_U[2][2]'
+         '_atom_site_anisotrop.U[2][2]'
+
+    _name.category_id             atom_site_aniso
+    _name.object_id               U_22
+
+    _import.get                   [{'file':templ_attr.cif  'save':aniso_uij}]
+
+save_
+
+save_atom_site_aniso.u_22_su
+
+    _definition.id                '_atom_site_aniso.U_22_su'
+
+    loop_
+      _alias.definition_id
+         '_atom_site_aniso_U_22_su'
+         '_atom_site.aniso_U[2][2]_esd'
+         '_atom_site_anisotrop.U[2][2]_esd'
+
+    _name.category_id             atom_site_aniso
+    _name.object_id               U_22_su
+    _name.linked_item_id          '_atom_site_aniso.U_22'
+
+    _import.get                   [{'file':templ_attr.cif  'save':aniso_uij_su}]
+
+save_
+
+save_atom_site_aniso.u_23
+
+    _definition.id                '_atom_site_aniso.U_23'
+
+    loop_
+      _alias.definition_id
+         '_atom_site_aniso_U_23'
+         '_atom_site.aniso_U[2][3]'
+         '_atom_site_anisotrop.U[2][3]'
+
+    _name.category_id             atom_site_aniso
+    _name.object_id               U_23
+
+    _import.get                   [{'file':templ_attr.cif  'save':aniso_uij}]
+
+save_
+
+save_atom_site_aniso.u_23_su
+
+    _definition.id                '_atom_site_aniso.U_23_su'
+
+    loop_
+      _alias.definition_id
+         '_atom_site_aniso_U_23_su'
+         '_atom_site.aniso_U[2][3]_esd'
+         '_atom_site_anisotrop.U[2][3]_esd'
+
+    _name.category_id             atom_site_aniso
+    _name.object_id               U_23_su
+    _name.linked_item_id          '_atom_site_aniso.U_23'
+
+    _import.get                   [{'file':templ_attr.cif  'save':aniso_uij_su}]
+
+save_
+
+save_atom_site_aniso.u_33
+
+    _definition.id                '_atom_site_aniso.U_33'
+
+    loop_
+      _alias.definition_id
+         '_atom_site_aniso_U_33'
+         '_atom_site.aniso_U[3][3]'
+         '_atom_site_anisotrop.U[3][3]'
+
+    _name.category_id             atom_site_aniso
+    _name.object_id               U_33
+
+    _import.get                   [{'file':templ_attr.cif  'save':aniso_uij}]
+
+save_
+
+save_atom_site_aniso.u_33_su
+
+    _definition.id                '_atom_site_aniso.U_33_su'
+
+    loop_
+      _alias.definition_id
+         '_atom_site_aniso_U_33_su'
+         '_atom_site.aniso_U[3][3]_esd'
+         '_atom_site_anisotrop.U[3][3]_esd'
+
+    _name.category_id             atom_site_aniso
+    _name.object_id               U_33_su
+    _name.linked_item_id          '_atom_site_aniso.U_33'
+
+    _import.get                   [{'file':templ_attr.cif  'save':aniso_uij_su}]
+
+save_
+
+save_ATOM_SITES
+
+    _definition.id                ATOM_SITES
+    _definition.scope             Category
+    _definition.class             Set
+    _definition.update            2012-11-20
+    _description.text
+;
+    The CATEGORY of data items used to describe information which applies
+    to all atom sites in a crystal structure.
+;
+    _name.category_id             ATOM
+    _name.object_id               ATOM_SITES
+
+save_
+
+save_atom_sites.solution_hydrogens
+
+    _definition.id                '_atom_sites.solution_hydrogens'
+    _alias.definition_id          '_atom_sites_solution_hydrogens'
+    _definition.update            2012-11-20
+    _description.text
+;
+    Codes which identify the methods used to locate the initial
+    atom sites. The *_primary code identifies how the first
+    atom sites were determined; the *_secondary code identifies
+    how the remaining non-hydrogen sites were located; and the
+    *_hydrogens code identifies how the hydrogen sites were located.
+
+    Ref: Sheldrick, G. M., Hauptman, H. A., Weeks, C. M.,
+         Miller, R. and Usón, I. (2001). Ab initio phasing.
+         In International Tables for Crystallography,
+         Vol. F. Crystallography of biological macromolecules,
+         edited by M. G. Rossmann and E. Arnold, ch. 16.1.
+         Dordrecht: Kluwer Academic Publishers.
+;
+    _name.category_id             atom_sites
+    _name.object_id               solution_hydrogens
+    _type.purpose                 State
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Text
+
+    loop_
+      _enumeration_set.state
+      _enumeration_set.detail
+         difmap
+;
+         Difference Fourier map.
+;
+         vecmap
+;
+         Real-space vector search.
+;
+         heavy
+;
+         Heavy-atom method.
+;
+         direct
+;
+         Structure-invariant direct methods.
+;
+         geom
+;
+         Inferred from neighbouring sites.
+;
+         disper
+;
+         Anomalous-dispersion techniques.
+;
+         isomor
+;
+         Isomorphous structure methods.
+;
+         mixed
+;
+         A mixture of "geom" and "difmap".
+;
+         notdet
+;
+         Coordinates were not determined.
+;
+         dual
+;
+         Dual-space method (Sheldrick et al., 2001).
+;
+         iterative
+;
+         Iterative e.g. charge flipping [Oszlányi, G. and Süto, A. (2004).
+         Acta Cryst. A60, 134-141].
+;
+         other
+;
+         A method not included elsewhere in this list.
+;
+
+save_
+
+save_atom_sites.solution_primary
+
+    _definition.id                '_atom_sites.solution_primary'
+    _alias.definition_id          '_atom_sites_solution_primary'
+    _definition.update            2012-11-20
+    _description.text
+;
+    Codes which identify the methods used to locate the initial
+    atom sites. The *_primary code identifies how the first
+    atom sites were determined; the *_secondary code identifies
+    how the remaining non-hydrogen sites were located; and the
+    *_hydrogens code identifies how the hydrogen sites were located.
+
+    Ref: Sheldrick, G. M., Hauptman, H. A., Weeks, C. M.,
+         Miller, R. and Usón, I. (2001). Ab initio phasing.
+         In International Tables for Crystallography,
+         Vol. F. Crystallography of biological macromolecules,
+         edited by M. G. Rossmann and E. Arnold, ch. 16.1.
+         Dordrecht: Kluwer Academic Publishers.
+;
+    _name.category_id             atom_sites
+    _name.object_id               solution_primary
+    _type.purpose                 State
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Text
+
+    loop_
+      _enumeration_set.state
+      _enumeration_set.detail
+         difmap
+;
+         Difference Fourier map.
+;
+         vecmap
+;
+         Real-space vector search.
+;
+         heavy
+;
+         Heavy-atom method.
+;
+         direct
+;
+         Structure-invariant direct methods.
+;
+         geom
+;
+         Inferred from neighbouring sites.
+;
+         disper
+;
+         Anomalous-dispersion techniques.
+;
+         isomor
+;
+         Isomorphous structure methods.
+;
+         notdet
+;
+         Coordinates were not determined.
+;
+         dual
+;
+         Dual-space method (Sheldrick et al., 2001).
+;
+         iterative
+;
+         Iterative e.g. charge flipping [Oszlányi, G. and Süto, A. (2004).
+         Acta Cryst. A60, 134-141].
+;
+         other
+;
+         A method not included elsewhere in this list.
+;
+
+save_
+
+save_atom_sites.solution_secondary
+
+    _definition.id                '_atom_sites.solution_secondary'
+    _alias.definition_id          '_atom_sites_solution_secondary'
+    _definition.update            2012-11-20
+    _description.text
+;
+    Codes which identify the methods used to locate the initial
+    atom sites. The *_primary code identifies how the first
+    atom sites were determined; the *_secondary code identifies
+    how the remaining non-hydrogen sites were located; and the
+    *_hydrogens code identifies how the hydrogen sites were located.
+
+    Ref: Sheldrick, G. M., Hauptman, H. A., Weeks, C. M.,
+         Miller, R. and Usón, I. (2001). Ab initio phasing.
+         In International Tables for Crystallography,
+         Vol. F. Crystallography of biological macromolecules,
+         edited by M. G. Rossmann and E. Arnold, ch. 16.1.
+         Dordrecht: Kluwer Academic Publishers.
+;
+    _name.category_id             atom_sites
+    _name.object_id               solution_secondary
+    _type.purpose                 State
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Text
+
+    loop_
+      _enumeration_set.state
+      _enumeration_set.detail
+         difmap
+;
+         Difference Fourier map.
+;
+         vecmap
+;
+         Real-space vector search.
+;
+         heavy
+;
+         Heavy-atom method.
+;
+         direct
+;
+         Structure-invariant direct methods.
+;
+         geom
+;
+         Inferred from neighbouring sites.
+;
+         disper
+;
+         Anomalous-dispersion techniques.
+;
+         isomor
+;
+         Isomorphous structure methods.
+;
+         notdet
+;
+         Coordinates were not determined.
+;
+         dual
+;
+         Dual-space method (Sheldrick et al., 2001).
+;
+         iterative
+;
+         Iterative e.g. charge flipping [Oszlányi, G. and Süto, A. (2004).
+         Acta Cryst. A60, 134-141].
+;
+         other
+;
+         A method not included elsewhere in this list.
+;
+
+save_
+
+save_atom_sites.special_details
+
+    _definition.id                '_atom_sites.special_details'
+    _alias.definition_id          '_atom_sites_special_details'
+    _definition.update            2012-11-20
+    _description.text
+;
+    Information about atomic coordinates not coded elsewhere in the CIF.
+;
+    _name.category_id             atom_sites
+    _name.object_id               special_details
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_ATOM_SITES_CARTN_TRANSFORM
+
+    _definition.id                ATOM_SITES_CARTN_TRANSFORM
+    _definition.scope             Category
+    _definition.class             Set
+    _definition.update            2021-03-03
+    _description.text
+;
+    The CATEGORY of data items used to describe the matrix elements
+    used to transform fractional coordinates into Cartesian coordinates
+    of all atom sites in a crystal structure.
+;
+    _name.category_id             ATOM_SITES
+    _name.object_id               ATOM_SITES_CARTN_TRANSFORM
+
+save_
+
+save_atom_sites_cartn_transform.axes
+
+    _definition.id                '_atom_sites_Cartn_transform.axes'
+
+    loop_
+      _alias.definition_id
+         '_atom_sites_Cartn_transform_axes'
+         '_atom_sites.Cartn_transform_axes'
+
+    _definition.update            2012-12-11
+    _description.text
+;
+    Description of the relative alignment of the crystal cell axes to the
+    Cartesian orthogonal axes as applied in the transformation matrix
+    _atom_sites_Cartn_transform.matrix.
+;
+    _name.category_id             atom_sites_Cartn_transform
+    _name.object_id               axes
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+    _description_example.case     'a parallel to x; b in the plane of x & y'
+
+save_
+
+save_atom_sites_cartn_transform.mat_11
+
+    _definition.id                '_atom_sites_Cartn_transform.mat_11'
+
+    loop_
+      _alias.definition_id
+         '_atom_sites_Cartn_tran_matrix_11'
+         '_atom_sites.Cartn_transf_matrix[1][1]'
+
+    _name.category_id             atom_sites_Cartn_transform
+    _name.object_id               mat_11
+
+    _import.get                   [{'file':templ_attr.cif  'save':cartn_matrix}]
+
+    _method.purpose               Definition
+    _method.expression
+;
+     With c as cell
+
+    _enumeration.default =
+    c.length_a*Sind(c.angle_beta)*Sind(c.reciprocal_angle_gamma)
+;
+
+save_
+
+save_atom_sites_cartn_transform.mat_11_su
+
+    _definition.id                '_atom_sites_Cartn_transform.mat_11_su'
+    _definition.update            2023-07-01
+    _description.text
+;
+    Standard uncertainty of _atom_sites_Cartn_transform.mat_11.
+;
+    _name.category_id             atom_sites_Cartn_transform
+    _name.object_id               mat_11_su
+    _name.linked_item_id          '_atom_sites_Cartn_transform.mat_11'
+    _units.code                   angstroms
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+save_
+
+save_atom_sites_cartn_transform.mat_12
+
+    _definition.id                '_atom_sites_Cartn_transform.mat_12'
+
+    loop_
+      _alias.definition_id
+         '_atom_sites_Cartn_tran_matrix_12'
+         '_atom_sites.Cartn_transf_matrix[1][2]'
+
+    _name.category_id             atom_sites_Cartn_transform
+    _name.object_id               mat_12
+
+    _import.get                   [{'file':templ_attr.cif  'save':cartn_matrix}]
+
+    _method.purpose               Definition
+    _method.expression
+;
+    _enumeration.default =  0.
+;
+
+save_
+
+save_atom_sites_cartn_transform.mat_12_su
+
+    _definition.id                '_atom_sites_Cartn_transform.mat_12_su'
+    _definition.update            2023-07-01
+    _description.text
+;
+    Standard uncertainty of _atom_sites_Cartn_transform.mat_12.
+;
+    _name.category_id             atom_sites_Cartn_transform
+    _name.object_id               mat_12_su
+    _name.linked_item_id          '_atom_sites_Cartn_transform.mat_12'
+    _units.code                   angstroms
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+save_
+
+save_atom_sites_cartn_transform.mat_13
+
+    _definition.id                '_atom_sites_Cartn_transform.mat_13'
+
+    loop_
+      _alias.definition_id
+         '_atom_sites_Cartn_tran_matrix_13'
+         '_atom_sites.Cartn_transf_matrix[1][3]'
+
+    _name.category_id             atom_sites_Cartn_transform
+    _name.object_id               mat_13
+
+    _import.get                   [{'file':templ_attr.cif  'save':cartn_matrix}]
+
+    _method.purpose               Definition
+    _method.expression
+;
+    _enumeration.default =  0.
+;
+
+save_
+
+save_atom_sites_cartn_transform.mat_13_su
+
+    _definition.id                '_atom_sites_Cartn_transform.mat_13_su'
+    _definition.update            2023-07-01
+    _description.text
+;
+    Standard uncertainty of _atom_sites_Cartn_transform.mat_13.
+;
+    _name.category_id             atom_sites_Cartn_transform
+    _name.object_id               mat_13_su
+    _name.linked_item_id          '_atom_sites_Cartn_transform.mat_13'
+    _units.code                   angstroms
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+save_
+
+save_atom_sites_cartn_transform.mat_21
+
+    _definition.id                '_atom_sites_Cartn_transform.mat_21'
+
+    loop_
+      _alias.definition_id
+         '_atom_sites_Cartn_tran_matrix_21'
+         '_atom_sites.Cartn_transf_matrix[2][1]'
+
+    _name.category_id             atom_sites_Cartn_transform
+    _name.object_id               mat_21
+
+    _import.get                   [{'file':templ_attr.cif  'save':cartn_matrix}]
+
+    _method.purpose               Definition
+    _method.expression
+;
+     with c as cell
+
+    _enumeration.default =
+    -c.length_a*Sind(c.angle_beta)*Cosd(c.reciprocal_angle_gamma)
+;
+
+save_
+
+save_atom_sites_cartn_transform.mat_21_su
+
+    _definition.id                '_atom_sites_Cartn_transform.mat_21_su'
+    _definition.update            2023-07-01
+    _description.text
+;
+    Standard uncertainty of _atom_sites_Cartn_transform.mat_21.
+;
+    _name.category_id             atom_sites_Cartn_transform
+    _name.object_id               mat_21_su
+    _name.linked_item_id          '_atom_sites_Cartn_transform.mat_21'
+    _units.code                   angstroms
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+save_
+
+save_atom_sites_cartn_transform.mat_22
+
+    _definition.id                '_atom_sites_Cartn_transform.mat_22'
+
+    loop_
+      _alias.definition_id
+         '_atom_sites_Cartn_tran_matrix_22'
+         '_atom_sites.Cartn_transf_matrix[2][2]'
+
+    _name.category_id             atom_sites_Cartn_transform
+    _name.object_id               mat_22
+
+    _import.get                   [{'file':templ_attr.cif  'save':cartn_matrix}]
+
+    _method.purpose               Definition
+    _method.expression
+;
+     With c  as  cell
+
+    _enumeration.default =  c.length_b * Sind(c.angle_alpha)
+;
+
+save_
+
+save_atom_sites_cartn_transform.mat_22_su
+
+    _definition.id                '_atom_sites_Cartn_transform.mat_22_su'
+    _definition.update            2023-07-01
+    _description.text
+;
+    Standard uncertainty of _atom_sites_Cartn_transform.mat_22.
+;
+    _name.category_id             atom_sites_Cartn_transform
+    _name.object_id               mat_22_su
+    _name.linked_item_id          '_atom_sites_Cartn_transform.mat_22'
+    _units.code                   angstroms
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+save_
+
+save_atom_sites_cartn_transform.mat_23
+
+    _definition.id                '_atom_sites_Cartn_transform.mat_23'
+
+    loop_
+      _alias.definition_id
+         '_atom_sites_Cartn_tran_matrix_23'
+         '_atom_sites.Cartn_transf_matrix[2][3]'
+
+    _name.category_id             atom_sites_Cartn_transform
+    _name.object_id               mat_23
+
+    _import.get                   [{'file':templ_attr.cif  'save':cartn_matrix}]
+
+    _method.purpose               Definition
+    _method.expression
+;
+    _enumeration.default =  0.
+;
+
+save_
+
+save_atom_sites_cartn_transform.mat_23_su
+
+    _definition.id                '_atom_sites_Cartn_transform.mat_23_su'
+    _definition.update            2023-07-01
+    _description.text
+;
+    Standard uncertainty of _atom_sites_Cartn_transform.mat_23.
+;
+    _name.category_id             atom_sites_Cartn_transform
+    _name.object_id               mat_23_su
+    _name.linked_item_id          '_atom_sites_Cartn_transform.mat_23'
+    _units.code                   angstroms
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+save_
+
+save_atom_sites_cartn_transform.mat_31
+
+    _definition.id                '_atom_sites_Cartn_transform.mat_31'
+
+    loop_
+      _alias.definition_id
+         '_atom_sites_Cartn_tran_matrix_31'
+         '_atom_sites.Cartn_transf_matrix[3][1]'
+
+    _name.category_id             atom_sites_Cartn_transform
+    _name.object_id               mat_31
+
+    _import.get                   [{'file':templ_attr.cif  'save':cartn_matrix}]
+
+    _method.purpose               Definition
+    _method.expression
+;
+     With c  as  cell
+
+    _enumeration.default =  c.length_a * Cosd(c.angle_beta)
+;
+
+save_
+
+save_atom_sites_cartn_transform.mat_31_su
+
+    _definition.id                '_atom_sites_Cartn_transform.mat_31_su'
+    _definition.update            2023-07-01
+    _description.text
+;
+    Standard uncertainty of _atom_sites_Cartn_transform.mat_31.
+;
+    _name.category_id             atom_sites_Cartn_transform
+    _name.object_id               mat_31_su
+    _name.linked_item_id          '_atom_sites_Cartn_transform.mat_31'
+    _units.code                   angstroms
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+save_
+
+save_atom_sites_cartn_transform.mat_32
+
+    _definition.id                '_atom_sites_Cartn_transform.mat_32'
+
+    loop_
+      _alias.definition_id
+         '_atom_sites_Cartn_tran_matrix_32'
+         '_atom_sites.Cartn_transf_matrix[3][2]'
+
+    _name.category_id             atom_sites_Cartn_transform
+    _name.object_id               mat_32
+
+    _import.get                   [{'file':templ_attr.cif  'save':cartn_matrix}]
+
+    _method.purpose               Definition
+    _method.expression
+;
+     With c  as  cell
+
+    _enumeration.default =  c.length_b * Cosd(c.angle_alpha)
+;
+
+save_
+
+save_atom_sites_cartn_transform.mat_32_su
+
+    _definition.id                '_atom_sites_Cartn_transform.mat_32_su'
+    _definition.update            2023-07-01
+    _description.text
+;
+    Standard uncertainty of _atom_sites_Cartn_transform.mat_32.
+;
+    _name.category_id             atom_sites_Cartn_transform
+    _name.object_id               mat_32_su
+    _name.linked_item_id          '_atom_sites_Cartn_transform.mat_32'
+    _units.code                   angstroms
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+save_
+
+save_atom_sites_cartn_transform.mat_33
+
+    _definition.id                '_atom_sites_Cartn_transform.mat_33'
+
+    loop_
+      _alias.definition_id
+         '_atom_sites_Cartn_tran_matrix_33'
+         '_atom_sites.Cartn_transf_matrix[3][3]'
+
+    _name.category_id             atom_sites_Cartn_transform
+    _name.object_id               mat_33
+
+    _import.get                   [{'file':templ_attr.cif  'save':cartn_matrix}]
+
+    _method.purpose               Definition
+    _method.expression
+;
+    _enumeration.default =  _cell.length_c
+;
+
+save_
+
+save_atom_sites_cartn_transform.mat_33_su
+
+    _definition.id                '_atom_sites_Cartn_transform.mat_33_su'
+    _definition.update            2023-07-01
+    _description.text
+;
+    Standard uncertainty of _atom_sites_Cartn_transform.mat_33.
+;
+    _name.category_id             atom_sites_Cartn_transform
+    _name.object_id               mat_33_su
+    _name.linked_item_id          '_atom_sites_Cartn_transform.mat_33'
+    _units.code                   angstroms
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+save_
+
+save_atom_sites_cartn_transform.matrix
+
+    _definition.id                '_atom_sites_Cartn_transform.matrix'
+    _definition.update            2021-07-07
+    _description.text
+;
+    Matrix used to transform fractional coordinates in the ATOM_SITE
+    category to Cartesian coordinates. The axial alignments of this
+    transformation are described in _atom_sites_Cartn_transform.axes.
+    The 3 x 1 translation is defined in _atom_sites_Cartn_transform.vector.
+
+      x'                   |11 12 13|     x                  | 1 |
+    ( y' ) Cartesian   =   |21 22 23| * ( y ) fractional  + v| 2 |
+      z'                   |31 32 33|     z                  | 3 |
+
+    The default transformation matrix uses Rollet's axial
+    assignments with cell vectors a,b,c aligned with orthogonal
+    axes X,Y,Z so that c||Z and b in plane YZ.
+;
+    _name.category_id             atom_sites_Cartn_transform
+    _name.object_id               matrix
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               Matrix
+    _type.dimension               '[3,3]'
+    _type.contents                Real
+    _units.code                   angstroms
+    _method.purpose               Evaluation
+    _method.expression
+;
+    With a as atom_sites_Cartn_transform
+
+    _atom_sites_Cartn_transform.matrix = [[a.mat_11, a.mat_12, a.mat_13],
+                                          [a.mat_21, a.mat_22, a.mat_23],
+                                          [a.mat_31, a.mat_32, a.mat_33]]
+;
+
+save_
+
+save_atom_sites_cartn_transform.matrix_su
+
+    _definition.id                '_atom_sites_Cartn_transform.matrix_su'
+    _definition.update            2023-07-01
+    _description.text
+;
+    Standard uncertainty of _atom_sites_Cartn_transform.matrix.
+;
+    _name.category_id             atom_sites_Cartn_transform
+    _name.object_id               matrix_su
+    _name.linked_item_id          '_atom_sites_Cartn_transform.matrix'
+    _type.purpose                 SU
+    _type.source                  Related
+    _type.container               Matrix
+    _type.dimension               '[3,3]'
+    _type.contents                Real
+    _units.code                   angstroms
+
+save_
+
+save_atom_sites_cartn_transform.vec_1
+
+    _definition.id                '_atom_sites_Cartn_transform.vec_1'
+
+    loop_
+      _alias.definition_id
+         '_atom_sites_Cartn_tran_vector_1'
+         '_atom_sites.Cartn_transf_vector[1]'
+
+    _name.category_id             atom_sites_Cartn_transform
+    _name.object_id               vec_1
+
+    _import.get                   [{'file':templ_attr.cif  'save':cartn_vector}]
+
+save_
+
+save_atom_sites_cartn_transform.vec_1_su
+
+    _definition.id                '_atom_sites_Cartn_transform.vec_1_su'
+    _definition.update            2023-07-01
+    _description.text
+;
+    Standard uncertainty of _atom_sites_Cartn_transform.vec_1.
+;
+    _name.category_id             atom_sites_Cartn_transform
+    _name.object_id               vec_1_su
+    _name.linked_item_id          '_atom_sites_Cartn_transform.vec_1'
+    _units.code                   angstroms
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+save_
+
+save_atom_sites_cartn_transform.vec_2
+
+    _definition.id                '_atom_sites_Cartn_transform.vec_2'
+
+    loop_
+      _alias.definition_id
+         '_atom_sites_Cartn_tran_vector_2'
+         '_atom_sites.Cartn_transf_vector[2]'
+
+    _name.category_id             atom_sites_Cartn_transform
+    _name.object_id               vec_2
+
+    _import.get                   [{'file':templ_attr.cif  'save':cartn_vector}]
+
+save_
+
+save_atom_sites_cartn_transform.vec_2_su
+
+    _definition.id                '_atom_sites_Cartn_transform.vec_2_su'
+    _definition.update            2023-07-01
+    _description.text
+;
+    Standard uncertainty of _atom_sites_Cartn_transform.vec_2.
+;
+    _name.category_id             atom_sites_Cartn_transform
+    _name.object_id               vec_2_su
+    _name.linked_item_id          '_atom_sites_Cartn_transform.vec_2'
+    _units.code                   angstroms
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+save_
+
+save_atom_sites_cartn_transform.vec_3
+
+    _definition.id                '_atom_sites_Cartn_transform.vec_3'
+
+    loop_
+      _alias.definition_id
+         '_atom_sites_Cartn_tran_vector_3'
+         '_atom_sites.Cartn_transf_vector[3]'
+
+    _name.category_id             atom_sites_Cartn_transform
+    _name.object_id               vec_3
+
+    _import.get                   [{'file':templ_attr.cif  'save':cartn_vector}]
+
+save_
+
+save_atom_sites_cartn_transform.vec_3_su
+
+    _definition.id                '_atom_sites_Cartn_transform.vec_3_su'
+    _definition.update            2023-07-01
+    _description.text
+;
+    Standard uncertainty of _atom_sites_Cartn_transform.vec_3.
+;
+    _name.category_id             atom_sites_Cartn_transform
+    _name.object_id               vec_3_su
+    _name.linked_item_id          '_atom_sites_Cartn_transform.vec_3'
+    _units.code                   angstroms
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+save_
+
+save_atom_sites_cartn_transform.vector
+
+    _definition.id                '_atom_sites_Cartn_transform.vector'
+    _definition.update            2021-07-07
+    _description.text
+;
+    The 3x1 translation is used with _atom_sites_Cartn_transform.matrix
+    used to transform fractional coordinates to Cartesian coordinates.
+    The axial alignments of this transformation are described in
+    _atom_sites_Cartn_transform.axes.
+;
+    _name.category_id             atom_sites_Cartn_transform
+    _name.object_id               vector
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               Matrix
+    _type.dimension               '[3]'
+    _type.contents                Real
+    _units.code                   angstroms
+    _method.purpose               Evaluation
+    _method.expression
+;
+     With t as atom_sites_Cartn_transform
+
+    _atom_sites_Cartn_transform.vector =  [ t.vec_1, t.vec_2, t.vec_3 ]
+;
+
+save_
+
+save_atom_sites_cartn_transform.vector_su
+
+    _definition.id                '_atom_sites_Cartn_transform.vector_su'
+    _definition.update            2023-07-01
+    _description.text
+;
+    Standard uncertainty of _atom_sites_Cartn_transform.vector.
+;
+    _name.category_id             atom_sites_Cartn_transform
+    _name.object_id               vector_su
+    _name.linked_item_id          '_atom_sites_Cartn_transform.vector'
+    _type.purpose                 SU
+    _type.source                  Related
+    _type.container               Matrix
+    _type.dimension               '[3]'
+    _type.contents                Real
+    _units.code                   angstroms
+
+save_
+
+save_ATOM_SITES_FRACT_TRANSFORM
+
+    _definition.id                ATOM_SITES_FRACT_TRANSFORM
+    _definition.scope             Category
+    _definition.class             Set
+    _definition.update            2021-03-03
+    _description.text
+;
+    The CATEGORY of data items used to describe the matrix elements
+    used to transform Cartesian coordinates into fractional coordinates
+    of all atom sites in a crystal structure.
+;
+    _name.category_id             ATOM_SITES
+    _name.object_id               ATOM_SITES_FRACT_TRANSFORM
+
+save_
+
+save_atom_sites_fract_transform.axes
+
+    _definition.id                '_atom_sites_fract_transform.axes'
+
+    loop_
+      _alias.definition_id
+         '_atom_sites_fract_transform_axes'
+         '_atom_sites.fract_transform_axes'
+
+    _definition.update            2012-12-11
+    _description.text
+;
+    Description of the relative alignment of the crystal cell axes to the
+    Cartesian orthogonal axes as applied in the transformation matrix
+    _atom_sites_fract_transform.matrix.
+;
+    _name.category_id             atom_sites_fract_transform
+    _name.object_id               axes
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+    _description_example.case     'a parallel to x; b in the plane of x & y'
+
+save_
+
+save_atom_sites_fract_transform.mat_11
+
+    _definition.id                '_atom_sites_fract_transform.mat_11'
+
+    loop_
+      _alias.definition_id
+         '_atom_sites_fract_tran_matrix_11'
+         '_atom_sites.fract_transf_matrix[1][1]'
+
+    _name.category_id             atom_sites_fract_transform
+    _name.object_id               mat_11
+
+    _import.get                   [{'file':templ_attr.cif  'save':fract_matrix}]
+
+save_
+
+save_atom_sites_fract_transform.mat_11_su
+
+    _definition.id                '_atom_sites_fract_transform.mat_11_su'
+    _definition.update            2023-07-01
+    _description.text
+;
+    Standard uncertainty of _atom_sites_fract_transform.mat_11.
+;
+    _name.category_id             atom_sites_fract_transform
+    _name.object_id               mat_11_su
+    _name.linked_item_id          '_atom_sites_fract_transform.mat_11'
+    _units.code                   reciprocal_angstroms
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+save_
+
+save_atom_sites_fract_transform.mat_12
+
+    _definition.id                '_atom_sites_fract_transform.mat_12'
+
+    loop_
+      _alias.definition_id
+         '_atom_sites_fract_tran_matrix_12'
+         '_atom_sites.fract_transf_matrix[1][2]'
+
+    _name.category_id             atom_sites_fract_transform
+    _name.object_id               mat_12
+
+    _import.get                   [{'file':templ_attr.cif  'save':fract_matrix}]
+
+save_
+
+save_atom_sites_fract_transform.mat_12_su
+
+    _definition.id                '_atom_sites_fract_transform.mat_12_su'
+    _definition.update            2023-07-01
+    _description.text
+;
+    Standard uncertainty of _atom_sites_fract_transform.mat_12.
+;
+    _name.category_id             atom_sites_fract_transform
+    _name.object_id               mat_12_su
+    _name.linked_item_id          '_atom_sites_fract_transform.mat_12'
+    _units.code                   reciprocal_angstroms
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+save_
+
+save_atom_sites_fract_transform.mat_13
+
+    _definition.id                '_atom_sites_fract_transform.mat_13'
+
+    loop_
+      _alias.definition_id
+         '_atom_sites_fract_tran_matrix_13'
+         '_atom_sites.fract_transf_matrix[1][3]'
+
+    _name.category_id             atom_sites_fract_transform
+    _name.object_id               mat_13
+
+    _import.get                   [{'file':templ_attr.cif  'save':fract_matrix}]
+
+save_
+
+save_atom_sites_fract_transform.mat_13_su
+
+    _definition.id                '_atom_sites_fract_transform.mat_13_su'
+    _definition.update            2023-07-01
+    _description.text
+;
+    Standard uncertainty of _atom_sites_fract_transform.mat_13.
+;
+    _name.category_id             atom_sites_fract_transform
+    _name.object_id               mat_13_su
+    _name.linked_item_id          '_atom_sites_fract_transform.mat_13'
+    _units.code                   reciprocal_angstroms
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+save_
+
+save_atom_sites_fract_transform.mat_21
+
+    _definition.id                '_atom_sites_fract_transform.mat_21'
+
+    loop_
+      _alias.definition_id
+         '_atom_sites_fract_tran_matrix_21'
+         '_atom_sites.fract_transf_matrix[2][1]'
+
+    _name.category_id             atom_sites_fract_transform
+    _name.object_id               mat_21
+
+    _import.get                   [{'file':templ_attr.cif  'save':fract_matrix}]
+
+save_
+
+save_atom_sites_fract_transform.mat_21_su
+
+    _definition.id                '_atom_sites_fract_transform.mat_21_su'
+    _definition.update            2023-07-01
+    _description.text
+;
+    Standard uncertainty of _atom_sites_fract_transform.mat_21.
+;
+    _name.category_id             atom_sites_fract_transform
+    _name.object_id               mat_21_su
+    _name.linked_item_id          '_atom_sites_fract_transform.mat_21'
+    _units.code                   reciprocal_angstroms
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+save_
+
+save_atom_sites_fract_transform.mat_22
+
+    _definition.id                '_atom_sites_fract_transform.mat_22'
+
+    loop_
+      _alias.definition_id
+         '_atom_sites_fract_tran_matrix_22'
+         '_atom_sites.fract_transf_matrix[2][2]'
+
+    _name.category_id             atom_sites_fract_transform
+    _name.object_id               mat_22
+
+    _import.get                   [{'file':templ_attr.cif  'save':fract_matrix}]
+
+save_
+
+save_atom_sites_fract_transform.mat_22_su
+
+    _definition.id                '_atom_sites_fract_transform.mat_22_su'
+    _definition.update            2023-07-01
+    _description.text
+;
+    Standard uncertainty of _atom_sites_fract_transform.mat_22.
+;
+    _name.category_id             atom_sites_fract_transform
+    _name.object_id               mat_22_su
+    _name.linked_item_id          '_atom_sites_fract_transform.mat_22'
+    _units.code                   reciprocal_angstroms
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+save_
+
+save_atom_sites_fract_transform.mat_23
+
+    _definition.id                '_atom_sites_fract_transform.mat_23'
+
+    loop_
+      _alias.definition_id
+         '_atom_sites_fract_tran_matrix_23'
+         '_atom_sites.fract_transf_matrix[2][3]'
+
+    _name.category_id             atom_sites_fract_transform
+    _name.object_id               mat_23
+
+    _import.get                   [{'file':templ_attr.cif  'save':fract_matrix}]
+
+save_
+
+save_atom_sites_fract_transform.mat_23_su
+
+    _definition.id                '_atom_sites_fract_transform.mat_23_su'
+    _definition.update            2023-07-01
+    _description.text
+;
+    Standard uncertainty of _atom_sites_fract_transform.mat_23.
+;
+    _name.category_id             atom_sites_fract_transform
+    _name.object_id               mat_23_su
+    _name.linked_item_id          '_atom_sites_fract_transform.mat_23'
+    _units.code                   reciprocal_angstroms
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+save_
+
+save_atom_sites_fract_transform.mat_31
+
+    _definition.id                '_atom_sites_fract_transform.mat_31'
+
+    loop_
+      _alias.definition_id
+         '_atom_sites_fract_tran_matrix_31'
+         '_atom_sites.fract_transf_matrix[3][1]'
+
+    _name.category_id             atom_sites_fract_transform
+    _name.object_id               mat_31
+
+    _import.get                   [{'file':templ_attr.cif  'save':fract_matrix}]
+
+save_
+
+save_atom_sites_fract_transform.mat_31_su
+
+    _definition.id                '_atom_sites_fract_transform.mat_31_su'
+    _definition.update            2023-07-01
+    _description.text
+;
+    Standard uncertainty of _atom_sites_fract_transform.mat_31.
+;
+    _name.category_id             atom_sites_fract_transform
+    _name.object_id               mat_31_su
+    _name.linked_item_id          '_atom_sites_fract_transform.mat_31'
+    _units.code                   reciprocal_angstroms
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+save_
+
+save_atom_sites_fract_transform.mat_32
+
+    _definition.id                '_atom_sites_fract_transform.mat_32'
+
+    loop_
+      _alias.definition_id
+         '_atom_sites_fract_tran_matrix_32'
+         '_atom_sites.fract_transf_matrix[3][2]'
+
+    _name.category_id             atom_sites_fract_transform
+    _name.object_id               mat_32
+
+    _import.get                   [{'file':templ_attr.cif  'save':fract_matrix}]
+
+save_
+
+save_atom_sites_fract_transform.mat_32_su
+
+    _definition.id                '_atom_sites_fract_transform.mat_32_su'
+    _definition.update            2023-07-01
+    _description.text
+;
+    Standard uncertainty of _atom_sites_fract_transform.mat_32.
+;
+    _name.category_id             atom_sites_fract_transform
+    _name.object_id               mat_32_su
+    _name.linked_item_id          '_atom_sites_fract_transform.mat_32'
+    _units.code                   reciprocal_angstroms
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+save_
+
+save_atom_sites_fract_transform.mat_33
+
+    _definition.id                '_atom_sites_fract_transform.mat_33'
+
+    loop_
+      _alias.definition_id
+         '_atom_sites_fract_tran_matrix_33'
+         '_atom_sites.fract_transf_matrix[3][3]'
+
+    _name.category_id             atom_sites_fract_transform
+    _name.object_id               mat_33
+
+    _import.get                   [{'file':templ_attr.cif  'save':fract_matrix}]
+
+save_
+
+save_atom_sites_fract_transform.mat_33_su
+
+    _definition.id                '_atom_sites_fract_transform.mat_33_su'
+    _definition.update            2023-07-01
+    _description.text
+;
+    Standard uncertainty of _atom_sites_fract_transform.mat_33.
+;
+    _name.category_id             atom_sites_fract_transform
+    _name.object_id               mat_33_su
+    _name.linked_item_id          '_atom_sites_fract_transform.mat_33'
+    _units.code                   reciprocal_angstroms
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+save_
+
+save_atom_sites_fract_transform.matrix
+
+    _definition.id                '_atom_sites_fract_transform.matrix'
+    _definition.update            2021-07-21
+    _description.text
+;
+    Matrix used to transform Cartesian coordinates in the ATOM_SITE
+    category to fractional coordinates. The axial alignments of this
+    transformation are described in _atom_sites_fract_transform.axes.
+    The 3 x 1 translation is defined in _atom_sites_fract_transform.vector.
+
+      x'                   |11 12 13|     x                  | 1 |
+    ( y' )fractional = mat |21 22 23| * ( y ) Cartesian + vec| 2 |
+      z'                   |31 32 33|     z                  | 3 |
+
+    The default transformation matrix uses Rollet's axial
+    assignments with cell vectors a,b,c aligned with orthogonal
+    axes X,Y,Z so that c||Z and b in plane YZ.
+;
+    _name.category_id             atom_sites_fract_transform
+    _name.object_id               matrix
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               Matrix
+    _type.dimension               '[3,3]'
+    _type.contents                Real
+    _units.code                   reciprocal_angstroms
+    _method.purpose               Evaluation
+    _method.expression
+;
+    With a as atom_sites_fract_transform
+
+    _atom_sites_fract_transform.matrix = [[a.mat_11, a.mat_12, a.mat_13],
+                                          [a.mat_21, a.mat_22, a.mat_23],
+                                          [a.mat_31, a.mat_32, a.mat_33]]
+;
+
+save_
+
+save_atom_sites_fract_transform.matrix_su
+
+    _definition.id                '_atom_sites_fract_transform.matrix_su'
+    _definition.update            2023-07-01
+    _description.text
+;
+    Standard uncertainty of _atom_sites_fract_transform.matrix.
+;
+    _name.category_id             atom_sites_fract_transform
+    _name.object_id               matrix_su
+    _name.linked_item_id          '_atom_sites_fract_transform.matrix'
+    _type.purpose                 SU
+    _type.source                  Related
+    _type.container               Matrix
+    _type.dimension               '[3,3]'
+    _type.contents                Real
+    _units.code                   reciprocal_angstroms
+
+save_
+
+save_atom_sites_fract_transform.vec_1
+
+    _definition.id                '_atom_sites_fract_transform.vec_1'
+
+    loop_
+      _alias.definition_id
+         '_atom_sites_fract_tran_vector_1'
+         '_atom_sites.fract_transf_vector[1]'
+
+    _name.category_id             atom_sites_fract_transform
+    _name.object_id               vec_1
+
+    _import.get                   [{'file':templ_attr.cif  'save':fract_vector}]
+
+save_
+
+save_atom_sites_fract_transform.vec_1_su
+
+    _definition.id                '_atom_sites_fract_transform.vec_1_su'
+    _definition.update            2023-07-01
+    _description.text
+;
+    Standard uncertainty of _atom_sites_fract_transform.vec_1.
+;
+    _name.category_id             atom_sites_fract_transform
+    _name.object_id               vec_1_su
+    _name.linked_item_id          '_atom_sites_fract_transform.vec_1'
+    _units.code                   none
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+save_
+
+save_atom_sites_fract_transform.vec_2
+
+    _definition.id                '_atom_sites_fract_transform.vec_2'
+
+    loop_
+      _alias.definition_id
+         '_atom_sites_fract_tran_vector_2'
+         '_atom_sites.fract_transf_vector[2]'
+
+    _name.category_id             atom_sites_fract_transform
+    _name.object_id               vec_2
+
+    _import.get                   [{'file':templ_attr.cif  'save':fract_vector}]
+
+save_
+
+save_atom_sites_fract_transform.vec_2_su
+
+    _definition.id                '_atom_sites_fract_transform.vec_2_su'
+    _definition.update            2023-07-01
+    _description.text
+;
+    Standard uncertainty of _atom_sites_fract_transform.vec_2.
+;
+    _name.category_id             atom_sites_fract_transform
+    _name.object_id               vec_2_su
+    _name.linked_item_id          '_atom_sites_fract_transform.vec_2'
+    _units.code                   none
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+save_
+
+save_atom_sites_fract_transform.vec_3
+
+    _definition.id                '_atom_sites_fract_transform.vec_3'
+
+    loop_
+      _alias.definition_id
+         '_atom_sites_fract_tran_vector_3'
+         '_atom_sites.fract_transf_vector[3]'
+
+    _name.category_id             atom_sites_fract_transform
+    _name.object_id               vec_3
+
+    _import.get                   [{'file':templ_attr.cif  'save':fract_vector}]
+
+save_
+
+save_atom_sites_fract_transform.vec_3_su
+
+    _definition.id                '_atom_sites_fract_transform.vec_3_su'
+    _definition.update            2023-07-01
+    _description.text
+;
+    Standard uncertainty of _atom_sites_fract_transform.vec_3.
+;
+    _name.category_id             atom_sites_fract_transform
+    _name.object_id               vec_3_su
+    _name.linked_item_id          '_atom_sites_fract_transform.vec_3'
+    _units.code                   none
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+save_
+
+save_atom_sites_fract_transform.vector
+
+    _definition.id                '_atom_sites_fract_transform.vector'
+    _definition.update            2021-03-01
+    _description.text
+;
+    The 3x1 translation is used with _atom_sites_fract_transform.matrix
+    used to transform Cartesian coordinates to fractional coordinates.
+    The axial alignments of this transformation are described in
+    _atom_sites_fract_transform.axes.
+;
+    _name.category_id             atom_sites_fract_transform
+    _name.object_id               vector
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               Matrix
+    _type.dimension               '[3]'
+    _type.contents                Real
+    _units.code                   none
+    _method.purpose               Evaluation
+    _method.expression
+;
+     With t as atom_sites_fract_transform
+
+    _atom_sites_fract_transform.vector =  [ t.vec_1, t.vec_2, t.vec_3 ]
+;
+
+save_
+
+save_atom_sites_fract_transform.vector_su
+
+    _definition.id                '_atom_sites_fract_transform.vector_su'
+    _definition.update            2023-07-01
+    _description.text
+;
+    Standard uncertainty of _atom_sites_fract_transform.vector.
+;
+    _name.category_id             atom_sites_fract_transform
+    _name.object_id               vector_su
+    _name.linked_item_id          '_atom_sites_fract_transform.vector'
+    _type.purpose                 SU
+    _type.source                  Related
+    _type.container               Matrix
+    _type.dimension               '[3]'
+    _type.contents                Real
+    _units.code                   none
+
+save_
+
+save_ATOM_TYPE
+
+    _definition.id                ATOM_TYPE
+    _definition.scope             Category
+    _definition.class             Loop
+    _definition.update            2023-07-13
+    _description.text
+;
+    The CATEGORY of data items used to describe atomic type information
+    used in crystallographic structure studies.
+;
+    _name.category_id             ATOM
+    _name.object_id               ATOM_TYPE
+    _category_key.name            '_atom_type.symbol'
+    _method.purpose               Evaluation
+    _method.expression
+;
+    typelist  = List()
+
+    Loop  a  as  atom_site  {
+       type = a.type_symbol
+       If( type not in typelist )  typelist ++= type
+     }
+     For type in typelist {
+                             atom_type(.symbol         = type,
+                                       .number_in_cell = '?'   )
+     }
+;
+
+save_
+
+save_atom_type.analytical_mass_percent
+
+    _definition.id                '_atom_type.analytical_mass_percent'
+
+    loop_
+      _alias.definition_id
+         '_atom_type_analytical_mass_%'
+         '_atom_type.analytical_mass_%'
+
+    _definition.update            2013-04-11
+    _description.text
+;
+    Mass percentage of this atom type derived from chemical analysis.
+;
+    _name.category_id             atom_type
+    _name.object_id               analytical_mass_percent
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:100.0
+    _units.code                   none
+
+save_
+
+save_atom_type.analytical_mass_percent_su
+
+    _definition.id                '_atom_type.analytical_mass_percent_su'
+    _definition.update            2023-07-01
+    _description.text
+;
+    Standard uncertainty of _atom_type.analytical_mass_percent.
+;
+    _name.category_id             atom_type
+    _name.object_id               analytical_mass_percent_su
+    _name.linked_item_id          '_atom_type.analytical_mass_percent'
+    _units.code                   none
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+save_
+
+save_atom_type.atomic_mass
+
+    _definition.id                '_atom_type.atomic_mass'
+    _definition.update            2012-11-20
+    _description.text
+;
+    Mass of this atom type.
+;
+    _name.category_id             atom_type
+    _name.object_id               atomic_mass
+    _type.purpose                 Number
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.def_index_id     '_atom_type.symbol'
+
+    _import.get                   [{'file':templ_enum.cif  'save':atomic_mass}]
+
+save_
+
+save_atom_type.atomic_number
+
+    _definition.id                '_atom_type.atomic_number'
+    _definition.update            2023-06-01
+    _description.text
+;
+    Atomic number of this atom type.
+;
+    _name.category_id             atom_type
+    _name.object_id               atomic_number
+    _type.purpose                 Number
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Integer
+    _enumeration.range            1:
+    _enumeration.def_index_id     '_atom_type.element_symbol'
+
+    _import.get
+        [{'file':templ_enum.cif  'save':atomic_number}]
+
+save_
+
+save_atom_type.description
+
+    _definition.id                '_atom_type.description'
+    _alias.definition_id          '_atom_type_description'
+    _definition.update            2023-01-13
+    _description.text
+;
+    A description of the atom(s) designated by this atom type. In
+    most cases this will be the element name and oxidation state of
+    a single atom species. For disordered or nonstoichiometric
+    structures it will describe a combination of atom species.
+;
+    _name.category_id             atom_type
+    _name.object_id               description
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+
+    loop_
+      _description_example.case
+         deuterium
+         0.34Fe+0.66Ni
+
+save_
+
+save_atom_type.display_colour
+
+    _definition.id                '_atom_type.display_colour'
+    _definition.update            2023-02-06
+    _description.text
+;
+    The display colour assigned to this atom type. Note that the
+    possible colours are enumerated in the DISPLAY_COLOUR list
+    category of items.
+;
+    _name.category_id             atom_type
+    _name.object_id               display_colour
+    _type.purpose                 State
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Word
+    _enumeration.def_index_id     '_atom_type.symbol'
+
+    _import.get                   [
+                                   {'file':templ_enum.cif  'save':colour_rgb}
+                                   {'file':templ_enum.cif  'save':colour_hue}
+                                  ]
+
+save_
+
+save_atom_type.electron_count
+
+    _definition.id                '_atom_type.electron_count'
+    _definition.update            2021-03-01
+    _description.text
+;
+    Number of electrons in this atom type.
+;
+    _name.category_id             atom_type
+    _name.object_id               electron_count
+    _type.purpose                 Number
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Integer
+    _enumeration.range            1:
+    _enumeration.def_index_id     '_atom_type.symbol'
+
+    _import.get
+        [{'file':templ_enum.cif  'save':electron_count}]
+
+save_
+
+save_atom_type.element_symbol
+
+    _definition.id                '_atom_type.element_symbol'
+    _definition.update            2021-10-27
+    _description.text
+;
+    Element symbol for of this atom type. The default value is extracted
+    from the ion-to-element enumeration_default list using the index
+    value of _atom_type.symbol.
+;
+    _name.category_id             atom_type
+    _name.object_id               element_symbol
+    _type.purpose                 State
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Word
+    _enumeration.def_index_id     '_atom_type.symbol'
+
+    _import.get
+        [
+         {'file':templ_enum.cif  'save':element_symbol}
+         {'file':templ_enum.cif  'save':ion_to_element}
+        ]
+
+save_
+
+save_atom_type.key
+
+    _definition.id                '_atom_type.key'
+    _definition.update            2021-10-27
+    _description.text
+;
+    Value is a unique key to a set of ATOM_TYPE items
+    in a looped list.
+;
+    _name.category_id             atom_type
+    _name.object_id               key
+    _type.purpose                 Key
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Word
+    _method.purpose               Evaluation
+    _method.expression
+;
+    _atom_type.key = _atom_type.symbol
+;
+
+save_
+
+save_atom_type.mass_number
+
+    _definition.id                '_atom_type.mass_number'
+    _definition.update            2023-05-22
+    _description.text
+;
+    Mass number of this atom type.
+
+    Used to denote a specific isotope. Special value '.' indicates
+    that the element is present in natural isotopic abundance.
+;
+    _name.category_id             atom_type
+    _name.object_id               mass_number
+    _type.purpose                 Number
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Integer
+    _enumeration.range            1:
+    _units.code                   none
+
+save_
+
+save_atom_type.number_in_cell
+
+    _definition.id                '_atom_type.number_in_cell'
+    _alias.definition_id          '_atom_type_number_in_cell'
+    _definition.update            2013-01-28
+    _description.text
+;
+    Total number of atoms of this atom type in the unit cell.
+;
+    _name.category_id             atom_type
+    _name.object_id               number_in_cell
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   none
+    _method.purpose               Evaluation
+    _method.expression
+;
+    With t as atom_type
+
+    cnt =  0.
+
+    Loop a  as  atom_site  {
+
+       if ( a.type_symbol == t.symbol ) {
+
+          cnt +=  a.occupancy * a.site_symmetry_multiplicity
+    }  }
+    _atom_type.number_in_cell =  cnt
+;
+
+save_
+
+save_atom_type.oxidation_number
+
+    _definition.id                '_atom_type.oxidation_number'
+    _alias.definition_id          '_atom_type_oxidation_number'
+    _definition.update            2021-03-01
+    _description.text
+;
+    Formal oxidation state of this atom type in the structure.
+;
+    _name.category_id             atom_type
+    _name.object_id               oxidation_number
+    _type.purpose                 Number
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Integer
+    _enumeration.range            -8:8
+    _units.code                   none
+
+save_
+
+save_atom_type.radius_bond
+
+    _definition.id                '_atom_type.radius_bond'
+    _alias.definition_id          '_atom_type_radius_bond'
+    _definition.update            2012-11-20
+    _description.text
+;
+    The effective intra-molecular bonding radius of this atom type.
+;
+    _name.category_id             atom_type
+    _name.object_id               radius_bond
+    _type.purpose                 Number
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:5.0
+    _enumeration.def_index_id     '_atom_type.symbol'
+
+    _import.get                   [{'file':templ_enum.cif  'save':radius_bond}]
+
+save_
+
+save_atom_type.radius_contact
+
+    _definition.id                '_atom_type.radius_contact'
+    _alias.definition_id          '_atom_type_radius_contact'
+    _definition.update            2012-11-20
+    _description.text
+;
+    The effective inter-molecular bonding radius of this atom type.
+;
+    _name.category_id             atom_type
+    _name.object_id               radius_contact
+    _type.purpose                 Number
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:5.0
+    _units.code                   angstroms
+    _method.purpose               Definition
+    _method.expression
+;
+    _enumeration.default = _atom_type.radius_bond + 1.25
+;
+
+save_
+
+save_atom_type.symbol
+
+    _definition.id                '_atom_type.symbol'
+    _alias.definition_id          '_atom_type_symbol'
+    _definition.update            2021-10-27
+    _description.text
+;
+    The identity of the atom specie(s) representing this atom type.
+    Normally this code is the element symbol followed by the charge
+    if there is one. The symbol may be composed of any character except
+    an underline or a blank, with the proviso that digits designate an
+    oxidation state and must be followed by a + or - character.
+;
+    _name.category_id             atom_type
+    _name.object_id               symbol
+    _type.purpose                 Encode
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Word
+
+    loop_
+      _description_example.case
+         Mg
+         Cu2+
+         dummy
+         FeNi
+
+save_
+
+save_ATOM_TYPE_SCAT
+
+    _definition.id                ATOM_TYPE_SCAT
+    _definition.scope             Category
+    _definition.class             Loop
+    _definition.update            2021-06-29
+    _description.text
+;
+    The CATEGORY of data items used to describe atomic scattering
+    information used in crystallographic structure studies.
+;
+    _name.category_id             ATOM_TYPE
+    _name.object_id               ATOM_TYPE_SCAT
+    _category_key.name            '_atom_type_scat.symbol'
+
+save_
+
+save_atom_type_scat.cromer_mann_a1
+
+    _definition.id                '_atom_type_scat.Cromer_Mann_a1'
+
+    loop_
+      _alias.definition_id
+         '_atom_type_scat_Cromer_Mann_a1'
+         '_atom_type.scat_Cromer_Mann_a1'
+
+    _name.category_id             atom_type_scat
+    _name.object_id               Cromer_Mann_a1
+
+    _import.get
+        [
+         {'file':templ_attr.cif  'save':cromer_mann_coeff}
+         {'file':templ_enum.cif  'save':cromer_mann_a1}
+        ]
+
+save_
+
+save_atom_type_scat.cromer_mann_a2
+
+    _definition.id                '_atom_type_scat.Cromer_Mann_a2'
+
+    loop_
+      _alias.definition_id
+         '_atom_type_scat_Cromer_Mann_a2'
+         '_atom_type.scat_Cromer_Mann_a2'
+
+    _name.category_id             atom_type_scat
+    _name.object_id               Cromer_Mann_a2
+
+    _import.get
+        [
+         {'file':templ_attr.cif  'save':cromer_mann_coeff}
+         {'file':templ_enum.cif  'save':cromer_mann_a2}
+        ]
+
+save_
+
+save_atom_type_scat.cromer_mann_a3
+
+    _definition.id                '_atom_type_scat.Cromer_Mann_a3'
+
+    loop_
+      _alias.definition_id
+         '_atom_type_scat_Cromer_Mann_a3'
+         '_atom_type.scat_Cromer_Mann_a3'
+
+    _name.category_id             atom_type_scat
+    _name.object_id               Cromer_Mann_a3
+
+    _import.get
+        [
+         {'file':templ_attr.cif  'save':cromer_mann_coeff}
+         {'file':templ_enum.cif  'save':cromer_mann_a3}
+        ]
+
+save_
+
+save_atom_type_scat.cromer_mann_a4
+
+    _definition.id                '_atom_type_scat.Cromer_Mann_a4'
+
+    loop_
+      _alias.definition_id
+         '_atom_type_scat_Cromer_Mann_a4'
+         '_atom_type.scat_Cromer_Mann_a4'
+
+    _name.category_id             atom_type_scat
+    _name.object_id               Cromer_Mann_a4
+
+    _import.get
+        [
+         {'file':templ_attr.cif  'save':cromer_mann_coeff}
+         {'file':templ_enum.cif  'save':cromer_mann_a4}
+        ]
+
+save_
+
+save_atom_type_scat.cromer_mann_b1
+
+    _definition.id                '_atom_type_scat.Cromer_Mann_b1'
+
+    loop_
+      _alias.definition_id
+         '_atom_type_scat_Cromer_Mann_b1'
+         '_atom_type.scat_Cromer_Mann_b1'
+
+    _name.category_id             atom_type_scat
+    _name.object_id               Cromer_Mann_b1
+
+    _import.get
+        [
+         {'file':templ_attr.cif  'save':cromer_mann_coeff}
+         {'file':templ_enum.cif  'save':cromer_mann_b1}
+        ]
+
+save_
+
+save_atom_type_scat.cromer_mann_b2
+
+    _definition.id                '_atom_type_scat.Cromer_Mann_b2'
+
+    loop_
+      _alias.definition_id
+         '_atom_type_scat_Cromer_Mann_b2'
+         '_atom_type.scat_Cromer_Mann_b2'
+
+    _name.category_id             atom_type_scat
+    _name.object_id               Cromer_Mann_b2
+
+    _import.get
+        [
+         {'file':templ_attr.cif  'save':cromer_mann_coeff}
+         {'file':templ_enum.cif  'save':cromer_mann_b2}
+        ]
+
+save_
+
+save_atom_type_scat.cromer_mann_b3
+
+    _definition.id                '_atom_type_scat.Cromer_Mann_b3'
+
+    loop_
+      _alias.definition_id
+         '_atom_type_scat_Cromer_Mann_b3'
+         '_atom_type.scat_Cromer_Mann_b3'
+
+    _name.category_id             atom_type_scat
+    _name.object_id               Cromer_Mann_b3
+
+    _import.get
+        [
+         {'file':templ_attr.cif  'save':cromer_mann_coeff}
+         {'file':templ_enum.cif  'save':cromer_mann_b3}
+        ]
+
+save_
+
+save_atom_type_scat.cromer_mann_b4
+
+    _definition.id                '_atom_type_scat.Cromer_Mann_b4'
+
+    loop_
+      _alias.definition_id
+         '_atom_type_scat_Cromer_Mann_b4'
+         '_atom_type.scat_Cromer_Mann_b4'
+
+    _name.category_id             atom_type_scat
+    _name.object_id               Cromer_Mann_b4
+
+    _import.get
+        [
+         {'file':templ_attr.cif  'save':cromer_mann_coeff}
+         {'file':templ_enum.cif  'save':cromer_mann_b4}
+        ]
+
+save_
+
+save_atom_type_scat.cromer_mann_c
+
+    _definition.id                '_atom_type_scat.Cromer_Mann_c'
+
+    loop_
+      _alias.definition_id
+         '_atom_type_scat_Cromer_Mann_c'
+         '_atom_type.scat_Cromer_Mann_c'
+
+    _name.category_id             atom_type_scat
+    _name.object_id               Cromer_Mann_c
+
+    _import.get
+        [
+         {'file':templ_attr.cif  'save':cromer_mann_coeff}
+         {'file':templ_enum.cif  'save':cromer_mann_c}
+        ]
+
+save_
+
+save_atom_type_scat.cromer_mann_coeffs
+
+    _definition.id                '_atom_type_scat.Cromer_Mann_coeffs'
+    _definition.update            2023-06-16
+    _description.text
+;
+    The set of Cromer-Mann coefficients for generating X-ray scattering
+    factors. [ c, a1, b1, a2, b2, a3, b3, a4, b4 ]
+    Ref: International Tables for Crystallography, Vol. C
+            (1991) Table 6.1.1.4
+;
+    _name.category_id             atom_type_scat
+    _name.object_id               Cromer_Mann_coeffs
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               List
+    _type.dimension               '[9]'
+    _type.contents                Real
+    _units.code                   unspecified
+    _method.purpose               Evaluation
+    _method.expression
+;
+    With t  as  atom_type_scat
+
+     _atom_type_scat.Cromer_Mann_coeffs  =          [ t.Cromer_Mann_c,
+                                    t.Cromer_Mann_a1, t.Cromer_Mann_b1,
+                                    t.Cromer_Mann_a2, t.Cromer_Mann_b2,
+                                    t.Cromer_Mann_a3, t.Cromer_Mann_b3,
+                                    t.Cromer_Mann_a4, t.Cromer_Mann_b4 ]
+;
+
+save_
+
+save_atom_type_scat.dispersion
+
+    _definition.id                '_atom_type_scat.dispersion'
+    _definition.update            2013-04-28
+    _description.text
+;
+    The anomalous dispersion scattering factor in its complex form
+    for this atom type and radiation by _diffrn_radiation_wavelength.value
+;
+    _name.category_id             atom_type_scat
+    _name.object_id               dispersion
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Complex
+    _units.code                   none
+    _method.purpose               Evaluation
+    _method.expression
+;
+    With s as atom_type_scat
+
+            d = Complex( s.dispersion_real, s.dispersion_imag )
+
+       if(_reflns.apply_dispersion_to_Fcalc == 'no')   d = 0.
+
+                _atom_type_scat.dispersion = d
+;
+
+save_
+
+save_atom_type_scat.dispersion_imag
+
+    _definition.id                '_atom_type_scat.dispersion_imag'
+
+    loop_
+      _alias.definition_id
+         '_atom_type_scat_dispersion_imag'
+         '_atom_type.scat_dispersion_imag'
+
+    _definition.update            2021-09-24
+    _description.text
+;
+    The imaginary component of the anomalous dispersion scattering factors
+    for this atom type and radiation by _diffrn_radiation_wavelength.value
+;
+    _name.category_id             atom_type_scat
+    _name.object_id               dispersion_imag
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _units.code                   none
+    _method.purpose               Evaluation
+    _method.expression
+;
+    With q as atom_type_scat
+
+     If ( _diffrn_radiation.type[0:2] == 'Cu' ) a = q.dispersion_imag_Cu
+     If ( _diffrn_radiation.type[0:2] == 'Mo' ) a = q.dispersion_imag_Mo
+
+             _atom_type_scat.dispersion_imag = a
+;
+
+save_
+
+save_atom_type_scat.dispersion_imag_cu
+
+    _definition.id                '_atom_type_scat.dispersion_imag_Cu'
+    _definition.update            2023-06-01
+    _description.text
+;
+    The imaginary component of the anomalous dispersion scattering factors
+    for this atom type and Cu Kα radiation.
+;
+    _name.category_id             atom_type_scat
+    _name.object_id               dispersion_imag_Cu
+    _type.purpose                 Number
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.def_index_id     '_atom_type.element_symbol'
+
+    _import.get
+        [{'file':templ_enum.cif  'save':dispersion_imag_cu}]
+
+save_
+
+save_atom_type_scat.dispersion_imag_mo
+
+    _definition.id                '_atom_type_scat.dispersion_imag_Mo'
+    _definition.update            2023-06-01
+    _description.text
+;
+    The imaginary component of the anomalous dispersion scattering factors
+    for this atom type and Mo Kα radiation.
+;
+    _name.category_id             atom_type_scat
+    _name.object_id               dispersion_imag_Mo
+    _type.purpose                 Number
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.def_index_id     '_atom_type.element_symbol'
+
+    _import.get
+        [{'file':templ_enum.cif  'save':dispersion_imag_mo}]
+
+save_
+
+save_atom_type_scat.dispersion_real
+
+    _definition.id                '_atom_type_scat.dispersion_real'
+
+    loop_
+      _alias.definition_id
+         '_atom_type_scat_dispersion_real'
+         '_atom_type.scat_dispersion_real'
+
+    _definition.update            2012-11-20
+    _description.text
+;
+    The real component of the anomalous dispersion scattering factors
+    for this atom type and radiation by _diffrn_radiation_wavelength.value
+;
+    _name.category_id             atom_type_scat
+    _name.object_id               dispersion_real
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _units.code                   none
+    _method.purpose               Evaluation
+    _method.expression
+;
+    With q as atom_type_scat
+
+     If ( _diffrn_radiation.type[0:2] == 'Cu' ) a = q.dispersion_real_Cu
+     If ( _diffrn_radiation.type[0:2] == 'Mo' ) a = q.dispersion_real_Mo
+
+             _atom_type_scat.dispersion_real = a
+;
+
+save_
+
+save_atom_type_scat.dispersion_real_cu
+
+    _definition.id                '_atom_type_scat.dispersion_real_Cu'
+    _definition.update            2023-06-01
+    _description.text
+;
+    The real component of the anomalous dispersion scattering factors
+    for this atom type and Cu Kα radiation.
+;
+    _name.category_id             atom_type_scat
+    _name.object_id               dispersion_real_Cu
+    _type.purpose                 Number
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.def_index_id     '_atom_type.element_symbol'
+
+    _import.get
+        [{'file':templ_enum.cif  'save':dispersion_real_cu}]
+
+save_
+
+save_atom_type_scat.dispersion_real_mo
+
+    _definition.id                '_atom_type_scat.dispersion_real_Mo'
+    _definition.update            2023-06-01
+    _description.text
+;
+    The real component of the anomalous dispersion scattering factors
+    for this atom type and Mo Kα radiation.
+;
+    _name.category_id             atom_type_scat
+    _name.object_id               dispersion_real_Mo
+    _type.purpose                 Number
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.def_index_id     '_atom_type.element_symbol'
+
+    _import.get
+        [{'file':templ_enum.cif  'save':dispersion_real_mo}]
+
+save_
+
+save_atom_type_scat.dispersion_source
+
+    _definition.id                '_atom_type_scat.dispersion_source'
+
+    loop_
+      _alias.definition_id
+         '_atom_type_scat_dispersion_source'
+         '_atom_type.scat_dispersion_source'
+
+    _definition.update            2012-11-20
+    _description.text
+;
+    Reference to source of real and imaginary dispersion
+    corrections for scattering factors used for this atom type.
+;
+    _name.category_id             atom_type_scat
+    _name.object_id               dispersion_source
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+    _description_example.case     'International Tables Vol. IV Table 2.3.1'
+
+save_
+
+save_atom_type_scat.exponential_polynomial_coefs
+
+    _definition.id                '_atom_type_scat.exponential_polynomial_coefs'
+    _definition.update            2023-06-16
+    _description.text
+;
+    The set of polynomial coefficients for generating X-ray scattering factors:
+    [ a_0, a_1, ... , a_N ].
+
+    f(s; Z) = exp(Sum(a~i~ * s^i^), i=0:N)
+
+    where s = sin(θ)/λ and θ is the diffraction angle and λ is the wavelength
+    of the incident radiation in angstroms.
+;
+    _name.category_id             atom_type_scat
+    _name.object_id               exponential_polynomial_coefs
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               List
+    _type.dimension               '[]'
+    _type.contents                Real
+    _units.code                   unspecified
+
+save_
+
+save_atom_type_scat.exponential_polynomial_coefs_su
+
+    _definition.id
+        '_atom_type_scat.exponential_polynomial_coefs_su'
+    _definition.update            2023-07-01
+    _description.text
+;
+    Standard uncertainty of _atom_type_scat.exponential_polynomial_coefs.
+;
+    _name.category_id             atom_type_scat
+    _name.object_id               exponential_polynomial_coefs_su
+    _name.linked_item_id          '_atom_type_scat.exponential_polynomial_coefs'
+    _type.purpose                 SU
+    _type.source                  Related
+    _type.container               List
+    _type.dimension               '[]'
+    _type.contents                Real
+    _units.code                   unspecified
+
+save_
+
+save_atom_type_scat.exponential_polynomial_lower_limit
+
+    _definition.id
+        '_atom_type_scat.exponential_polynomial_lower_limit'
+    _definition.update            2023-04-09
+    _description.text
+;
+    The inclusive lower limit of s for which the corresponding exponential
+    polynomial coefficients are valid.
+
+    See _atom_type_scat.exponential_polynomial_coefs.
+;
+    _name.category_id             atom_type_scat
+    _name.object_id               exponential_polynomial_lower_limit
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _units.code                   reciprocal_angstroms
+
+save_
+
+save_atom_type_scat.exponential_polynomial_upper_limit
+
+    _definition.id
+        '_atom_type_scat.exponential_polynomial_upper_limit'
+    _definition.update            2023-04-09
+    _description.text
+;
+    The exclusive upper limit of s for which the corresponding exponential
+    polynomial coefficients are valid.
+
+    See _atom_type_scat.exponential_polynomial_coefs.
+;
+    _name.category_id             atom_type_scat
+    _name.object_id               exponential_polynomial_upper_limit
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _units.code                   reciprocal_angstroms
+
+save_
+
+save_atom_type_scat.gaussian_coefs
+
+    _definition.id                '_atom_type_scat.Gaussian_coefs'
+    _definition.update            2023-06-16
+    _description.text
+;
+    The set of Gaussian coefficients for generating X-ray scattering factors:
+    [ c, a_1, b_1, a_2, b_2, ... , a_N, b_N ].
+
+    f(s; Z) = c + Sum(a~i~ * exp(-b~i~ * s^2^), i=1:N)
+
+    where s = sin(θ)/λ and θ is the diffraction angle and λ is the wavelength
+    of the incident radiation in angstroms.
+;
+    _name.category_id             atom_type_scat
+    _name.object_id               Gaussian_coefs
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               List
+    _type.dimension               '[]'
+    _type.contents                Real
+    _units.code                   unspecified
+
+save_
+
+save_atom_type_scat.gaussian_coefs_su
+
+    _definition.id                '_atom_type_scat.Gaussian_coefs_su'
+    _definition.update            2023-07-01
+    _description.text
+;
+    Standard uncertainty of _atom_type_scat.Gaussian_coefs.
+;
+    _name.category_id             atom_type_scat
+    _name.object_id               Gaussian_coefs_su
+    _name.linked_item_id          '_atom_type_scat.Gaussian_coefs'
+    _type.purpose                 SU
+    _type.source                  Related
+    _type.container               List
+    _type.dimension               '[]'
+    _type.contents                Real
+    _units.code                   unspecified
+
+save_
+
+save_atom_type_scat.gaussian_lower_limit
+
+    _definition.id                '_atom_type_scat.Gaussian_lower_limit'
+    _definition.update            2023-04-09
+    _description.text
+;
+    The inclusive lower limit of s for which the corresponding Gaussian
+    coefficients are valid.
+
+    See _atom_type_scat.Gaussian_coefs.
+;
+    _name.category_id             atom_type_scat
+    _name.object_id               Gaussian_lower_limit
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _units.code                   reciprocal_angstroms
+
+save_
+
+save_atom_type_scat.gaussian_upper_limit
+
+    _definition.id                '_atom_type_scat.Gaussian_upper_limit'
+    _definition.update            2023-04-09
+    _description.text
+;
+    The exclusive upper limit of s for which the corresponding Gaussian
+    coefficients are valid.
+
+    See _atom_type_scat.Gaussian_coefs.
+;
+    _name.category_id             atom_type_scat
+    _name.object_id               Gaussian_upper_limit
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _units.code                   reciprocal_angstroms
+
+save_
+
+save_atom_type_scat.hi_ang_fox_c0
+
+    _definition.id                '_atom_type_scat.hi_ang_Fox_c0'
+    _name.category_id             atom_type_scat
+    _name.object_id               hi_ang_Fox_c0
+
+    _import.get
+        [
+         {'file':templ_attr.cif  'save':hi_ang_fox_coeffs}
+         {'file':templ_enum.cif  'save':hi_ang_fox_c0}
+        ]
+
+save_
+
+save_atom_type_scat.hi_ang_fox_c1
+
+    _definition.id                '_atom_type_scat.hi_ang_Fox_c1'
+    _name.category_id             atom_type_scat
+    _name.object_id               hi_ang_Fox_c1
+
+    _import.get
+        [
+         {'file':templ_attr.cif  'save':hi_ang_fox_coeffs}
+         {'file':templ_enum.cif  'save':hi_ang_fox_c1}
+        ]
+
+save_
+
+save_atom_type_scat.hi_ang_fox_c2
+
+    _definition.id                '_atom_type_scat.hi_ang_Fox_c2'
+    _name.category_id             atom_type_scat
+    _name.object_id               hi_ang_Fox_c2
+
+    _import.get
+        [
+         {'file':templ_attr.cif  'save':hi_ang_fox_coeffs}
+         {'file':templ_enum.cif  'save':hi_ang_fox_c2}
+        ]
+
+save_
+
+save_atom_type_scat.hi_ang_fox_c3
+
+    _definition.id                '_atom_type_scat.hi_ang_Fox_c3'
+    _name.category_id             atom_type_scat
+    _name.object_id               hi_ang_Fox_c3
+
+    _import.get
+        [
+         {'file':templ_attr.cif  'save':hi_ang_fox_coeffs}
+         {'file':templ_enum.cif  'save':hi_ang_fox_c3}
+        ]
+
+save_
+
+save_atom_type_scat.hi_ang_fox_coeffs
+
+    _definition.id                '_atom_type_scat.hi_ang_Fox_coeffs'
+    _definition.update            2023-06-16
+    _description.text
+;
+    The set of Fox et al. coefficients for generating high angle
+    X-ray scattering factors. [ c0, c1, c2, c3 ]
+    Ref: International Tables for Crystallography, Vol. C
+         (1991) Table 6.1.1.5
+;
+    _name.category_id             atom_type_scat
+    _name.object_id               hi_ang_Fox_coeffs
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               List
+    _type.dimension               '[4]'
+    _type.contents                Real
+    _units.code                   unspecified
+    _method.purpose               Evaluation
+    _method.expression
+;
+     With t  as  atom_type_scat
+
+    _atom_type_scat.hi_ang_Fox_coeffs  =
+    [t.hi_ang_Fox_c0,t.hi_ang_Fox_c1,t.hi_ang_Fox_c2,t.hi_ang_Fox_c3]
+;
+
+save_
+
+save_atom_type_scat.inv_mott_bethe_coefs
+
+    _definition.id                '_atom_type_scat.inv_Mott_Bethe_coefs'
+    _definition.update            2023-06-16
+    _description.text
+;
+    The set of Gaussian coefficients for use in the inverse Mott-Bethe
+    relationship for generating X-ray scattering factors:
+    [ e, c_1, d_1, c_2, d_2, ... , c_N, d_N ].
+
+    f(s; Z) =
+    Z - 8π * a~0~ * s^2^ * (e + Sum( c~i~ * exp(-d~i~ * s^2^), i=1:N))
+
+    where s = sin(θ)/λ, a~0~ is the Bohr radius, and Z is the atomic number.
+    θ is the diffraction angle and λ is the wavelength of the incident
+    radiation in angstroms.
+;
+    _name.category_id             atom_type_scat
+    _name.object_id               inv_Mott_Bethe_coefs
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               List
+    _type.dimension               '[]'
+    _type.contents                Real
+    _units.code                   unspecified
+
+save_
+
+save_atom_type_scat.inv_mott_bethe_coefs_su
+
+    _definition.id                '_atom_type_scat.inv_Mott_Bethe_coefs_su'
+    _definition.update            2023-07-01
+    _description.text
+;
+    Standard uncertainty of _atom_type_scat.inv_Mott_Bethe_coefs.
+;
+    _name.category_id             atom_type_scat
+    _name.object_id               inv_Mott_Bethe_coefs_su
+    _name.linked_item_id          '_atom_type_scat.inv_Mott_Bethe_coefs'
+    _type.purpose                 SU
+    _type.source                  Related
+    _type.container               List
+    _type.dimension               '[]'
+    _type.contents                Real
+    _units.code                   unspecified
+
+save_
+
+save_atom_type_scat.inv_mott_bethe_lower_limit
+
+    _definition.id                '_atom_type_scat.inv_Mott_Bethe_lower_limit'
+    _definition.update            2023-04-09
+    _description.text
+;
+    The inclusive lower limit of s for which the corresponding Gaussian
+    coefficients are valid.
+
+    See _atom_type_scat.inv_Mott_Bethe_coefs.
+;
+    _name.category_id             atom_type_scat
+    _name.object_id               inv_Mott_Bethe_lower_limit
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _units.code                   reciprocal_angstroms
+
+save_
+
+save_atom_type_scat.inv_mott_bethe_upper_limit
+
+    _definition.id                '_atom_type_scat.inv_Mott_Bethe_upper_limit'
+    _definition.update            2023-04-09
+    _description.text
+;
+    The exclusive upper limit of s for which the corresponding Gaussian
+    coefficients are valid.
+
+    See _atom_type_scat.inv_Mott_Bethe_coefs.
+;
+    _name.category_id             atom_type_scat
+    _name.object_id               inv_Mott_Bethe_upper_limit
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _units.code                   reciprocal_angstroms
+
+save_
+
+save_atom_type_scat.length_neutron
+
+    _definition.id                '_atom_type_scat.length_neutron'
+
+    loop_
+      _alias.definition_id
+         '_atom_type_scat_length_neutron'
+         '_atom_type.scat_length_neutron'
+
+    _definition.update            2012-11-20
+    _description.text
+;
+    The bound coherent scattering length for the atom type at the
+    isotopic composition used for the diffraction experiment.
+;
+    _name.category_id             atom_type_scat
+    _name.object_id               length_neutron
+    _type.purpose                 Number
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Real
+    _units.code                   femtometres
+
+save_
+
+save_atom_type_scat.source
+
+    _definition.id                '_atom_type_scat.source'
+
+    loop_
+      _alias.definition_id
+         '_atom_type_scat_source'
+         '_atom_type.scat_source'
+
+    _definition.update            2012-11-20
+    _description.text
+;
+    Reference to source of scattering factors used for this atom type.
+;
+    _name.category_id             atom_type_scat
+    _name.object_id               source
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+    _description_example.case     'International Tables Vol. IV Table 2.4.6B'
+
+save_
+
+save_atom_type_scat.symbol
+
+    _definition.id                '_atom_type_scat.symbol'
+    _alias.definition_id          '_atom_type_scat_symbol'
+    _definition.update            2021-10-27
+    _description.text
+;
+    The identity of the atom specie(s) representing this atom type.
+    See _atom_type.symbol for further details.
+;
+    _name.category_id             atom_type_scat
+    _name.object_id               symbol
+    _name.linked_item_id          '_atom_type.symbol'
+    _type.purpose                 Link
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Word
+
+save_
+
+save_atom_type_scat.versus_stol_list
+
+    _definition.id                '_atom_type_scat.versus_stol_list'
+
+    loop_
+      _definition_replaced.id
+      _definition_replaced.by
+         1                        '_atom_scat_versus_stol.atom_type'
+         2                        '_atom_scat_versus_stol.stol_value'
+         3                        '_atom_scat_versus_stol.scat_value'
+
+    loop_
+      _alias.definition_id
+         '_atom_type_scat_versus_stol_list'
+         '_atom_type.scat_versus_stol_list'
+
+    _definition.update            2023-07-05
+    _description.text
+;
+    Deprecated. Data items from the ATOM_SCAT_VERSUS_STOL category should be
+    used instead of this item.
+
+    A table of scattering factors as a function of sin(θ)/λ (sin theta over
+    lambda, stol). This table should be well-commented to indicate the items
+    present. Regularly formatted lists are strongly recommended.
+;
+    _name.category_id             atom_type_scat
+    _name.object_id               versus_stol_list
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_REFINE
+
+    _definition.id                REFINE
+    _definition.scope             Category
+    _definition.class             Set
+    _definition.update            2012-11-20
+    _description.text
+;
+    The CATEGORY of data items used to specify information about the
+    refinement of the structural model.
+;
+    _name.category_id             STRUCTURE
+    _name.object_id               REFINE
+
+save_
+
+save_refine.special_details
+
+    _definition.id                '_refine.special_details'
+
+    loop_
+      _alias.definition_id
+         '_refine_special_details'
+         '_refine.details'
+
+    _definition.update            2012-11-20
+    _description.text
+;
+    Details of the refinement not specified by other data items.
+;
+    _name.category_id             refine
+    _name.object_id               special_details
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_REFINE_DIFF
+
+    _definition.id                REFINE_DIFF
+    _definition.scope             Category
+    _definition.class             Set
+    _definition.update            2023-01-12
+    _description.text
+;
+    The CATEGORY of data items which specify the scattering density limits
+    in a difference Fourier map after the structure has been refined. The
+    RMS value is with respect to the arithmetic mean density, and is derived
+    from summations over each grid point in the asymmetric unit of the cell.
+;
+    _name.category_id             REFINE
+    _name.object_id               REFINE_DIFF
+
+save_
+
+save_refine_diff.density_max
+
+    _definition.id                '_refine_diff.density_max'
+
+    loop_
+      _alias.definition_id
+         '_refine_diff_density_max'
+         '_refine.diff_density_max'
+
+    _definition.update            2023-01-12
+    _description.text
+;
+    Maximum density value in a difference Fourier map.
+;
+    _name.category_id             refine_diff
+    _name.object_id               density_max
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            -100.0:
+    _method.purpose               Definition
+    _method.expression
+;
+    # Default units. Applicable to x-ray, electron and gamma radiation.
+    _units.code = "electrons_per_angstrom_cubed"
+
+    If (_diffrn_radiation.probe == "neutron")
+        _units.code = "femtometres_per_angstrom_cubed"
+;
+
+save_
+
+save_refine_diff.density_max_su
+
+    _definition.id                '_refine_diff.density_max_su'
+
+    loop_
+      _alias.definition_id
+         '_refine_diff_density_max_su'
+         '_refine.diff_density_max_esd'
+
+    _definition.update            2023-01-12
+    _description.text
+;
+    Standard uncertainty of _refine_diff.density_max.
+;
+    _name.category_id             refine_diff
+    _name.object_id               density_max_su
+    _name.linked_item_id          '_refine_diff.density_max'
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+    _method.purpose               Definition
+    _method.expression
+;
+    # Default units. Applicable to x-ray, electron and gamma radiation.
+    _units.code = "electrons_per_angstrom_cubed"
+
+    If (_diffrn_radiation.probe == "neutron")
+        _units.code = "femtometres_per_angstrom_cubed"
+;
+
+save_
+
+save_refine_diff.density_min
+
+    _definition.id                '_refine_diff.density_min'
+
+    loop_
+      _alias.definition_id
+         '_refine_diff_density_min'
+         '_refine.diff_density_min'
+
+    _definition.update            2023-01-12
+    _description.text
+;
+    Minimum density value in a difference Fourier map.
+;
+    _name.category_id             refine_diff
+    _name.object_id               density_min
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            :100.0
+    _method.purpose               Definition
+    _method.expression
+;
+    # Default units. Applicable to x-ray, electron and gamma radiation.
+    _units.code = "electrons_per_angstrom_cubed"
+
+    If (_diffrn_radiation.probe == "neutron")
+        _units.code = "femtometres_per_angstrom_cubed"
+;
+
+save_
+
+save_refine_diff.density_min_su
+
+    _definition.id                '_refine_diff.density_min_su'
+
+    loop_
+      _alias.definition_id
+         '_refine_diff_density_min_su'
+         '_refine.diff_density_min_esd'
+
+    _definition.update            2023-01-12
+    _description.text
+;
+    Standard uncertainty of _refine_diff.density_min.
+;
+    _name.category_id             refine_diff
+    _name.object_id               density_min_su
+    _name.linked_item_id          '_refine_diff.density_min'
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+    _method.purpose               Definition
+    _method.expression
+;
+    # Default units. Applicable to x-ray, electron and gamma radiation.
+    _units.code = "electrons_per_angstrom_cubed"
+
+    If (_diffrn_radiation.probe == "neutron")
+        _units.code = "femtometres_per_angstrom_cubed"
+;
+
+save_
+
+save_refine_diff.density_rms
+
+    _definition.id                '_refine_diff.density_RMS'
+
+    loop_
+      _alias.definition_id
+         '_refine_diff_density_RMS'
+         '_refine.diff_density_RMS'
+
+    _definition.update            2023-01-12
+    _description.text
+;
+    Root mean square density value in a difference Fourier map.
+    This value is measured with respect to the arithmetic mean
+    density and is derived from summations over each grid point
+    in the asymmetric unit of the cell. This quantity is useful
+    for assessing the significance of *_min and *_max values,
+    and also for defining suitable contour levels.
+;
+    _name.category_id             refine_diff
+    _name.object_id               density_RMS
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            -100.0:100.0
+    _method.purpose               Definition
+    _method.expression
+;
+    # Default units. Applicable to x-ray, electron and gamma radiation.
+    _units.code = "electrons_per_angstrom_cubed"
+
+    If (_diffrn_radiation.probe == "neutron")
+        _units.code = "femtometres_per_angstrom_cubed"
+;
+
+save_
+
+save_refine_diff.density_rms_su
+
+    _definition.id                '_refine_diff.density_RMS_su'
+
+    loop_
+      _alias.definition_id
+         '_refine_diff_density_RMS_su'
+         '_refine.diff_density_RMS_esd'
+
+    _definition.update            2023-01-12
+    _description.text
+;
+    Standard uncertainty of _refine_diff.density_RMS.
+;
+    _name.category_id             refine_diff
+    _name.object_id               density_RMS_su
+    _name.linked_item_id          '_refine_diff.density_RMS'
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+    _method.purpose               Definition
+    _method.expression
+;
+    # Default units. Applicable to x-ray, electron and gamma radiation.
+    _units.code = "electrons_per_angstrom_cubed"
+
+    If (_diffrn_radiation.probe == "neutron")
+        _units.code = "femtometres_per_angstrom_cubed"
+;
+
+save_
+
+save_REFINE_LS
+
+    _definition.id                REFINE_LS
+    _definition.scope             Category
+    _definition.class             Set
+    _definition.update            2012-11-20
+    _description.text
+;
+    The CATEGORY of data items used to specify information about the
+    refinement of the structural model.
+;
+    _name.category_id             REFINE
+    _name.object_id               REFINE_LS
+
+save_
+
+save_refine_ls.abs_structure_details
+
+    _definition.id                '_refine_ls.abs_structure_details'
+
+    loop_
+      _alias.definition_id
+         '_refine_ls_abs_structure_details'
+         '_refine.ls_abs_structure_details'
+
+    _definition.update            2012-11-20
+    _description.text
+;
+    Details on the absolute structure and how it was determined.
+;
+    _name.category_id             refine_ls
+    _name.object_id               abs_structure_details
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_refine_ls.abs_structure_flack
+
+    _definition.id                '_refine_ls.abs_structure_Flack'
+
+    loop_
+      _alias.definition_id
+         '_refine_ls_abs_structure_Flack'
+         '_refine.ls_abs_structure_Flack'
+
+    _definition.update            2021-08-18
+    _description.text
+;
+    The measure of absolute structure as defined by Flack (1983).
+    For centrosymmetric structures, the only permitted value, if
+    the data item is present, is 'inapplicable', represented by '.' .
+    For noncentrosymmetric structures, the value must lie in the
+    99.97% Gaussian confidence interval  -3u =< x =< 1 + 3u and a
+    standard uncertainty (e.s.d.) u must be supplied. The
+    _enumeration.range of 0.0:1.0 is correctly interpreted as
+    meaning (0.0 - 3u) =< x =< (1.0 + 3u).
+    Ref: Flack, H. D. (1983). Acta Cryst. A39, 876-881.
+;
+    _name.category_id             refine_ls
+    _name.object_id               abs_structure_Flack
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:1.0
+    _units.code                   none
+
+save_
+
+save_refine_ls.abs_structure_flack_su
+
+    _definition.id                '_refine_ls.abs_structure_Flack_su'
+
+    loop_
+      _alias.definition_id
+         '_refine_ls_abs_structure_Flack_su'
+         '_refine.ls_abs_structure_Flack_esd'
+
+    _definition.update            2021-03-03
+    _description.text
+;
+    Standard uncertainty of _refine_ls.abs_structure_Flack.
+;
+    _name.category_id             refine_ls
+    _name.object_id               abs_structure_Flack_su
+    _name.linked_item_id          '_refine_ls.abs_structure_Flack'
+    _units.code                   none
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+save_
+
+save_refine_ls.abs_structure_rogers
+
+    _definition.id                '_refine_ls.abs_structure_Rogers'
+
+    loop_
+      _alias.definition_id
+         '_refine_ls_abs_structure_Rogers'
+         '_refine.ls_abs_structure_Rogers'
+
+    _definition.update            2012-11-20
+    _description.text
+;
+    The measure of absolute structure as defined by Rogers (1981).
+    The value must lie in the 99.97% Gaussian confidence interval
+    -1 -3u =< η =< 1 + 3u and a standard uncertainty (e.s.d.) u must
+    be supplied. The _enumeration.range of -1.0:1.0 is correctly
+    interpreted as meaning (-1.0 - 3u) =< η =< (1.0 + 3u).
+    Ref: Rogers, D. (1981). Acta Cryst. A37, 734-741.
+;
+    _name.category_id             refine_ls
+    _name.object_id               abs_structure_Rogers
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            -1.0:1.0
+    _units.code                   none
+
+save_
+
+save_refine_ls.abs_structure_rogers_su
+
+    _definition.id                '_refine_ls.abs_structure_Rogers_su'
+
+    loop_
+      _alias.definition_id
+         '_refine_ls_abs_structure_Rogers_su'
+         '_refine.ls_abs_structure_Rogers_esd'
+
+    _definition.update            2021-03-03
+    _description.text
+;
+    Standard uncertainty of _refine_ls.abs_structure_Rogers.
+;
+    _name.category_id             refine_ls
+    _name.object_id               abs_structure_Rogers_su
+    _name.linked_item_id          '_refine_ls.abs_structure_Rogers'
+    _units.code                   none
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+save_
+
+save_refine_ls.d_res_high
+
+    _definition.id                '_refine_ls.d_res_high'
+
+    loop_
+      _alias.definition_id
+         '_refine_ls_d_res_high'
+         '_refine.ls_d_res_high'
+
+    _definition.update            2021-03-03
+    _description.text
+;
+    Highest resolution for the reflections used in refinement.
+    This corresponds to the smallest interplanar d value.
+;
+    _name.category_id             refine_ls
+    _name.object_id               d_res_high
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   angstroms
+
+save_
+
+save_refine_ls.d_res_low
+
+    _definition.id                '_refine_ls.d_res_low'
+
+    loop_
+      _alias.definition_id
+         '_refine_ls_d_res_low'
+         '_refine.ls_d_res_low'
+
+    _definition.update            2021-03-03
+    _description.text
+;
+    Lowest resolution for the reflections used in refinement.
+    This corresponds to the largest interplanar d value.
+;
+    _name.category_id             refine_ls
+    _name.object_id               d_res_low
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   angstroms
+
+save_
+
+save_refine_ls.extinction_coef
+
+    _definition.id                '_refine_ls.extinction_coef'
+
+    loop_
+      _alias.definition_id
+         '_refine_ls_extinction_coef'
+         '_refine.ls_extinction_coef'
+
+    _definition.update            2012-11-20
+    _description.text
+;
+    The extinction coefficient used to calculate the correction
+    factor applied to the structure-factor data. The nature of the
+    extinction coefficient is given in the definitions of
+    _refine_ls.extinction_expression and _refine_ls.extinction_method.
+    For the 'Zachariasen' method it is the r* value; for the
+    'Becker-Coppens type 1 isotropic' method it is the 'g' value.
+    For 'Becker-Coppens type 2 isotropic' corrections it is
+    the 'rho' value. Note that the magnitude of these values is
+    usually of the order of 10000.
+    Ref:  Becker, P. J. & Coppens, P. (1974). Acta Cryst. A30,
+          129-147, 148-153.
+          Zachariasen, W. H. (1967). Acta Cryst. 23, 558-564.
+          Larson, A. C. (1967). Acta Cryst. 23, 664-665.
+;
+    _name.category_id             refine_ls
+    _name.object_id               extinction_coef
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   none
+    _description_example.case     3472(52)
+    _description_example.detail   'Zachariasen coefficient r* = 0.347(5)e+04.'
+
+save_
+
+save_refine_ls.extinction_coef_su
+
+    _definition.id                '_refine_ls.extinction_coef_su'
+
+    loop_
+      _alias.definition_id
+         '_refine_ls_extinction_coef_su'
+         '_refine.ls_extinction_coef_esd'
+
+    _definition.update            2021-03-03
+    _description.text
+;
+    Standard uncertainty of _refine_ls.extinction_coef.
+;
+    _name.category_id             refine_ls
+    _name.object_id               extinction_coef_su
+    _name.linked_item_id          '_refine_ls.extinction_coef'
+    _units.code                   none
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+save_
+
+save_refine_ls.extinction_expression
+
+    _definition.id                '_refine_ls.extinction_expression'
+
+    loop_
+      _alias.definition_id
+         '_refine_ls_extinction_expression'
+         '_refine.ls_extinction_expression'
+
+    _definition.update            2023-01-13
+    _description.text
+;
+    Description of or reference to the extinction-correction equation
+    used to apply the data item  _refine_ls.extinction_coef. This
+    information should be sufficient to reproduce the extinction-correction
+    factors applied to the structure factors.
+;
+    _name.category_id             refine_ls
+    _name.object_id               extinction_expression
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+    _description_example.case     'Larson approach'
+    _description_example.detail
+;
+    Larson, A. C. (1970). "Crystallographic Computing", edited by
+    F. R. Ahmed. Eq. (22) p. 292.  Copenhagen: Munksgaard.
+;
+
+save_
+
+save_refine_ls.extinction_method
+
+    _definition.id                '_refine_ls.extinction_method'
+
+    loop_
+      _alias.definition_id
+         '_refine_ls_extinction_method'
+         '_refine.ls_extinction_method'
+
+    _definition.update            2019-01-09
+    _description.text
+;
+    Description of the extinction correction method applied with the
+    data item _refine_ls.extinction_coef. This description should
+    include information about the correction method, either 'Becker-
+    Coppens' or 'Zachariasen'. The latter is sometimes referred to as
+    the 'Larson' method even though it employs Zachariasen's formula.
+
+    The Becker-Coppens procedure is referred to as 'type 1' when
+    correcting secondary extinction dominated by the mosaic spread;
+    as 'type 2' when secondary extinction is dominated by particle
+    size and includes a primary extinction component; and as 'mixed'
+    when there are types 1 and 2.
+
+    For the Becker-Coppens method it is also necessary to set the
+    mosaic distribution as either 'Gaussian' or 'Lorentzian'; and the
+    nature of the extinction as 'isotropic' or 'anisotropic'. Note
+    that if either the 'mixed' or 'anisotropic' corrections are applied
+    the multiple coefficients cannot be contained in the
+    _refine_ls.extinction_coef and must be listed in _refine.special_details.
+
+    Ref:  Becker, P. J. & Coppens, P. (1974). Acta Cryst. A30, 129-153.
+          Zachariasen, W. H. (1967). Acta Cryst. 23, 558-564.
+          Larson, A. C. (1967). Acta Cryst. 23, 664-665.
+;
+    _name.category_id             refine_ls
+    _name.object_id               extinction_method
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+
+    loop_
+      _description_example.case
+         'Zachariasen'
+         'B-C type 2 Gaussian isotropic'
+
+save_
+
+save_refine_ls.f_calc_details
+
+    _definition.id                '_refine_ls.F_calc_details'
+    _alias.definition_id          '_refine_ls_F_calc_details'
+    _definition.update            2023-01-13
+    _description.text
+;
+    Details concerning the evaluation of the structure factors
+    using the expression given in _refine_ls.F_calc_formula.
+;
+    _name.category_id             refine_ls
+    _name.object_id               F_calc_details
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+
+    loop_
+      _description_example.case
+;
+       Gaussian integration using 16 points
+;
+;
+       Bessel functions expansion up to 5th order. Estimated accuracy of
+       Bessel function better than 0.001 electrons
+;
+
+save_
+
+save_refine_ls.f_calc_formula
+
+    _definition.id                '_refine_ls.F_calc_formula'
+    _alias.definition_id          '_refine_ls_F_calc_formula'
+    _definition.update            2013-01-23
+    _description.text
+;
+    Analytical expression used to calculate the structure factors.
+;
+    _name.category_id             refine_ls
+    _name.object_id               F_calc_formula
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_refine_ls.f_calc_precision
+
+    _definition.id                '_refine_ls.F_calc_precision'
+    _alias.definition_id          '_refine_ls_F_calc_precision'
+    _definition.update            2023-05-14
+    _description.text
+;
+    Estimate of the precision resulting from the numerical
+    approximations made during the evaluation of the structure
+    factors using the expression _refine_ls.F_calc_formula
+    following the method outlined in _refine_ls.F_calc_details.
+;
+    _name.category_id             refine_ls
+    _name.object_id               F_calc_precision
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _method.purpose               Definition
+    _method.expression
+;
+         If (_diffrn_radiation.probe == "neutron")  _units.code =  "femtometres"
+    Else If (_diffrn_radiation.probe == "electron") _units.code =  "volts"
+    Else                                            _units.code =  "electrons"
+;
+
+save_
+
+save_refine_ls.f_calc_precision_su
+
+    _definition.id                '_refine_ls.F_calc_precision_su'
+    _definition.update            2023-07-01
+    _description.text
+;
+    Standard uncertainty of _refine_ls.F_calc_precision.
+;
+    _name.category_id             refine_ls
+    _name.object_id               F_calc_precision_su
+    _name.linked_item_id          '_refine_ls.F_calc_precision'
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+    _method.purpose               Definition
+    _method.expression
+;
+         If (_diffrn_radiation.probe == "neutron")  _units.code =  "femtometres"
+    Else If (_diffrn_radiation.probe == "electron") _units.code =  "volts"
+    Else                                            _units.code =  "electrons"
+;
+
+save_
+
+save_refine_ls.goodness_of_fit_all
+
+    _definition.id                '_refine_ls.goodness_of_fit_all'
+
+    loop_
+      _alias.definition_id
+         '_refine_ls_goodness_of_fit_all'
+         '_refine.ls_goodness_of_fit_all'
+
+    _definition.update            2012-11-20
+    _description.text
+;
+    Least-squares goodness-of-fit parameter S for all reflections after
+    the final cycle of refinement. Ideally, account should be taken of
+    parameters restrained in the least squares.
+
+             {  sum { w [ Y(meas) - Y(calc) ]^2^ }  }^1/2^
+         S = { ------------------------------------ }
+             {            Nref - Nparam             }
+
+         Y(meas) = the measured coefficients
+                   (see _refine_ls.structure_factor_coef)
+         Y(calc) = the calculated coefficients
+                   (see _refine_ls.structure_factor_coef)
+         w       = the least-squares reflection weight
+                   [1/(u^2^)]
+         u       = standard uncertainty
+         Nref   = the number of reflections used in the refinement
+         Nparam = the number of refined parameters
+         and the sum is taken over the specified reflections
+;
+    _name.category_id             refine_ls
+    _name.object_id               goodness_of_fit_all
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   none
+
+save_
+
+save_refine_ls.goodness_of_fit_all_su
+
+    _definition.id                '_refine_ls.goodness_of_fit_all_su'
+
+    loop_
+      _alias.definition_id
+         '_refine_ls_goodness_of_fit_all_su'
+         '_refine.ls_goodness_of_fit_all_esd'
+
+    _definition.update            2021-03-03
+    _description.text
+;
+    Standard uncertainty of _refine_ls.goodness_of_fit_all.
+;
+    _name.category_id             refine_ls
+    _name.object_id               goodness_of_fit_all_su
+    _name.linked_item_id          '_refine_ls.goodness_of_fit_all'
+    _units.code                   none
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+save_
+
+save_refine_ls.goodness_of_fit_gt
+
+    _definition.id                '_refine_ls.goodness_of_fit_gt'
+
+    loop_
+      _alias.definition_id
+      _alias.deprecation_date
+         '_refine_ls_goodness_of_fit_gt'                             .
+         '_refine_ls_goodness_of_fit_obs'                            1999-03-24
+         '_refine.ls_goodness_of_fit_obs'                            .
+         '_refine.ls_goodness_of_fit_gt'                             .
+
+    _definition.update            2024-02-14
+    _description.text
+;
+    Least-squares goodness-of-fit parameter S for significantly
+    intense reflections, (i.e. 'observed' reflections with values
+    greater-than the threshold set in _reflns.threshold_expression),
+    after the final cycle. Ideally, account should be taken of
+    parameters restrained in the least-squares refinement.
+
+             {  sum { w [ Y(meas_gt) - Y(calc) ]^2^ }  }^1/2^
+         S = { --------------------------------------- }
+             {           Nref - Nparam                 }
+
+         Y(meas_gt)  = the 'observed' coefficients
+                   (see _refine_ls.structure_factor_coef)
+         Y(calc)     = the calculated coefficients
+                   (see _refine_ls.structure_factor_coef)
+         w       = the least-squares reflection weight
+                   [1/(u^2^)]
+         u       = standard uncertainty
+         Nref   = the number of reflections used in the refinement
+         Nparam = the number of refined parameters
+         and the sum is taken over the specified reflections
+;
+    _name.category_id             refine_ls
+    _name.object_id               goodness_of_fit_gt
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   none
+
+save_
+
+save_refine_ls.goodness_of_fit_gt_su
+
+    _definition.id                '_refine_ls.goodness_of_fit_gt_su'
+
+    loop_
+      _alias.definition_id
+         '_refine_ls_goodness_of_fit_gt_su'
+         '_refine.ls_goodness_of_fit_gt_esd'
+         '_refine.ls_goodness_of_fit_obs_esd'
+
+    _definition.update            2021-03-03
+    _description.text
+;
+    Standard uncertainty of _refine_ls.goodness_of_fit_gt.
+;
+    _name.category_id             refine_ls
+    _name.object_id               goodness_of_fit_gt_su
+    _name.linked_item_id          '_refine_ls.goodness_of_fit_gt'
+    _units.code                   none
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+save_
+
+save_refine_ls.goodness_of_fit_ref
+
+    _definition.id                '_refine_ls.goodness_of_fit_ref'
+
+    loop_
+      _alias.definition_id
+         '_refine_ls_goodness_of_fit_ref'
+         '_refine.ls_goodness_of_fit_ref'
+
+    _definition.update            2012-11-20
+    _description.text
+;
+    Least-squares goodness-of-fit parameter S for those reflections
+    included in the final cycle of refinement. Account should be
+    taken of restrained parameters.
+
+             {  sum { w [ Y(meas) - Y(calc) ]^2^ }  }^1/2^
+         S = { ------------------------------------ }
+             {            Nref - Nparam             }
+
+         Y(meas) = the measured coefficients
+                   (see _refine_ls.structure_factor_coef)
+         Y(calc) = the calculated coefficients
+                   (see _refine_ls.structure_factor_coef)
+         w       = the least-squares reflection weight
+                   [1/(u^2^)]
+         u       = standard uncertainty
+         Nref   = the number of reflections used in the refinement
+         Nparam = the number of refined parameters
+         and the sum is taken over the specified reflections
+;
+    _name.category_id             refine_ls
+    _name.object_id               goodness_of_fit_ref
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   none
+
+save_
+
+save_refine_ls.goodness_of_fit_ref_su
+
+    _definition.id                '_refine_ls.goodness_of_fit_ref_su'
+    _definition.update            2023-07-01
+    _description.text
+;
+    Standard uncertainty of _refine_ls.goodness_of_fit_ref.
+;
+    _name.category_id             refine_ls
+    _name.object_id               goodness_of_fit_ref_su
+    _name.linked_item_id          '_refine_ls.goodness_of_fit_ref'
+    _units.code                   none
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+save_
+
+save_refine_ls.hydrogen_treatment
+
+    _definition.id                '_refine_ls.hydrogen_treatment'
+
+    loop_
+      _alias.definition_id
+         '_refine_ls_hydrogen_treatment'
+         '_refine.ls_hydrogen_treatment'
+
+    _definition.update            2012-11-20
+    _description.text
+;
+    Code identifying how hydrogen atoms were treated in the refinement.
+;
+    _name.category_id             refine_ls
+    _name.object_id               hydrogen_treatment
+    _type.purpose                 State
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Text
+
+    loop_
+      _enumeration_set.state
+      _enumeration_set.detail
+         refall
+;
+         Refined all H-atom parameters.
+;
+         refxyz
+;
+         Refined H-atom coordinates only.
+;
+         refU
+;
+         Refined H-atom Us only.
+;
+         noref
+;
+         No refinement of H-atom parameters.
+;
+         constr
+;
+         H-atom parameters constrained.
+;
+         hetero
+;
+         H-atom parameters constrained for H on C, all H-atom parameters
+         refined for H on heteroatoms.
+;
+         heteroxyz
+;
+         H-atom parameters constrained for H on C, refined H-atom coordinates
+         only for H on heteroatoms.
+;
+         heteroU
+;
+         H-atom parameters constrained for H on C, refined H-atom U's only for
+         H on heteroatoms.
+;
+         heteronoref
+;
+         H-atom parameters constrained for H on C, no refinement of H-atom
+         parameters for H on heteroatoms.
+;
+         hetero-mixed
+;
+         H-atom parameters constrained for H on C and some heteroatoms, all
+         H-atom parameters refined for H on remaining heteroatoms.
+;
+         heteroxyz-mixed
+;
+         H-atom parameters constrained for H on C and some heteroatoms, refined
+         H-atom coordinates only for H on remaining heteroatoms.
+;
+         heteroU-mixed
+;
+         H-atom parameters constrained for H on C and some heteroatoms, refined
+         H-atom U's only for H on remaining heteroatoms.
+;
+         heteronoref-mixed
+;
+         H-atom parameters constrained for H on C and some heteroatoms, no
+         refinement of H-atom parameters for H on remaining heteroatoms.
+;
+         mixed
+;
+         Some constrained, some independent.
+;
+         undef
+;
+         H-atom parameters not defined.
+;
+
+save_
+
+save_refine_ls.matrix_type
+
+    _definition.id                '_refine_ls.matrix_type'
+
+    loop_
+      _alias.definition_id
+         '_refine_ls_matrix_type'
+         '_refine.ls_matrix_type'
+
+    _definition.update            2012-11-20
+    _description.text
+;
+    Code identifying the matrix type used for least-squares derivatives.
+;
+    _name.category_id             refine_ls
+    _name.object_id               matrix_type
+    _type.purpose                 State
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Text
+
+    loop_
+      _enumeration_set.state
+      _enumeration_set.detail
+         full                     'Full.'
+         fullcycle                'Full with fixed elements per cycle.'
+         atomblock                'Block diagonal per atom.'
+         userblock                'User-defined blocks.'
+         diagonal                 'Diagonal elements only.'
+         sparse                   'Selected elements only.'
+
+save_
+
+save_refine_ls.number_constraints
+
+    _definition.id                '_refine_ls.number_constraints'
+
+    loop_
+      _alias.definition_id
+         '_refine_ls_number_constraints'
+         '_refine.ls_number_constraints'
+
+    _definition.update            2023-01-13
+    _description.text
+;
+    Number of constrained (non-refined or dependent) parameters
+    in the least-squares process. These may be due to symmetry or any
+    other constraint process (e.g. rigid-body refinement). See also
+    _atom_site.constraints and _atom_site.refinement_flags_*. A general
+    description of constraints may appear in _refine.special_details.
+;
+    _name.category_id             refine_ls
+    _name.object_id               number_constraints
+    _type.purpose                 Number
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Integer
+    _enumeration.range            0:
+    _units.code                   none
+
+save_
+
+save_refine_ls.number_parameters
+
+    _definition.id                '_refine_ls.number_parameters'
+
+    loop_
+      _alias.definition_id
+         '_refine_ls_number_parameters'
+         '_refine.ls_number_parameters'
+
+    _definition.update            2021-03-01
+    _description.text
+;
+    Number of parameters refined in the least-squares process. If
+    possible this number should include the restrained parameters.
+    The restrained parameters are distinct from the constrained
+    parameters (where one or more parameters are linearly dependent
+    on the refined value of another).  Least-squares restraints
+    often depend on geometry or energy considerations and this
+    makes their direct contribution to this number, and to the
+    goodness-of-fit calculation, difficult to assess.
+;
+    _name.category_id             refine_ls
+    _name.object_id               number_parameters
+    _type.purpose                 Number
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Integer
+    _enumeration.range            0:
+    _units.code                   none
+
+save_
+
+save_refine_ls.number_reflns
+
+    _definition.id                '_refine_ls.number_reflns'
+
+    loop_
+      _alias.definition_id
+         '_refine_ls_number_reflns'
+         '_refine.ls_number_reflns_all'
+
+    _definition.update            2021-03-01
+    _description.text
+;
+    Number of unique reflections used in the least-squares refinement.
+;
+    _name.category_id             refine_ls
+    _name.object_id               number_reflns
+    _type.purpose                 Number
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Integer
+    _enumeration.range            0:
+    _units.code                   none
+
+save_
+
+save_refine_ls.number_reflns_gt
+
+    _definition.id                '_refine_ls.number_reflns_gt'
+
+    loop_
+      _alias.definition_id
+         '_refine_ls_number_reflns_gt'
+         '_refine.ls_number_reflns_obs'
+
+    _definition.update            2021-03-01
+    _description.text
+;
+    The number of reflections that satisfy the resolution limits
+    established by _refine_ls.d_res_high and _refine_ls.d_res_low
+    and the observation limit established by _reflns.threshold_expression.
+;
+    _name.category_id             refine_ls
+    _name.object_id               number_reflns_gt
+    _type.purpose                 Number
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Integer
+    _enumeration.range            1:
+    _units.code                   none
+
+save_
+
+save_refine_ls.number_restraints
+
+    _definition.id                '_refine_ls.number_restraints'
+
+    loop_
+      _alias.definition_id
+         '_refine_ls_number_restraints'
+         '_refine.ls_number_restraints'
+
+    _definition.update            2023-01-13
+    _description.text
+;
+    Number of restrained parameters in the least-squares refinement. These
+    parameters do not directly dependent on another refined parameter. Often
+    restrained parameters involve geometry or energy dependencies. See also
+    _atom_site.constraints and _atom_site.refinement_flags_*. A description
+    of refinement constraints may appear in _refine.special_details.
+;
+    _name.category_id             refine_ls
+    _name.object_id               number_restraints
+    _type.purpose                 Number
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Integer
+    _enumeration.range            0:
+    _units.code                   none
+
+save_
+
+save_refine_ls.r_factor_all
+
+    _definition.id                '_refine_ls.R_factor_all'
+
+    loop_
+      _alias.definition_id
+         '_refine_ls_R_factor_all'
+         '_refine.ls_R_factor_all'
+
+    _definition.update            2014-04-17
+    _description.text
+;
+    Residual factor for all reflections satisfying the resolution limits
+    specified by _refine_ls.d_res_high and _refine_ls.d_res_low. This is
+    the conventional R factor. See also wR factor definitions.
+
+                  sum | F(meas) - F(calc) |
+              R = ------------------------
+                        sum | F(meas) |
+
+              F(meas) = the measured structure-factor amplitudes
+              F(calc) = the calculated structure-factor amplitudes
+              and the sum is taken over the specified reflections
+;
+    _name.category_id             refine_ls
+    _name.object_id               R_factor_all
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   none
+    _method.purpose               Evaluation
+    _method.expression
+;
+    sumFdiff  =   0.
+    sumFmeas  =   0.
+    Loop r  as  refln  {
+                  sumFdiff  +=   Abs(r.F_calc - r.F_meas)
+                  sumFmeas  +=   Abs(r.F_meas)
+                       }
+        _refine_ls.R_factor_all  =   sumFdiff / sumFmeas
+;
+
+save_
+
+save_refine_ls.r_factor_gt
+
+    _definition.id                '_refine_ls.R_factor_gt'
+
+    loop_
+      _alias.definition_id
+      _alias.deprecation_date
+         '_refine_ls_R_factor_obs'                                   1999-03-24
+         '_refine_ls_R_factor_gt'                                    .
+         '_refine.ls_R_factor_obs'                                   .
+         '_refine.ls_R_factor_gt'                                    .
+
+    _definition.update            2024-02-14
+    _description.text
+;
+    Residual factor for the reflections judged significantly intense
+    (see _reflns.number_gt and _reflns.threshold_expression) and included
+    in the refinement. The reflections also satisfy the resolution limits
+    specified by _refine_ls.d_res_high and _refine_ls.d_res_low. This is
+    the conventional R factor.
+
+                  sum | F(meas_gt) - F(calc) |
+              R = -----------------------------
+                        sum | F(meas_gt) |
+
+              F(meas_gt) = the 'observed' structure-factor amplitudes
+              F(calc)    = the calculated structure-factor amplitudes
+              and the sum is taken over the specified reflections
+;
+    _name.category_id             refine_ls
+    _name.object_id               R_factor_gt
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   none
+
+save_
+
+save_refine_ls.r_fsqd_factor
+
+    _definition.id                '_refine_ls.R_Fsqd_factor'
+
+    loop_
+      _alias.definition_id
+         '_refine_ls_R_Fsqd_factor'
+         '_refine.ls_R_Fsqd_factor_obs'
+
+    _definition.update            2012-11-20
+    _description.text
+;
+    Residual factor R(Fsqd), calculated on the squared amplitudes of the
+    measured and calculated structure factors, for significantly intense
+    reflections (satisfying _reflns.threshold_expression) and included in
+    the refinement. The reflections also satisfy the resolution limits
+    specified by _refine_ls.d_res_high and _refine_ls.d_res_low.
+
+                         sum | F(meas_gt)^2^ - F(calc)^2^ |
+              R(Fsqd) = ------------------------------------
+                                 sum F(meas_gt)^2^
+
+              F(meas_gt)^2^ = squares of the 'observed' structure-factor
+              F(calc)^2^    = squares of the calculated structure-factor
+              and the sum is taken over the specified reflections
+;
+    _name.category_id             refine_ls
+    _name.object_id               R_Fsqd_factor
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   none
+
+save_
+
+save_refine_ls.r_i_factor
+
+    _definition.id                '_refine_ls.R_I_factor'
+
+    loop_
+      _alias.definition_id
+         '_refine_ls_R_I_factor'
+         '_refine.ls_R_I_factor_obs'
+
+    _definition.update            2012-11-20
+    _description.text
+;
+    Residual factor R(I) for significantly intense reflections (satisfying
+    _reflns.threshold_expression) and included in the refinement. This is
+    most often calculated in Rietveld refinements of powder data, where it
+    is referred to as R~B~ or R~Bragg~.
+
+                      sum | I(meas_gt) - I(calc) |
+              R(I) =  -----------------------------
+                             sum | I(meas_gt) |
+
+              I(meas_gt) = the net 'observed' intensities
+              I(calc)    = the net calculated intensities
+              and the sum is taken over the specified reflections
+;
+    _name.category_id             refine_ls
+    _name.object_id               R_I_factor
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   none
+
+save_
+
+save_refine_ls.restrained_s_all
+
+    _definition.id                '_refine_ls.restrained_S_all'
+
+    loop_
+      _alias.definition_id
+         '_refine_ls_restrained_S_all'
+         '_refine.ls_restrained_S_all'
+
+    _definition.update            2012-11-20
+    _description.text
+;
+    Least-squares goodness-of-fit parameter S' for all reflections after
+    the final cycle of least squares. This parameter explicitly includes
+    the restraints applied in the least-squares process. See also
+    _refine_ls.goodness_of_fit_all definition.
+
+           {sum { w [ Y(meas) - Y(calc) ]^2^ }                  }^1/2^
+           {         + sum~r~ { w~r~ [ P(calc) - P(targ) ]^2^ } }
+      S' = { -------------------------------------------------- }
+           {            N~ref~ + N~restr~ - N~param~            }
+
+              Y(meas)  = the measured coefficients
+                         (see _refine_ls.structure_factor_coef)
+              Y(calc)  = the calculated coefficients
+                         (see _refine_ls.structure_factor_coef)
+              w        = the least-squares reflection weight
+                         [1/square of standard uncertainty (e.s.d.)]
+              P(calc)  = the calculated restraint values
+              P(targ)  = the target restraint values
+              w~r~     = the restraint weight
+
+              N~ref~   = the number of reflections used in the refinement
+                       (see _refine_ls.number_reflns)
+              N~restr~ = the number of restraints
+                       (see _refine_ls.number_restraints)
+              N~param~ = the number of refined parameters
+                       (see _refine_ls.number_parameters)
+
+              sum     is taken over the specified reflections
+              sum~r~  is taken over the restraints
+;
+    _name.category_id             refine_ls
+    _name.object_id               restrained_S_all
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   none
+
+save_
+
+save_refine_ls.restrained_s_all_su
+
+    _definition.id                '_refine_ls.restrained_S_all_su'
+    _definition.update            2023-07-01
+    _description.text
+;
+    Standard uncertainty of _refine_ls.restrained_S_all.
+;
+    _name.category_id             refine_ls
+    _name.object_id               restrained_S_all_su
+    _name.linked_item_id          '_refine_ls.restrained_S_all'
+    _units.code                   none
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+save_
+
+save_refine_ls.restrained_s_gt
+
+    _definition.id                '_refine_ls.restrained_S_gt'
+
+    loop_
+      _alias.definition_id
+      _alias.deprecation_date
+         '_refine_ls_restrained_S_obs'                               1999-03-24
+         '_refine_ls_restrained_S_gt'                                .
+         '_refine.ls_restrained_S_obs'                               .
+
+    _definition.update            2024-02-14
+    _description.text
+;
+    Least-squares goodness-of-fit parameter S' for significantly intense
+    reflections (satisfying _reflns.threshold_expression) after the final
+    cycle of least squares. This parameter explicitly includes the restraints
+    applied. The expression for S' is given in _refine_ls.restrained_S_all.
+
+           {sum { w [ Y(meas_gt) - Y(calc) ]^2^ }               }^1/2^
+           {         + sum~r~ { w~r~ [ P(calc) - P(targ) ]^2^ } }
+      S' = { -------------------------------------------------- }
+           {            N~ref~ + N~restr~ - N~param~            }
+
+              Y(meas_gt) = the 'observed' coefficients
+                         (see _refine_ls.structure_factor_coef)
+              Y(calc)    = the calculated coefficients
+                         (see _refine_ls.structure_factor_coef)
+              w        = the least-squares reflection weight
+                         [1/square of standard uncertainty (e.s.d.)]
+              P(calc)  = the calculated restraint values
+              P(targ)  = the target restraint values
+              w~r~     = the restraint weight
+
+              N~ref~   = the number of reflections used in the refinement
+                       (see _refine_ls.number_reflns)
+              N~restr~ = the number of restraints
+                       (see _refine_ls.number_restraints)
+              N~param~ = the number of refined parameters
+                       (see _refine_ls.number_parameters)
+
+              sum     is taken over the specified reflections
+              sum~r~  is taken over the restraints
+;
+    _name.category_id             refine_ls
+    _name.object_id               restrained_S_gt
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   none
+
+save_
+
+save_refine_ls.restrained_s_gt_su
+
+    _definition.id                '_refine_ls.restrained_S_gt_su'
+    _definition.update            2023-07-01
+    _description.text
+;
+    Standard uncertainty of _refine_ls.restrained_S_gt.
+;
+    _name.category_id             refine_ls
+    _name.object_id               restrained_S_gt_su
+    _name.linked_item_id          '_refine_ls.restrained_S_gt'
+    _units.code                   none
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+save_
+
+save_refine_ls.shift_over_su_max
+
+    _definition.id                '_refine_ls.shift_over_su_max'
+
+    loop_
+      _alias.definition_id
+      _alias.deprecation_date
+         '_refine_ls_shift_over_su_max'                              .
+         '_refine.ls_shift_over_esd_max'                             .
+         '_refine.ls_shift_over_su_max'                              .
+         '_refine_ls_shift/su_max'                                   .
+         '_refine_ls_shift/esd_max'                                  1999-03-24
+
+    _definition.update            2024-02-14
+    _description.text
+;
+    The largest ratio of the final least-squares parameter shift
+    to the final standard uncertainty (s.u., formerly described
+    as estimated standard deviation, e.s.d.).
+;
+    _name.category_id             refine_ls
+    _name.object_id               shift_over_su_max
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   none
+
+save_
+
+save_refine_ls.shift_over_su_max_lt
+
+    _definition.id                '_refine_ls.shift_over_su_max_lt'
+
+    loop_
+      _alias.definition_id
+         '_refine_ls_shift/su_max_lt'
+         '_refine.ls_shift_over_su_max_lt'
+
+    _definition.update            2012-12-11
+    _description.text
+;
+    Upper limit for the largest ratio of the final l-s parameter
+    shift divided by the final standard uncertainty. This item is
+    used when the largest value of the shift divided by the final
+    standard uncertainty is too small to measure.
+;
+    _name.category_id             refine_ls
+    _name.object_id               shift_over_su_max_lt
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   none
+
+save_
+
+save_refine_ls.shift_over_su_mean
+
+    _definition.id                '_refine_ls.shift_over_su_mean'
+
+    loop_
+      _alias.definition_id
+      _alias.deprecation_date
+         '_refine_ls_shift_over_su_mean'                             .
+         '_refine.ls_shift_over_esd_mean'                            .
+         '_refine.ls_shift_over_su_mean'                             .
+         '_refine_ls_shift/su_mean'                                  .
+         '_refine_ls_shift/esd_mean'                                 1999-03-24
+
+    _definition.update            2024-02-14
+    _description.text
+;
+    The average ratio of the final least-squares parameter shift
+    to the final standard uncertainty (s.u., formerly described
+    as estimated standard deviation, e.s.d.).
+;
+    _name.category_id             refine_ls
+    _name.object_id               shift_over_su_mean
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   none
+
+save_
+
+save_refine_ls.shift_over_su_mean_lt
+
+    _definition.id                '_refine_ls.shift_over_su_mean_lt'
+
+    loop_
+      _alias.definition_id
+         '_refine_ls_shift/su_mean_lt'
+         '_refine.ls_shift_over_su_mean_lt'
+
+    _definition.update            2012-12-11
+    _description.text
+;
+    Upper limit for the average ratio of the final l-s parameter
+    shift divided by the final standard uncertainty. This item is
+    used when the average value of the shift divided by the final
+    standard uncertainty is too small to measure.
+;
+    _name.category_id             refine_ls
+    _name.object_id               shift_over_su_mean_lt
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   none
+
+save_
+
+save_refine_ls.structure_factor_coef
+
+    _definition.id                '_refine_ls.structure_factor_coef'
+
+    loop_
+      _alias.definition_id
+         '_refine_ls_structure_factor_coef'
+         '_refine.ls_structure_factor_coef'
+
+    _definition.update            2012-11-20
+    _description.text
+;
+    Structure-factor coefficient used in the least-squares process.
+;
+    _name.category_id             refine_ls
+    _name.object_id               structure_factor_coef
+    _type.purpose                 State
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Text
+
+    loop_
+      _enumeration_set.state
+      _enumeration_set.detail
+         F                        'Structure factor magnitude.'
+         Fsqd                     'Structure factor squared.'
+         Inet                     'Net intensity.'
+
+save_
+
+save_refine_ls.weighting_details
+
+    _definition.id                '_refine_ls.weighting_details'
+
+    loop_
+      _alias.definition_id
+         '_refine_ls_weighting_details'
+         '_refine.ls_weighting_details'
+
+    _definition.update            2012-11-20
+    _description.text
+;
+    Description of special aspects of the weighting scheme used in the
+    least-squares refinement. Used to describe the weighting when the
+    value of _refine_ls.weighting_scheme is specified as 'calc'.
+;
+    _name.category_id             refine_ls
+    _name.object_id               weighting_details
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+    _description_example.case
+;
+    Sigdel model of Konnert-Hendrickson:
+      Sigdel = Afsig +  Bfsig*(sin(θ)/λ - 1/6)
+      Afsig  = 22.0, Bfsig = 150.0 at the beginning of refinement.
+      Afsig  = 16.0, Bfsig =  60.0 at the end of refinement.
+;
+
+save_
+
+save_refine_ls.weighting_scheme
+
+    _definition.id                '_refine_ls.weighting_scheme'
+
+    loop_
+      _alias.definition_id
+         '_refine_ls_weighting_scheme'
+         '_refine.ls_weighting_scheme'
+
+    _definition.update            2012-11-20
+    _description.text
+;
+    General description of the weighting scheme used in the least-squares.
+    An enumerated code should be contained in this description.
+;
+    _name.category_id             refine_ls
+    _name.object_id               weighting_scheme
+    _type.purpose                 State
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Text
+
+    loop_
+      _enumeration_set.state
+      _enumeration_set.detail
+         sigma                    "Based on measured s.u.'s."
+         unit                     "Unit or no weights applied."
+         calc                     "Calculated weights applied."
+
+save_
+
+save_refine_ls.wr_factor_all
+
+    _definition.id                '_refine_ls.wR_factor_all'
+
+    loop_
+      _alias.definition_id
+         '_refine_ls_wR_factor_all'
+         '_refine.ls_wR_factor_all'
+
+    _definition.update            2012-11-20
+    _description.text
+;
+    Weighted residual factors for all reflections satisfying the resolution
+    limits specified by _refine_ls.d_res_high and _refine_ls.d_res_low.
+    See also the _refine_ls.R_factor_all definition.
+
+           ( sum w [ Y(meas) - Y(calc) ]^2^ )^1/2^
+      wR = ( ------------------------------ )
+           (         sum w Y(meas)^2^       )
+
+      Y(meas) = the measured   amplitude _refine_ls.structure_factor_coef
+      Y(calc) = the calculated amplitude _refine_ls.structure_factor_coef
+      w       = the least-squares weight
+      and the sum is taken over the specified reflections
+;
+    _name.category_id             refine_ls
+    _name.object_id               wR_factor_all
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   none
+
+save_
+
+save_refine_ls.wr_factor_gt
+
+    _definition.id                '_refine_ls.wR_factor_gt'
+
+    loop_
+      _alias.definition_id
+      _alias.deprecation_date
+         '_refine_ls_wR_factor_obs'                                  1999-03-24
+         '_refine.ls_wR_factor_obs'                                  .
+         '_refine_ls_wR_factor_gt'                                   .
+
+    _definition.update            2024-02-14
+    _description.text
+;
+    Weighted residual factors for significantly intense reflections
+    (satisfying _reflns.threshold_expression) included in the refinement.
+    The reflections must also satisfy the resolution limits established by
+    _refine_ls.d_res_high and _refine_ls.d_res_low.
+
+           ( sum w [ Y(meas_gt) - Y(calc) ]^2^  )^1/2^
+      wR = ( ---------------------------------- )
+           (         sum w Y(meas_gt)^2^        )
+
+    Y(meas_gt) = the 'observed' amplitude _refine_ls.structure_factor_coef
+    Y(calc)    = the calculated amplitude _refine_ls.structure_factor_coef
+      w        = the least-squares weight
+      and the sum is taken over the specified reflections
+;
+    _name.category_id             refine_ls
+    _name.object_id               wR_factor_gt
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   none
+
+save_
+
+save_refine_ls.wr_factor_ref
+
+    _definition.id                '_refine_ls.wR_factor_ref'
+    _alias.definition_id          '_refine_ls_wR_factor_ref'
+    _definition.update            2012-11-20
+    _description.text
+;
+    Weighted residual factors for reflections included in the refinement
+    which satisfy the limits specified by _refine_ls.d_res_high and
+    _refine_ls.d_res_low.
+
+           ( sum w [ Y(meas) - Y(calc) ]^2^ )^1/2^
+      wR = ( ------------------------------ )
+           (         sum w Y(meas)^2^       )
+
+      Y(meas) = the measured   amplitude _refine_ls.structure_factor_coef
+      Y(calc) = the calculated amplitude _refine_ls.structure_factor_coef
+      w       = the least-squares weight
+      and the sum is taken over the specified reflections
+;
+    _name.category_id             refine_ls
+    _name.object_id               wR_factor_ref
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   none
+
+save_
+
+save_REFINE_LS_CLASS
+
+    _definition.id                REFINE_LS_CLASS
+    _definition.scope             Category
+    _definition.class             Loop
+    _definition.update            2021-06-29
+    _description.text
+;
+    The CATEGORY of data items used to specify information about the
+    refinement of the structural model.
+;
+    _name.category_id             REFINE_LS
+    _name.object_id               REFINE_LS_CLASS
+    _category_key.name            '_refine_ls_class.code'
+
+save_
+
+save_refine_ls_class.code
+
+    _definition.id                '_refine_ls_class.code'
+    _alias.definition_id          '_refine_ls_class_code'
+    _definition.update            2021-10-27
+    _description.text
+;
+    Code identifying a certain reflection class.
+;
+    _name.category_id             refine_ls_class
+    _name.object_id               code
+    _name.linked_item_id          '_reflns_class.code'
+    _type.purpose                 Link
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Word
+
+    loop_
+      _description_example.case
+         1
+         m1
+         s2
+
+save_
+
+save_refine_ls_class.d_res_high
+
+    _definition.id                '_refine_ls_class.d_res_high'
+    _alias.definition_id          '_refine_ls_class_d_res_high'
+    _definition.update            2021-03-03
+    _description.text
+;
+    Highest resolution for the reflections in this class.
+    This corresponds to the smallest interplanar d value.
+;
+    _name.category_id             refine_ls_class
+    _name.object_id               d_res_high
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   angstroms
+
+save_
+
+save_refine_ls_class.d_res_low
+
+    _definition.id                '_refine_ls_class.d_res_low'
+    _alias.definition_id          '_refine_ls_class_d_res_low'
+    _definition.update            2021-03-03
+    _description.text
+;
+    Lowest resolution for the reflections in this class.
+    This corresponds to the largest interplanar d value.
+;
+    _name.category_id             refine_ls_class
+    _name.object_id               d_res_low
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   angstroms
+
+save_
+
+save_refine_ls_class.r_factor_all
+
+    _definition.id                '_refine_ls_class.R_factor_all'
+    _alias.definition_id          '_refine_ls_class_R_factor_all'
+    _definition.update            2012-11-20
+    _description.text
+;
+    Residual factor for reflections in this class included in the
+    refinement.  See _refine_ls.R_factor_all definition for details.
+;
+    _name.category_id             refine_ls_class
+    _name.object_id               R_factor_all
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   none
+
+save_
+
+save_refine_ls_class.r_factor_gt
+
+    _definition.id                '_refine_ls_class.R_factor_gt'
+
+    loop_
+      _alias.definition_id
+         '_refine_ls_class_R_factor_gt'
+         '_refine_ls_class_R_factor_obs'
+
+    _definition.update            2012-11-20
+    _description.text
+;
+    Residual factor for the reflections in this class judged
+    significantly intense (see _reflns.threshold_expression) and
+    included in refinement. See _refine_ls.R_factor_gt for details.
+;
+    _name.category_id             refine_ls_class
+    _name.object_id               R_factor_gt
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   none
+
+save_
+
+save_refine_ls_class.r_fsqd_factor
+
+    _definition.id                '_refine_ls_class.R_Fsqd_factor'
+    _alias.definition_id          '_refine_ls_class_R_Fsqd_factor'
+    _definition.update            2012-11-20
+    _description.text
+;
+    Residual factor R(F^2^) for reflections in this class judged
+    significantly intense (see _reflns.threshold_expression) and
+    included in refinement. See _refine_ls.R_Fsqd_factor for details.
+;
+    _name.category_id             refine_ls_class
+    _name.object_id               R_Fsqd_factor
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   none
+
+save_
+
+save_refine_ls_class.r_i_factor
+
+    _definition.id                '_refine_ls_class.R_I_factor'
+    _alias.definition_id          '_refine_ls_class_R_I_factor'
+    _definition.update            2012-11-20
+    _description.text
+;
+    Residual factor R(I) for reflections in this class judged
+    significantly intense (see _reflns.threshold_expression) and
+    included in refinement. See _refine_ls.R_I_factor for details.
+;
+    _name.category_id             refine_ls_class
+    _name.object_id               R_I_factor
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   none
+
+save_
+
+save_refine_ls_class.wr_factor_all
+
+    _definition.id                '_refine_ls_class.wR_factor_all'
+    _alias.definition_id          '_refine_ls_class_wR_factor_all'
+    _definition.update            2012-11-20
+    _description.text
+;
+    Weight residual for all reflections in this class judged
+    significantly intense (see _reflns.threshold_expression) and
+    included in refinement. See _refine_ls.wR_factor_all for details.
+;
+    _name.category_id             refine_ls_class
+    _name.object_id               wR_factor_all
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   none
+
+save_
+
+save_FUNCTION
+
+    _definition.id                FUNCTION
+    _definition.scope             Category
+    _definition.class             Functions
+    _definition.update            2024-05-15
+    _description.text
+;
+    The crystallographic functions the invoked in the definition
+    methods of CORE STRUCTURE data items defined and used within
+    the Crystallographic Information Framework (CIF).
+;
+    _name.category_id             CIF_CORE_HEAD
+    _name.object_id               FUNCTION
+
+save_
+
+save_function.atomtype
+
+    _definition.id                '_function.AtomType'
+    _definition.update            2021-10-27
+    _description.text
+;
+    The function
+                  r  =  AtomType( s )
+
+    returns an atom type symbol (element name) from the atom site label.
+;
+    _name.category_id             function
+    _name.object_id               AtomType
+    _type.purpose                 Encode
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Word
+    _method.purpose               Evaluation
+    _method.expression
+;
+    Function AtomType( s :[Single, Word])  {  # atom label
+
+       m = Len(s)
+       n = 1
+       If (m > 1 and s[1] not in '0123456789') n = 2
+       If (m > 2 and s[2]     in '+-'        ) n = 3
+       If (m > 3 and s[3]     in '+-'        ) n = 4
+
+                AtomType =  s[0:n]
+    }
+;
+
+save_
+
+save_function.closest
+
+    _definition.id                '_function.Closest'
+    _definition.update            2021-03-03
+    _description.text
+;
+    The function
+                  d  =  Closest( v, w )
+
+    returns the cell translation vector required to obtain the
+    closest cell-translated occurrence of the vector V to the vector
+    W.
+;
+    _name.category_id             function
+    _name.object_id               Closest
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Matrix
+    _type.dimension               '[3]'
+    _type.contents                Real
+    _units.code                   none
+    _method.purpose               Evaluation
+    _method.expression
+;
+    Function Closest( v :[Matrix, Real],   # coord vector to be cell translated
+                      w :[Matrix, Real]) { # target vector
+
+           d  =  v - w
+           Closest  =  Int( Mod( 99.5 + d, 1.0 ) - d )
+    }
+;
+
+save_
+
+save_function.seitzfromjones
+
+    _definition.id                '_function.SeitzFromJones'
+    _definition.update            2021-03-01
+    _description.text
+;
+    The function
+                  s  =  SeitzFromJones( j )
+
+    returns a 4x4 Seitz matrix from the Jones faithful representation of
+    the equivalent position which is a character string e.g. 1/2+x,-x,z.
+;
+    _name.category_id             function
+    _name.object_id               SeitzFromJones
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Matrix
+    _type.dimension               '[4,4]'
+    _type.contents                Real
+    _units.code                   none
+    _method.purpose               Evaluation
+    _method.expression
+;
+     Function SeitzFromJones( j :[Single, Text])  { # Jones symmetry notation
+
+      joneschrs = "123456xyz/,+- "
+      s         = Matrix([[0,0,0,0],[0,0,0,0],[0,0,0,0],[0,0,0,1]])
+      axis      = 0
+      sign      = 1
+      inum      = 0
+
+      do i=0,Len(j)-1    {
+          c = j[i]
+          If (c not in joneschrs) dummy = print('illegal char in symmetry xyz')
+
+          If      (c == ' ') Next
+          If      (c == ',') {
+                             axis     += 1
+                             inum      = 0
+                             sign      = 1
+          }
+          Else If (c == '+') sign      = +1
+          Else If (c == '-') sign      = -1
+          Else If (c == 'x') s[axis,0] = sign
+          Else If (c == 'y') s[axis,1] = sign
+          Else If (c == 'z') s[axis,2] = sign
+          Else   {
+               If (inum == 0)   m  = AtoI(c)
+               If (inum == 1 and c != '/') dummy = print('illegal num in
+    symmetry xyz')            If (inum == 2)   {
+                                n  = AtoI(c)
+                     If(n == 5) dummy = print('illegal translation in symmetry
+    xyz')                  s[axis,3] = Mod(10.+ Float(sign*m)/Float(n), 1.)
+                     sign      = 1
+               }
+               inum += 1
+       }  }
+                          SeitzFromJones = s
+    }
+;
+
+save_
+
+save_function.symequiv
+
+    _definition.id                '_function.SymEquiv'
+    _definition.update            2021-03-01
+    _description.text
+;
+    The function
+                    xyz' =  SymEquiv( symop, xyz )
+
+    returns a fractional coordinate vector xyz' which is input vector
+    xyz transformed by the input symop 'n_pqr' applied to the symmetry
+    equivalent matrix extracted from the category SPACE_GROUP_SYMOP.
+;
+    _name.category_id             function
+    _name.object_id               SymEquiv
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Matrix
+    _type.dimension               '[3]'
+    _type.contents                Real
+    _units.code                   none
+    _method.purpose               Evaluation
+    _method.expression
+;
+    Function SymEquiv( c :[Single, Symop],    # symop string n_pqr
+                       x :[Matrix, Real]   ){  # fract coordinate vector
+
+            s = space_group_symop [ SymKey( c ) ]
+            SymEquiv = s.R * x + s.T + SymLat( c )
+    }
+;
+
+save_
+
+save_function.symkey
+
+    _definition.id                '_function.SymKey'
+    _definition.update            2021-03-01
+    _description.text
+;
+    The function
+                  m  =  SymKey( s )
+
+    returns an integer index to the Seitz matrices from the character
+    string of the form 'n_pqr'.
+;
+    _name.category_id             function
+    _name.object_id               SymKey
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Integer
+    _enumeration.range            1:192
+    _units.code                   none
+    _method.purpose               Evaluation
+    _method.expression
+;
+    Function SymKey( s :[Single, Symop])  {  # symop string
+
+           If (s == '.')   n = 1
+           Else            n = AtoI(s[0])
+
+                SymKey =  n       # index from 1
+    }
+;
+
+save_
+
+save_function.symlat
+
+    _definition.id                '_function.SymLat'
+    _definition.update            2021-03-01
+    _description.text
+;
+    The function
+                  v  =  SymLat( s )
+
+    returns a vector of the cell translations applied to the coordinates
+    from the character string of the form 'n_pqr'. i.e. p-5, q-5, r-5.
+;
+    _name.category_id             function
+    _name.object_id               SymLat
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Matrix
+    _type.dimension               '[3]'
+    _type.contents                Integer
+    _units.code                   none
+    _method.purpose               Evaluation
+    _method.expression
+;
+    Function SymLat( s :[Single, Symop])  {  # symop string
+
+           If (s[0] == ' ')  v = [ 5, 5, 5 ]
+           Else              v = [ AtoI(s[2]), AtoI(s[3]), AtoI(s[4]) ]
+
+                 SymLat  =  v - 5
+    }
+;
+
+save_
+
+save_function.symop
+
+    _definition.id                '_function.Symop'
+    _definition.update            2006-06-30
+    _description.text
+;
+    The function
+                  s  =  Symop( n, t )
+
+    returns a character string of the form 'n_pqr' where n is the
+    symmetry equivalent site number and [p,q,r] is the cell translation
+    vector PLUS [5,5,5].
+;
+    _name.category_id             function
+    _name.object_id               Symop
+    _type.purpose                 Composite
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Symop
+    _method.purpose               Evaluation
+    _method.expression
+;
+    Function Symop( n  :[Single, Integer],   # symmetry equivalent site number
+                    t  :[List  , Integer]) { # cell translation vector
+
+           d  =  t + 5
+        Symop =  repr(n) + '_' + repr(d[0]) + repr(d[1]) + repr(d[2])
+    }
+;
+
+save_
+
+    loop_
+      _dictionary_audit.version
+      _dictionary_audit.date
+      _dictionary_audit.revision
+         3.0.5                    2016-05-13
+;
+       Merged in most symmetry dictionary definitions (James Hester)
+;
+         3.0.6                    2016-09-13
+;
+       Adjusted and removed keys for changes in dREL operation.
+       _citation_id added to key list of citation_author (James Hester).
+       _diffrn.crystal_id removed as diffrn is Set category. Changed
+       EXPTL_CRYSTAL to Set type in keeping with current use patterns.
+       Removed all child keys of exptl_crystal_id.
+;
+         3.0.7                    2017-06-10
+;
+       Added and deprecated symmetry.cell_setting. Removed rhombohedral
+       option from dREL method for space_group.crystal_system. (James Hester)
+;
+         3.0.8                    2017-09-23
+;
+       Added missing items from DDL1 version: _citation.doi, _audit.block_doi
+       _citation.publisher, _database.dataset_doi,
+       _publ_contact_author.id_orcid, _publ_author.id_orcid (James Hester)
+;
+         3.0.9                    2018-04-10
+;
+       Rewrote CITATION category description to cover all relevant uses rather
+       than only publication-related uses (James Hester).
+;
+         3.0.10                   2019-01-08
+;
+       Added DATABASE_RELATED category (James Hester).
+;
+         3.0.11                   2019-09-25
+;
+       Removed the _chemical_conn_bond.distance_su data item.
+       Changed the purpose of the diffrn_radiation_wavelength.value data item
+       from 'Number' to 'Measurand'. Added the
+       diffrn_radiation_wavelength.value_su data item.
+
+       Replaced all instances of the _definition.replaced_by data item with
+       data items from the DEFINITION_REPLACED category.
+
+       Marked the _atom_site.refinement_flags data item as deprecated and
+       replaced by the _atom_site.refinement_flags_posn,
+       _atom_site.refinement_flags_adp and _atom_site.refinement_flags_occupancy
+       data items.
+
+       Changed the _type.purpose from 'Encode' to 'Link' in the definitions of
+       the _geom_angle.atom_site_label_2, _valence_param_atom_1,
+       _valence_param_atom_2, _valence_param_ref_id, _atom_site_aniso.label
+       and _atom_type_scat.symbol data items. Removed the _name.linked_item_id
+       data item from the definitions of the _diffrn_scale_group.code and
+       diffrn_standard_refln.code data items.
+
+       Updated the definitions of the _geom_hbond.angle_DHA and
+       _geom_hbond.angle_DHA_su data items.
+
+       Corrected the definitions of the _cell_measurement.temperature_su and
+       _cell_measurement.pressure_su data items.
+
+       Corrected a typo in the definitions of the _geom_contact.distance and
+       _geom_torsion.angle and data items.
+
+       Changed the content type of multiple data items from 'Index' or 'Count'
+       to 'Integer' and assigned the appropriate enumeration range if needed.
+;
+         3.0.12                   2020-03-13
+;
+       Adjusted the ranges of _geom_bond.angle and _geom_hbond.angle_DHA to
+       be 0:180 degrees.
+
+       Changed dREL methods for Cartesian transformation matrix elements
+       to calculate default values rather than required values.
+;
+         3.0.13                   2020-03-16
+;
+       Changed all synthetic identifiers ('id') to be Text, and removed dREL.
+       Validation method for _space_group.crystal_system removed as it contained
+       undefined dREL functions "throw" and "alert".
+;
+         3.0.14                   2021-06-29
+;
+       Added opaque author identifiers to AUDIT_AUTHOR and PUBL_AUTHOR as well
+       as relevant linking identifiers to AUDIT_CONTACT_AUTHOR and
+       PUBL_CONTACT_AUTHOR.
+
+       Added _diffrn_measurement.specimen_attachment_type.
+
+       Changed to DDL version 4.
+
+       Removed all instances of the _category.key_id attribute since it is no
+       longer defined in the DDLm reference dictionary.
+
+       Miscellaneous corrections to dREL and fixing typos.
+;
+         3.1.0                    2021-12-01
+;
+       Replaced _model_site.adp_eigen_system with _model_site.adp_eigenvectors
+       and _model_site.adp_eigenvalues.
+
+       Added additional enumeration values to the _journal_index.type data item
+       definition.
+
+       Numerous corrections to measurement units.
+
+       Numerous improvements to types and harmonisation of spelling.
+;
+         3.2.0                    2023-04-04
+;
+       Added data names to allow multi-data-block expression of data sets.
+
+       Deprecated and replaced _diffrn_radiation.type and
+       _diffrn_radiation.xray_symbol.
+
+       Added _diffrn_refln.intensity* data items.
+
+       Added the _exptl_absorpt.special_details data item.
+
+       Added categories and data names to allow for the elemental composition
+       of specimens to be recorded.
+
+       Corrections and additions for conformance with DDL1.
+
+       Explicitly added _diffrn_source.details to the list items that replaced
+       _diffrn_source.description.
+
+       Added the _citation.URL and _journal.paper_URL data items.
+
+       Added the _journal.paper_number and _journal.paper_pages data items.
+
+       Reparented CELL to DIFFRN category and added key data names to allow
+       multiple cells for different diffraction conditions. Deprecated
+       _cell_measurement.temperature,pressure data names.
+
+       Changed the purpose of the _diffrn_radiation_wavelength.id data item
+       from 'Encode' to 'Key'.
+;
+         3.3.0                    2024-11-12
+;
+       # Please update the date above and describe the change below until
+       # ready for the next release
+
+       Added _atom_type_scat.exponential_polynomial_coefs, Gaussian_coefs, and
+       inv_Mott_Bethe_coefs to allow for an arbitrary number of coefficients in
+       the definition of form factors.
+
+       Added a dREL definition method for the _citation.id data item.
+
+       Rewrote the _atom_type.radius_contact evaluation method as a definition
+       method.
+
+       Added _atom_type.mass_number to record specific isotope identities.
+
+       Changed enumeration of _atom_type.atomic_number,
+       _atom_type_scat.dispersion_real_Cu, _atom_type_scat.dispersion_imag_Cu,
+       _atom_type_scat.dispersion_real_Mo, _atom_type_scat.dispersion_imag_Mo
+       to be defaulted on _atom_type.element_symbol.
+
+       Expanded AUDIT_AUTHOR to include email, phone, and fax contact details.
+
+       Corrected the content type of the _refln.F_complex_su attribute.
+
+       Updated description of _space_group_wyckoff.letter.
+
+       Added a dREL definition method that determines the units of measure to
+       the definition of the _refln.form_factor_table data item. Changed the
+       units of several data items to 'unspecified'.
+
+       Added the default value of '1_555' to the site symmetry data items.
+
+       Redefined _exptl_absorpt.coefficient_mu as a derived measurand item.
+
+       Added the _exptl_absorpt.coefficient_mu_su data item.
+
+       Renamed _atom_site.tensor_beta to _atom_site_aniso.matrix_beta and
+       updated the associated dREL evaluation methods. The old data name was
+       retained as an alias. Added the _atom_site_aniso.beta_* data items.
+
+       Reverted _atom_type_scat.versus_stol_list to a text-type to regain
+       compatibility with DDL1 dictionary.
+
+       Added ATOM_SCAT_VERSUS_STOL to allow for the explicit listing of
+       scattering factor values with respect to sin theta over lambda.
+       Deprecated the _atom_type_scat.versus_stol_list data item.
+
+       Changed the _type.source attribute of all SU data items to 'Related'.
+
+       Updated dREL evaluation method of the ATOM_TYPE category.
+
+       Changed the purpose of _space_group_Wyckoff.id and _valence_ref.id
+       from 'Encode' to 'Key'.
+
+       Corrected examples of the _chemical.identifier_InChI and
+       _chemical.identifier_InChI_key data items.
+
+       Updated description of DIFFRN_RADIATION to remove looping reference.
+
+       Updated the definitions of _diffrn_refln.scale_group_code and
+       _diffrn_scale_group.code definitions to better reflect that
+       _diffrn_scale_group.code is the main data item.
+
+       Added the deprecation date for multiple aliases that were originally
+       deprecated in the DDL1 version of the dictionary.
+
+       Added the _atom_site_fract.symmform and _atom_site_aniso.symmform
+       data items.
+
+       Added _database_code.BIncStrDB (bm).
+
+       Changed the title of the dictionary to 'CIF_CORE'.
+
+       Renamed the Head category from 'CIF_CORE' to 'CIF_CORE_HEAD'.
+
+       Updated the dictionary description.
+
+       Redefined the _cell_measurement.wavelength data item as a measurand.
+       Added and immediately deprecated the _cell_measurement.wavelength_su
+       data item.
+
+       Moved the definition of _publ_contact_author data name into a
+       separate data item definition and deprecated it in favour of the
+       _publ_contact_author.name and _publ_contact_author.address data items.
+
+       Added the _audit_support.funding_organization_url and
+       _audit_support.special_details data items.
+
+       Added opaque identifiers for diffrn_refln and refln categories.
+;

--- a/dictionaries/cif_core_DDL1.dic
+++ b/dictionaries/cif_core_DDL1.dic
@@ -1,0 +1,11794 @@
+##############################################################################
+#                                                                            #
+#                             CIF CORE DEFINITIONS                           #
+#                             --------------------                           #
+#                                                                            #
+# This dictionary contains the names and definitions of the Core data items  #
+# recognised by the International Union of Crystallography for the exchange  #
+# of data between laboratories and submissions to journals and databases.    #
+#                                                                            #
+# The STAR/DDL dictionary is available as the file "ddl_core.dic"            #
+# located at URL ftp://ftp.iucr.org/pub/ddl_core.dic                         #
+#                                                                            #
+# Copyright 2011 International Union of Crystallography                      #
+##############################################################################
+
+
+data_on_this_dictionary
+    _dictionary_name            cif_core.dic
+    _dictionary_version         2.5.3-dev-7
+    _dictionary_update          2021-03-22
+    _dictionary_history
+;
+   1991-05-27  Created from CIF Dictionary text. SRH
+   1991-05-30  Validated with CYCLOPS & CIF ms. SRH
+   1991-06-03  Adjustments to some definitions. SRH
+   1991-06-06  Adjustments a la B. McMahon. SRH
+   1991-06-18  Additions & some redefinitions. SRH
+   1991-07-04  Corrected 90:0 in *_detect_slit_. SRH
+   1991-09-20  Additions & some redefinitions. SRH
+   1991-09-20  Final published version. IUCr
+   1991-11-12  Add _diffrn_ambient_environment. SRH
+   1991-11-12  Allow 'c' for _atom_site_calc_flag. SRH
+   1993-02-23  Apply global_ and 'unknown' -> '?' SRH
+   1993-03-05  Changes resulting from MM dictionary. SRH
+   1993-05-20  Changes arising from new DDL commands. SRH
+   1993-08-05  Additional finetuning pre-Beijing. SRH
+   1993-12-22  Introductory sections added to categories. BMcM
+   1993-12-22  Additional categories from mm work: audit_author,
+                 citation, atom_sites_fract_tran_matrix. BMcM
+   1994-03-01  Add 'undef' to _refine_ls_hydrogen_treatment. BMcM
+   1994-03-01  Add '_publ_section_exptl_prep' and '*_refinement'. BMcM
+   1994-03-01  Add 'atom_site_aniso_ratio'. BMcM
+   1994-04-15  Comments from IDB on draft version for circulation. BMcM
+   1994-04-15  Added _publ_section_exptl_solution. BMcM
+   1994-07-14  Added B. H. Toby's suggested _diffrn_radiation_xray_symbol
+                 and _diffrn_radiation_xray_target. BMcM
+   1994-08-05  Revised definition for _diffrn_reflns_number (S.R. Hall). BMcM
+   1994-08-05  Added _atom_type_scat_length_neutron (B.H. Toby). BMcM
+   1994-10-13  Reworded _diffrn_standards_ a la S.R. Hall. BMcM
+   1994-10-13  Added _diffrn_radiation_probe for non-X-ray experiments. BMcM
+   1995-01-17  Rewording of definition of _chemical_melting_point. BMcM
+   1995-02-24  Changed text references to e.s.d to 'standard uncertainty'. BMcM
+   1995-07-08  Added _chemical_formula_iupac. BMcM
+   1995-07-09  Finally added _symmetry_equiv_pos_id. BMcM
+   1995-07-09  _units_extension, _units_conversion and _units_description
+                 superseded by _units and _units_detail. Suffixed datanames
+                 retained as separate entries. BMcM
+   1995-10-23  Added _refine_ls_R_Fsqd_factor and _refine_ls_R_I_factor BMcM
+   1996-03-25  Correlated with mmCIF release 0.8 BMcM
+   1996-05-16  Added some extra datanames for use by Acta:
+                 _publ_section_synopsis, _publ_section_title_footnote,
+                 _publ_author_footnote, _journal_paper_category, and various
+                 _journal_index_ categories BMcM
+   1996-05-20  Added geom_hbond category BMcM
+   1996-06-10  Datanames with suffixes to indicate units moved to a new
+                 compatibility dictionary cif_compat.dic BMcM
+   1996-06-10  Embarrassing _units_ stuff removed from geom_hbond BMcM
+   1996-06-10  _list_mandatory and _list_reference added to _publ_author_
+                 datanames (where _list was given as "both") BMcM
+   1996-06-10  Added audit_conform category BMcM
+   1996-06-11  Added audit_link category BMcM
+   1996-06-11  Reworded _exptl_crystal_F_000 definition BMcM
+   1996-06-11  Added _atom_site_U_equiv_geom BMcM
+   1996-06-11  Added publ_body category BMcM
+   1996-06-27  Added examples for most of the remaining category overviews
+                 BMcM
+   1996-06-27  Added _journal_language BMcM
+   1996-06-28  Added area-detector definitions from mmCIF dictionary:
+                 _diffrn_measurement_device_details, *_specific and *_type;
+                 _diffrn_radiation_detector_details, *_specific, *_type;
+                 _diffrn_radiation_source_details, *_power, *_specific,
+                 *_target, *_type; reflns_shell category  BMcM
+               Added _refine_ls_d_res_high and *_low and changed wording of
+                 definitions for R factors to include these. BMcM
+               Added 'h' and 'f' flags to _refln_observed_status. BMcM
+   1996-07-05  Some typos fixed and examples modified as suggested by
+                 P.Strickland and I.D.Brown. BMcM
+   1996-07-27  BMcM:
+               Added example for _diffrn_orient_refln_[] from G. Madariaga
+               U~ij~ changed to U^ij^ a la Nomenclature Commission
+               Definition of _diffrn_ambient_environment changed to omit vacuum
+                 as a possible default environment
+               Changed definitions of *_site_symmetry_* items to I.D.Brown's
+                 suggested wording.
+               Compressed various journal indexing categories into one
+               Changed upper enumeration values for _refln_symmetry_epsilon
+                 and _refln_symmetry_multiplicity to 48.
+               Added references to deprecated use of B values.
+               Modified descriptions of phone, fax number conventions
+               _publ_manuscript_incl_ entries reworded for greater
+                 clarity and given individual data blocks
+               Added _list_reference to _symmetry_equiv_pos_id and changed
+                 _list value to 'both' for *_as_xyz to allow the P1 case
+               Added _atom_site_B_equiv_geom for completeness
+               Modified definitions of _atom_sites_[Cartn,fract]_tran_vector_
+               Added _units stuff to _chemical_formula_weight_* and
+                 _exptl_crystal_density_ items
+               Added *_theta, *_omega to _diffrn_orient_refln_angle_
+               Added 'q' to enumeration list for _diffrn_refln_scan_mode
+               Reworded definition in _diffrn_scale_group_[]
+               Permitted esd for _refln_phase_meas (necessitates splitting
+                 _refln_phase_ datablock in two)
+               Added _type_conditions esd for _reflns_scale_meas_
+   1996-07-28  BMcM:
+               Added example for refln_scale_[] and second example for
+                 _refln_[] from Xtal test data set.
+               Changed references to category names to CAPITALS.
+               Merged CELL and CELL_MEASUREMENT categories.
+               Added _units deg to all angle quantities.
+               Renamed _citation_journal_coden_CAS as
+                 _citation_journal_abstract_id_CAS
+               Removed _diffrn_measurement_device_details, *_specific,
+                 *_type, _diffrn_radiation_detector_details, *_specific,
+                 *_type, _diffrn_radiation_source_power, *_specific,
+                 *_target, *_type, pending full analysis of requirements
+                 for describing diffraction apparatus.
+               Reworded _exptl_crystal_F_000 definition again
+   1996-08-03  Reworded _refine_ls_number_reflns definition a la S.R.Hall BMcM
+   1996-09-10  BMcM:
+               Clarified _diffrn_attenuator_scale definition with help from SRH
+               In _refln_symmetry_multiplicity, changed 'structure-factor
+                 value' to 'structure-factor magnitudes'
+               Slight modification to _diffrn_reflns_number to exclude all
+                 systematic absences, not just those due to centring
+               Removed footnote markers from example of
+                 _publ_section_title_footnote
+               Added new example to SYMMETRY_EQUIV category to explain the
+                 use of _symmetry_equiv_pos_id
+               Reworking of DIFFRN_RADIATION and DIFFRN_MEASUREMENT
+                 categories and introduction of DIFFRN_DETECTOR and
+                 DIFFRN_SOURCE a la I.D.Brown
+   1996-09-11  Corrected category assignment for _diffrn_standards_ items BMcM
+   1996-09-12  BMcM:
+               Added _cell_id and _cell_measurement_refln_id
+               Changed the term "id" to "identifier" in definitions
+               Renamed _citation_journal_abstract_id_CAS as
+                 _citation_abstract_id_CAS
+               Added _audit_block_code and changed definition of
+                  _audit_link_block_code to refer to it
+   1996-09-18  BMcM:
+               Fine tuning of IDB's new DIFFRN categories: in DIFFRN_DETECTOR
+                 changed *_type to *_device and added *_device_type. Moved
+                 _diffrn_radiation_detector back to DIFFRN_RADIATION category
+                 with expanded definition. Reworded definitions of
+                 _diffrn_measurement_device and *_device_type. In
+                 DIFFRN_RADIATION changed enumeration range for
+                 *_polarisn_norm to -180:180 and added 'as viewed from the
+                 specimen' to the definition; also added 'Cu K-L~2,3~' to
+                 examples for *_type. Reworded definitions for
+                 _diffrn_refln_index and _diffrn_source_target, and changed
+                 _type of _diffrn_source_power to "numb".
+               Introduced _diffrn_detector_dtime in the DIFFRN_DETECTOR
+                 category and restored _diffrn_radiation_detector_dtime to
+                 DIFFRN_RADIATION
+   1996-09-25  BMcM:
+               Reworded definitions of _atom_site_disorder_assembly and *_group
+   1996-10-02  BMcM:
+               Changed _symmetry_equiv_pos_id to _symmetry_equiv_pos_site_id
+                 in recognition of the technical meaning of 'position' in
+                 International Tables
+               Addition of the names of the relevant units to definitions of
+                 _atom_type_scat_length_neutron, _exptl_crystal_size_,
+                 _geom_hbond_distance_, _refine_ls_d_res_high and *_low,
+                 _reflns_shell_d_res_high and *_low; and cosmetic expansion
+                 of units listed in the definitions for _diffrn_source_current,
+                 *_power and *_voltage
+               Addition of '_related_function conversion' to
+                 _atom_site_B_equiv_geom and *_U_equiv_geom and
+                 _atom_site_B_iso_or_equiv and *_U_iso_or_equiv
+               Examples for CELL_MEASUREMENT_REFLN and DIFFRN_REFLN from
+                 Gotzon Madariaga
+               Renamed _atom_site_U_equiv_geom as _atom_site_U_equiv_geom_mean
+                 and likewise for *_B_* to increase the consistency of
+                 abbreviations, as suggested by I.D. Brown
+               Added disorder example to the ATOM_SITE category description
+   1996-10-15  BMcM:
+               Modified description of example for DIFFRN_REFLN
+               Changed _enumeration_range of _atom_site_attached_hydrogens
+                 from 0:4 to 0:8 (cf CSD entry with refcode DUTMAG01) (PRE)
+               Added '_enumeration_default cif' to _publ_body_format
+               Changed underscores to spaces in the example for the Hall
+                 spacegroup symbol in data_symmetry_[]
+               Deleted extraneous '_' in data_(_)citation_abstract_id_CAS
+   1996-10-27  BMcM: Changed psiscan to psi-scan at request of SRH
+   1996-11-05  BMcM:
+               Changed _citation_book_coden_ISBN to _citation_book_id_ISBN,
+                 _citation_journal_coden_ASTM to _citation_journal_id_ASTM,
+                 _citation_journal_coden_CSD to _citation_journal_id_CSD,
+                 _citation_journal_coden_ISSN to _citation_journal_id_ISSN,
+                 and _citation_Medline_AN to _citation_database_id_Medline.
+                 Also modified description of CODEN in _citation_journal_id_ASTM
+                 and _database_journal_ASTM (suggested by PMDF)
+               The phrase 'diffraction data' modified to 'intensities' in
+                 several places, some other cosmetic commas and enforcement
+                 of consistent lower-case units names (PMDF)
+               Clarification of the definition for
+                 _diffrn_radiation_polarisn_norm (PMDF)
+               Added 'constr' to _refine_ls_hydrogen_treatment (SRH)
+               Corrected misassignment of category of
+                 _diffrn_radiation_detector_dtime (H.J.Bernstein)
+   1996-11-06  BMcM:
+               Added "_list   yes" to items in the REFLNS_SHELL category (IDB)
+               Added "measured" to definition of _reflns_shell_number_unique_all
+               Changed enumeration range for _diffrn_standards_decay_% to
+                 ":100" and added statement about negative values (PMDF/SRH)
+   1996-11-08  BMcM:
+               _diffrn_radiation_detector, _diffrn_radiation_detector_dtime and
+                 _diffrn_radiation_source removed (these will be transferred to
+                 cif_compat.dic for compatibility with files conforming to the
+                 original dictionary)
+               _diffrn_radiation_wavelength_* items moved to new category
+   1996-11-12  BMcM:
+               Deleted _cell_id and _cell_measurement_refln_id, and
+                 clarified the intent of the CELL category in _cell_[] (PMDF)
+               Some small rewordings of various _diffrn_* items due to
+                 B.H.Toby
+   1996-11-14  BMcM:
+               Imposed consistency on the nomenclature of diffraction device
+                 data names: _diffrn_detector_device_type -> *_detector_type,
+                 _diffrn_measurement_device_details -> *_measurement_details,
+                 *_measurement_device_type -> *_measurement_type; introduction
+                 of _diffrn_source_device and parallel definitions. Existing
+                 *_measurement_details example moved to *_special_details (PMDF)
+   1996-11-21  BMcM:
+               Reintroduced _diffrn_measurement_device_details, further tidying
+                 of data names thus: _diffrn_measurement_type -> *_device_type;
+                 _diffrn_detector_device and _diffrn_source_device both drop
+                 "_device" (PMDF)
+               Added _journal_data_validation_number and
+                 _publ_requested_category to enable handling of CIF-access
+                 submissions by Acta Cryst. C
+   1996-11-23  A few typos fixed. BMcM
+   1996-11-24  BMcM:
+               Added 'gaussian', 'multi-scan' and 'numerical' to enumeration
+                 list for _exptl_absorpt_correction_type (SRH)
+               Added 'mixed' to enumeration list for
+                 _refine_ls_hydrogen_treatment (SRH)
+   1996-11-25  A few typos fixed (BMcM)
+   1996-11-27  BMcM:
+               Removed looped _related_item from _publ_contact_author and
+                 reintroduced _diffrn_radiation_detector, *_dtime and
+                 _diffrn_radiation_source (see 1996-11-08) with
+                 "_related_function replace" as a preparation for
+                 using this mechanism further in version 2.1.
+   1996-11-27  Release version 2.0. IUCr
+   1997-01-20  BMcM:
+               Some small changes thanks to PMDF. Double space after period
+                 at end of sentence changed to single space throughout;
+                 _citation_database_id_Medline _diffrn_detector_type moved
+                 to correct alphabetic sequence; space introduced between
+                 sentences in definition of _citation_journal_id_CSD; some
+                 other minor grammatical changes
+   1997-10-30  BMcM: (changes to align with Acta C Notes for Authors)
+               Obsoleted *_obs_* entries in REFLNS and REFINE_LS categories
+                 and replaced with *_gt_*; obsoleted _refine_ls_shift/esd_
+                 by _refine_ls_shift/su_; obsoleted
+                 _atom_site_thermal_displace_type by *_adp_type
+   1997-11-05  BMcM: (changes to align with Acta C Notes for Authors)
+               Added _diffrn_detector_area_resol_mean,
+                 _diffrn_measured_fraction_theta_max and *_full,
+                 _diffrn_reflns_theta_full
+   1997-11-05  BMcM: Added _reflns_number_Friedel; changed various *_obs
+                 items in examples to *_gt equivalents and likewise for
+                 other obsoleted items
+   1997-11-24  BMcM: Slightly changed wording of _reflns_number_Friedel and
+                 _reflns_threshold_expression at suggestion of I.D.Brown.
+                 Modified definition of _refine_ls_abs_structure_Flack and
+                 changed the text of the example in category REFINE at
+                 the request of H.D.Flack.
+   1997-12-08  BMcM: Removed the phrase "(enantiomorph or polarity)" from
+                 _refine_ls_abs_structure_Flack and *_Rogers because
+                 "absolute structure" is a phrase uniquely defined (H.D.Flack)
+   1997-12-08  BMcM: Several instances of \s changed to u
+   1997-12-08  BMcM: Modified definitions of _reflns_number_total and
+                 *_Friedel (after H.D.Flack) to clarify the distinction between
+                 crystal-class and Laue-symmetry independent reflection sets
+   1997-12-08  BMcM: Added _chemical_absolute_configuration and
+                  _chemical_optical_rotation (H.D.Flack)
+   1998-08-04  BMcM: Moved _diffrn_pressure_history and _diffrn_thermal_history
+                  from draft msCIF dictionary to core as
+                  _exptl_crystal_pressure_history and
+                  _exptl_crystal_thermal_history (G. Madariaga/I.D.Brown)
+                    Moved _diffrn_symmetry_description and REFINE_LS_CLASS
+                  from draft msCIF dictionary to core (G. Madariaga/I.D.Brown)
+   1998-08-04  BMcM: Minor rewordings of _refine_ls_R_Fsqd_factor,
+                  _refine_ls_R_I_factor, various definitions referring to
+                  F_calc in electrons, and _reflns_shell_number_unique_*
+                  (I.D.Brown)
+   1998-08-04  BMcM: added _reflns_Friedel_coverage (H.D.Flack/S.R.Hall)
+   1998-08-04  BMcM: changed formula for F(000) (from
+                  F(000) = [ sum (f~r~^2^ + f~i~^2^) ]^1/2^     to
+                  F(000) = [ (sum f~r~)^2^ + (sum f~i~)^2^ ]^1/2^ ) (H.D.Flack)
+   1998-08-04  BMcM: added 'syn' and 'unk' as enumerations to
+                  _chemical_absolute_configuration (H.D.Flack/A.Linden)
+   1998-09-02  BMcM: added _exptl_crystal_size_length and modified slightly
+                  the definition of _exptl_crystal_size_ (W.Clegg/I.D.Brown)
+                    Added _diffrn_attenuator_material (I.D.Brown)
+                    Added sentence explaining the physical meaning of the
+                  _enumeration_range to _refine_ls_abs_structure_Flack
+                  (H.D.Flack)
+                    Some rewording in _chemical_absolute_configuration implying
+                  that for absolute configuration determination the measurement
+                  and reporting of the optical rotation in solution are
+                  considered mandatory. (H.D.Flack)
+                    Some rewording in _reflns_number_total and *_gt to clarify
+                  the inclusion of Friedel reflections; addition of
+                  _reflns_Friedel_coverage; deletion of _reflns_number_Friedel
+                  (H.D.Flack/S.R.Hall)
+                    Further minor rewording to _reflns_shell_number_unique_all,
+                  *_gt, *_obs (H.D.Flack)
+   1998-09-10  BMcM: transferred _diffrn_reflns_number_of_classes and the
+                  categories DIFFRN_REFLNS_CLASS, REFLNS_CLASS and
+                  REFLNS_SHELL_CLASS from the draft msCIF dictionary; added
+                  _diffrn_refln_class_code and _refln_class_code to link
+                  individual reflections to their related categories.
+   1998-12-08  BMcM: implemented H.D. Flack's reworking of DIFFRN_REFLNS_CLASS,
+                  REFLNS_CLASS, REFLNS_SHELL_CLASS and REFINE_LS_CLASS, deleting
+                  the latter two; removed _diffrn_reflns_number_of_classes.
+   1998-12-15  BMcM: completed the above reworking; fixed embarrassing typo for
+                  _related_function
+   1999-01-16  BMcM: coreDMG review of version 2.1beta5. Numerous small changes
+                  from I.D.Brown, the most significant being:
+                   _atom_site_occupancy definition clarifies how to impose an
+                    experimental uncertainty on the _enumeration_range;
+                   _atom_site_U_iso_or_equiv enumeration range set to infinity;
+                   _atom_type_analytical_mass_% enumeration range set as 0:100;
+                   expanded definitions of _diffrn_radiation_probe and *_type to
+                    clarify the distinction between these two items;
+                   added reference to _exptl_crystal_size to the definition of
+                    _exptl_crystal_description, and modified the definition of
+                    _exptl_crystal_face_diffr_ ;
+                   new data item _refln_d_spacing;
+                   clarified the role of _reflns_special_details in specifying
+                    whether Friedel pairs have been averaged;
+                  Numerous small changes from H.D.Flack, most significantly:
+                   removed enumeration range from _diffrn_refln_counts_ because
+                    *_net can go negative;
+                   fixed various typos in equations for wR and S;
+                   removed reference to Friedel reflections from
+                    _refln_symmetry_multiplicity
+   1999-01-24  BMcM: further revision to wording of _refln_symmetry_multiplicity
+                   following discussions by HDF and IDB
+                  Numerous small changes from G.Madariaga, most significantly:
+                   a instead of A for real-space cell lengths
+                    (_atom_site_B_iso_or_equiv and _atom_site_U_iso_or_equiv);
+                   _related_function alternate for _atom_site_Cartn_ & _fract_;
+                   "or scattering lengths" added to _atom_type_scat_source;
+                   deleted incorrect _list_reference in DIFFRN_RADIATION;
+                   added rtf to enumeration in _publ_body_format;
+                   added enumeration range to _refine_ls_abs_structure_Rogers
+   1999-02-04  BMcM: fixed some long lines
+   1999-02-06  BMcM: data names using sigma as an indicator of experimental
+                     standard uncertainty replaced by equivalents using the
+                     preferred 'u' notation (HDF):
+                          _diffrn_refln_intensity_sigma
+                          _diffrn_reflns_av_sigmaI/netI
+                          _diffrn_reflns_class_av_sgI/I
+                          _diffrn_standards_scale_sigma
+                          _reflns_shell_meanI_over_sigI_all
+                          _reflns_shell_meanI_over_sigI_gt
+                 (_reflns_shell_meanI_over_sigI_obs already replaced by *_gt)
+                   addition of '_related function alternate' to new data
+                     items corresponding to old items with
+                     '_related_function replace' (SRH)
+                   Example for _citation_journal_id_CSD changed to 0070 to
+                     reflect current practice at PDB (F.C.Bernstein)
+                   Added _atom_type_scat_dispersion_source (GM)
+   1999-03-24  Some minor cosmetic modifications (BMcM)
+   1999-03-24  Release version 2.1. IUCr
+   2001-01-09  BMcM: simplified entry for _chemical_absolute_configuration
+                     (H.D.Flack)
+                     Added _geom_bond_valence and the new categories
+                     VALENCE_PARAM and VALENCE_REF (I.D.Brown)
+   2001-01-11  BMcM: Categories EI, EO, EM added to _publ_requested_category
+   2001-01-11  Release version 2.2. IUCr
+   2003-09-28  BMcM: incorporated changes approved by COMCIFS following
+                     discussions of the core Dictionary Management Group:
+               _atom_site_fract_ nonsense enumeration default value removed
+               _atom_site_refinement_flags deprecated in favour of new
+                     *_flags_posn, *_adp and *_occupancy items
+               _atom_sites_special_details added
+               _cell_reciprocal_angle_ and *_length_ added
+               '_type_conditions esd' added to _chemical_melting_point
+               _chemical_melting_point_gt and *_lt added
+               Added several new items describing chemical properties to
+                     the CHEMICAL category: _chemical_properties_biological and
+                     *_physical, _chemical_temperature_decomposition_* and
+                     *_sublimation_*, at the request of CCDC
+               _citation_database_id_CSD added at request of CCDC
+               Several additional tags storing deposition numbers of
+                     database entries and record revision history at
+                     request of CCDC: _database_code_depnum_ccdc_fiz,
+                     *_journal, *_archive and _database_CSD_history
+               Added _diffrn_ambient_pressure_gt,lt and *_temperature_gt,lt
+               Added _diffrn_source_take-off_angle
+               Added _diffrn_standards_decay_%_lt
+               _diffrn_reflns_measured_fraction_resolution_full and *_max
+                     introduced as replacements for
+                     _diffrn_measured_fraction_theta_full and *_max, moved
+                     to a more appropriate category and defined in terms
+                     of resolution rather than angle which depends on the
+                     radiation used.
+               Likewise for _diffrn_reflns_resolution_full and *_max as
+                     replacements for _diffrn_reflns_theta_full and *_max
+               More specific parsable tags for crystal colour introduced as
+                     _exptl_crystal_colour_primary, *_modifier and *_lustre
+               Added _exptl_crystal_density_meas_gt,lt and *_meas_temp_gt,lt
+               Added _exptl_crystal_recrystallization_method
+               Added _publ_contact_author_id_iucr and _publ_author_id_iucr
+                     to allow unique author identification by IUCr database
+                     reference identifier
+               More datanames for recording imprecise quantities:
+                     _refine_ls_shift/su_max_lt and _refine_ls_shift/su_mean_lt
+               Added the categories SPACE_GROUP and SPACE_GROUP_SYMOP
+                     as imports from the symmetry dictionary cif_sym.dic
+               Added _related_function 'replace' to a number of items in
+                     the old SYMMETRY category pointing to the preferred
+                     items from the new SPACE_GROUP category
+   2003-08-19  BMcM: formal approval for COMCIFS for the additions and
+                     contingent changes discussed on the coreDMG discussion
+                     list from June 2002
+   2003-09-29  BMcM: second round of changes from coreDMG discussions:
+               Added _enumeration_range to new _chemical_temperature_* items;
+               Expanded definition of _space_group_symop_operation_xyz to
+                     make explicit the need for inclusion of centring
+                     translations (HDF/IDB)
+               Removed _diffrn_reflns_measured_fraction_resolution_full and
+                     *_max for reconsideration following suggestion by
+                     Curt Haltiwanger that terms are needed that do not
+                     refer to resolution or theta
+               Likewise removed _diffrn_standards_decay_%_lt for further
+                     consideration, and added _type_conditions esd to
+                     _diffrn_standards_decay_% as a measurable quantity
+                     (CH/HDF)
+               Modified _example_detail for _space_group_symop_operation_xyz
+                     to use a full and unambiguous wording in accordance
+                     with International Tables A (CH/IDB/HDF)
+   2003-09-29  Removed "_type_conditions esd" from the remaining *_gt and
+                     *_lt items at the suggestion of Gotzon Madariaga:
+                     since these are ceiling/floor values a measurable
+                     uncertainty is pointless (BMcM)
+   2003-10-01  Fixed some typos following checking by IDB (BMcM)
+   2003-10-03  BMcM: Final editorial pass. Added _related_function alternate
+                     to _exptl_crystal_colour. Also added this flag to the
+                     new items which replace existing ones:
+                     _atom_site_refinement_flags_* and the _space_group_ items
+   2003-10-04  Release version 2.3. IUCr
+   2004-06-06  BMcM: minor editorial changes for International Tables Volume G.
+                     Text of _atom_sites_*_tran_* definitions changed to
+                     ATOM_SITE from STOM_SITES.
+                       Some realignment of examples to fit column width.
+   2004-09-11  BMcM: corrected related item error in
+                     _atom_site_refinement_flags_posn, *_adp and *_occupancy
+   2004-11-26  NJA: updated reference to IT Vol A from 1987 to 2002
+   2004-12-22  NJA: minor corrections to hyphenation, spelling and punctuation
+                    atom_site definition: ', and so on' removed
+                    _atom_site_aniso_B_: 1/4 in formula replaced by (1/4)
+                    _atom_site_aniso_label: '...atom coordinate list' changed
+                     to '...atom in the atom coordinate list'
+                    _atom_site_B_iso_or_equiv: 'anisotropic temperature factor
+                      parameters' changed to 'anisotropic displacement
+                      components'
+                    _atom_site_label: 'Each label may have...' changed to
+                      'Different labels may have...'
+                    _atom_site_type_symbol: '...atom specie(s)...' changed to
+                      'atom species (singular or plural)...'
+                    _atom_type_scat_Cromer_Mann_: reference to Volume C
+                      updated to 2004
+                    _atom_type_symbol: 'atom specie(s)' changed to
+                      'atom species (singular or plural)'
+                    _audit_conform_dict_location: 'where the conformant
+                      dictionary resides' changed to 'for the dictionary
+                      to which the current data block conforms'
+                    _audit_conform_dict_version: 'conformant dictionary'
+                      changed to 'dictionary to which the current data
+                      block conforms'
+   2004-12-23  NJA: minor corrections to hyphenation, spelling and punctuation
+                   _audit_contact_author_fax,_audit_contact_author_phone:
+                      edited slightly
+                   _cell_angle_: 'in degrees of the reported structure'
+                      changed to 'of the reported structure in degrees'
+                   _cell_measurement_pressure: 'pressure used to synthesize
+                      the sample' changed to 'pressure at which the sample
+                      was synthesized'
+                   _cell_measurement_theta_: 'angles in degrees of reflections
+                      used to measure the unit cell' changed to 'angles
+                      of reflections used to measure the unit cell in degrees'
+                   _cell_reciprocal_angle_: 'angles in degrees defining
+                      the reciprocal cell' changed to 'angles defining
+                      the reciprocal cell in degrees'
+                   _chemical_[]: 'compounds' changed to 'compound'
+                   _chemical_optical_rotation: 'c is the value of CONC in g'
+                      changed to 'c is the value of CONC as defined above'.
+                   _chemical_properties_physical, _biological: 'free
+                      description' changed to 'free-text description'
+                   _chemical_conn_atom_display_: 'if absent...staff.' deleted
+                   _citation_[]: 'literature cited relevant' changed to
+                      'literature cited as being relevant'
+                   _citation_*: 'book chapters' changed to 'books or
+                      book chapters'
+                   _citation_country: 'both journal articles and' deleted
+                   _citation_database_id_CSD: 'containing' changed to
+                      'that contains'
+                   _citation_language: 'citation appears' changed to
+                      'cited article is written'
+                   _diffrn_crystal_treatment: 'intensity measurement' changed
+                      to 'the intensity measurements'
+                   _diffrn_special_details: 'diffraction measurement' changed
+                      to 'intensity-measurement'
+                   _diffrn_attenuator_scale: 'This scale must be multiplied
+                      by the measured intensity to convert it...' changed
+                      to 'The measured intensity must be multiplied by
+                      this scale to convert it...'
+                   _diffrn_orient_matrix_[]: 'used in data measurement'
+                      changed to 'used in the measurement of the
+                      diffraction intensities'
+                   _diffrn_orient_refln_angle_: 'in degrees of a reflection...
+                      matrix' changed to 'of a reflection...matrix in degrees'
+                   _diffrn_radiation_probe,_diffrn_radiation_type:
+                      definitions reworded slightly
+                _diffrn_refln_angle_: 'in degrees of a reflection' changed
+                   to 'of a reflection in degrees'
+                _diffrn_refln_elapsed_time: 'diffraction measurement'
+                   changed to 'the diffraction experiment'
+                _diffrn_refln_scale_group_code: 'applying' changed to
+                   'applicable'
+                _diffrn_refln_scan_mode: 'with a diffractometer' changed to
+                   'for measurements using a diffractometer'
+                _diffrn_refln_scan_rate: 'to measure the intensity in
+                   degrees per minute' changed to 'in degrees per minute
+                   to measure the intensity'
+                _diffrn_refln_standard_code: 'identifying' changed to
+                  'indicating'; 'intensity' changed to 'reflection'
+                _diffrn_reflns_class_d_res_high,_low: defintions rephrased.
+                _diffrn_source_details: 'used' deleted.
+                _diffrn_source_target: 'for generation of' changed to
+                   'to generate'
+                _diffrn_standards_decay_%: 'at the start of the measurement
+                   process and at the finish' changed to 'from the start of
+                   the measurement process to the end'
+                _diffrn_standards_number: 'used in the diffraction
+                   measurements' changed to 'used during the measurement of
+                   the diffraction intensities'
+                _exptl_absorpt_correction_type: 'no more detailed
+                   information is' changed to 'more detailed information
+                   is not'.
+                _exptl_crystal_[]: 'and so on' deleted
+                _exptl_crystal_face_perp_dist: 'millimetres of the face'
+                   changed to 'millimetres from the face'
+                _geom_[], _geom_angle_[], _geom_bond_[], _geom_contact_[],
+                _geom_hbond_[], _geom_torsion_[]: 'contents of the' deleted
+                _geom_contact_[], _geom_torsion_[]: year for reference for
+                   example 1 corrected from 1991 to 1992
+                _geom_hbond_angle_DHA: 'Site at *_D' changed to  'Site at *_H'
+                _publ_contact_author_fax: definition rephrased slightly
+                _publ_requested_category: Cif-access codes marked as '(no
+                longer in use)'
+
+   2005-01-05  NJA: minor corrections to hyphenation, spelling and punctuation
+                   _refine_ls_*: 'least squares' changed to 'least-squares
+                      refinement'
+                   _refine_ls_restrained_S_all: `Y(calc)  = the observed
+                      coefficients` changed to `Y(calc)  = the calculated
+                      coefficients`
+                   _refine_ls_restrained_S_gt: `Y(calc)  = the observed
+                      coefficients` changed to `Y(calc)  = the calculated
+                      coefficients`
+                   _refine_ls_restrained_S_obs: `Y(calc)  = the observed
+                      coefficients` changed to `Y(calc)  = the calculated
+                      coefficients`
+                   _refine_ls_shift/esd_*: 'divided by' changed to 'to'
+                   _refine_ls_shift/su_*: 'divided by' changed to 'to'
+                   _refine_ls_class_d_res_*: edited slightly
+                   _refine_ls_d_res_*: edited slightly
+                   _refln_intensity_*: edited slightly
+                   _refln_symmetry_multiplicity: reference to Volume A updated
+                      to (2002), Chapter 10.1
+                   _reflns_d_resolution_*: edited slightly
+                   _reflns_class_d_res_*: edited slightly
+                   _reflns_shell_d_res_*: edited slightly
+                   _space_group_name_Hall: erratum added to reference to Hall
+                      (1981); reference to Volume B updated to 2001.
+                   _space_group_name_H-M_alt: reference to Volume A updated
+                      to (2002)
+                   _symmetry_Int_Tables_number: reference to Volume A updated
+                      to (2002)
+                   _symmetry_space_group_name_Hall: erratum added to reference
+                      to Hall (1981)
+                   _symmetry_space_group_name_H-M: reference to Volume A
+                      updated to (2002)
+                   _symmetry_equiv_pos_as_xyz: reference to Volume A updated
+                      to (2002)
+   2005-01-11  NJA: more minor corrections to hyphenation, spelling and
+                     punctuation
+   2005-01-21 NJA: _reflns_shell_Rmerge_I_obs: related item changed from
+                       _reflns_shell_Rmerge_I_obs to _reflns_shell_Rmerge_I_gt
+   2005-06-21 NJA: corrections to proofs of Intl Tables G Chapter 4.1 included.
+                    New data name _publ_author_email added.
+   2005-06-27 BMcM: Removed _list_mandatory yes from _atom_site_aniso_label
+                    in response to cif-developers list discussion
+   2007-03-27 BMcM: Added _publ_section_related_literature; added
+                    new categories (QI, QM, QO) to _publ_requested_category
+   2007-12-04 BMcM: Fixed typo in equation appearing in
+                    _diffrn_reflns_av_sigmaI/netI and
+                    _diffrn_reflns_av_unetI/netI
+   2007-12-04  IDB: Added new items approved by coreDMG:
+                    SUMMARY
+
+                    1.  _atom_sites_solution_
+                        Added new flags notdet, dual, other (Bruce Noll)
+
+                    2.  _chemical_enantioexcess_
+                        Added items *_bulk, *_bulk_technique, *_crystal,
+                        *_crystal_technique (H. D. Flack)
+
+                    3.  _diffrn_..._measured_fraction_
+                        Added sentences to definitions of
+                        _diffrn_reflns_resolution_full, *_theta_max and
+                        *_resolution_max. Added new data items
+                        _diffrn_reflns_Laue_measured_fraction_full, *_max
+                        _diffrn_reflns_point_group_measured_fraction_full
+                        and *_max
+
+                    4.  _diffrn_standards_decay_%
+                        Clarified definition and added examples.
+
+                    5.  _distributed_density_
+                        Added _atom_site_distributed_density_id and the new
+                        DISTRIBUTED_DENSITY category following suggestions
+                        from David Watkin.
+
+                    6.  _exptl_absorpt_correction_T_max, *_T_min
+                        Clarified definition and added items
+                        _exptl_transmission_factor_max and *_min
+
+                    7.  _geom_bond_multiplicity
+                        New data item added.
+
+                    8.  _publ_section_keywords
+                        New data name added.
+
+                    9.  _refine_ls_F_calc
+                        Added _refine_ls_F_calc_details, *_formula and
+                        *_precision.
+
+                    10. _symmetry_equiv
+                        Added _enumeration_default 1 to _space_group_symop_id
+                        and _symmetry_equiv_pos_site_id; added
+                        _enumeration_default x,y,z to
+                        _symmetry_equiv_pos_as_xyz; added comment about the
+                        need to have the identity as symop 1 to
+                        _space_group_symop_operation_xyz, _space_group_symop_id,
+                        _symmetry_equiv_pos_as_xyz and
+                        _symmetry_equiv_pos_site_id
+   2008-02-10 BMcM: Final changes after COMCIFS review:
+                        Alphabetization of _atom_sites_Cartn_transform_axes,
+                        _citation_journal_full and a few others
+                        Removed upper enumeration limit from
+                        _diffrn_reflns_Laue_measured_fraction_full
+                        Fixed typo in definition of _distributed_density_[].
+                        Added comments from GM, IDB, RWGK querying aspects
+                        of some other definitions in the proposed
+                        DISTRIBUTED_DENSITY category.
+                        Removed DISTRIBUTED_DENSITY category for further review.
+                        Also removed data_atom_site_distributed_density_id
+   2010-06-29 BMcM: Added _diffrn_radiation_wavelength_determination
+   2011-04-26 BMcM: New enumeration value (iterative) for _atom_sites_solution_
+                        (suggested by A. van der Lee)
+                    New enumeration value (mixed) for
+                        _atom_sites_solution_hydrogens (D. Watkin)
+                    Added _journal_paper_doi, _database_code_COD
+                        (S. Grazulis), _chemical_identifier_inchi,
+                        _chemical_identifier_inchi_key,
+                        _chemical_identifier_inchi_version and
+                        _diffrn_radiation_wavelength_details
+   2012-05-16 BMcM: Deprecated _atom_site_symmetry_multiplicity;
+                        replaced with _atom_site_site_symmetry_multiplicity
+                        and added _atom_site_site_symmetry_order (IDB)
+               Reworded _exptl_crystal_F_000 definition to take
+                        account of neutron diffraction and removed
+                        _enumeration_range (can be negative for neutrons)
+               Added '_type_conditions su' to _diffrn_radiation_wavelength
+   2012-11-05 BMcM: Added _reflns_Friedel_fraction_full and
+                        _reflns_Friedel_fraction_max
+                    Added several new enumeration values to
+                        _refine_ls_hydrogen_treatment
+   2014-05-20 BMcM: Added new categories (GI, GM, GO, Hi, HM, HO)
+                        to _publ_requested_category
+   2014-11-21 BMcM: Data items related to data citation and author
+                        identification: _audit_block_doi; _citation_doi;
+                        _citation_id; _citation_publisher;
+                        _database_dataset_doi; _publ_author_id_orcid;
+                        _publ_contact_author_id_orcid
+   2017-06-30 AV: Maintenance update:
+                  Moved all unlooped instances of _related_function to
+                  a loop structure as required by the ddl.dic
+   2017-07-14 AV: Maintenance update:
+                  Declared all of the data items in the SPACE_GROUP category
+                  as strictly unlooped. Removed the _space_group_id and
+                  _space_group_symop_sg_id data items since they make no
+                  sense in the unlooped context.
+   2017-10-26 AV: Maintenance update:
+                  Added 'lustrous', 'transparent', 'translucent', 'opaque', '.'
+                  as enumerator values of the _exptl_crystal_colour_lustre data
+                  item and declared '.' as the default value. Added 'pale',
+                  'intense, '.' as enumerator values of the
+                  _exptl_crystal_colour_modifier data item and declared '.' as
+                  the default value.
+   2017-12-17 AV: Maintenance update:
+                  Changed the _citation_database_id_Medline data type from
+                  'numb' to 'char' and removed the numeric enumeration range
+                  from the definition of this data item.
+                  Changed the enumeration range of the _cell_length_a,
+                  _cell_length_b and _cell_length_c data items
+                  from '0.0:' to '1.0:'.
+   2018-03-04 AV: Maintenance update:
+                  Removed most of the default enumeration values. This removal
+                  reflects the policy change towards values that are not
+                  explicitly provided.
+   2018-03-05 AV: Maintenance update:
+                  Added 'Rf', 'Db', 'Sg', 'Bh', 'Hs', 'Mt', 'Ds', 'Rg', 'Cn'
+                  as enumerator values of the _diffrn_source_target data item.
+   2021-03-18 AV: Maintenance update:
+                  Changed the value of the _list data item from 'yes' to 'both'
+                    in the definitions of the _diffrn_radiation_wavelength_id,
+                    _diffrn_radiation_wavelength_wt, _exptl_crystal_id,
+                    _space_group_symop_id and _symmetry_equiv_pos_site_id
+                    data items to homogenise the loop eligibility of all
+                    items in the DIFFRN_RADIATION_WAVELENGTH, EXPTL_CRYSTAL,
+                    SPACE_GROUP_SYMOP and SYMMETRY_EQUIV categories.
+                  Added the _list data item with the value 'both' to the
+                    definition of the _exptl_crystal_recrystallization_method
+                    to homogenise the loop eligibility of all data items
+                    in the EXPTL_CRYSTAL category.
+                  Removed the redundant _list_reference data item from
+                    the definition of the _valence_ref_id data item.
+                  Added "_refln_wavelength_id" to the list of
+                    the _list_link_child data item values in the definition
+                    of the _diffrn_radiation_wavelength_id data item.
+                  Corrected the misspelt units of measurement of
+                    the _exptl_crystal_density_meas_lt and
+                    _exptl_crystal_density_meas_gt data items.
+                  Added units of measurement to the definitions of
+                    the _diffrn_detector_dtime, _diffrn_radiation_detector_dtime
+                    and _diffrn_radiation_inhomogeneity data items.
+                  Split the _diffrn_standards_interval_ definition into
+                    two distinct definitions _diffrn_standards_interval_count
+                    and _diffrn_standards_interval_time. Added units of
+                    measurement to the definition of
+                    the _diffrn_standards_interval_time data item.
+                  Homogenised the _units_detail data item values.
+;
+
+###############
+## ATOM_SITE ##
+###############
+
+data_atom_site_[]
+    _name                      '_atom_site_[]'
+    _category                    category_overview
+    _type                        null
+    loop_ _example
+          _example_detail
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+;
+    loop_
+    _atom_site_label
+    _atom_site_fract_x
+    _atom_site_fract_y
+    _atom_site_fract_z
+    _atom_site_U_iso_or_equiv
+    _atom_site_adp_type
+    _atom_site_calc_flag
+    _atom_site_calc_attached_atom
+      O1   .4154(4)  .5699(1)  .3026(0)  .060(1)  Uani  ?    ?
+      C2   .5630(5)  .5087(2)  .3246(1)  .060(2)  Uani  ?    ?
+      C3   .5350(5)  .4920(2)  .3997(1)  .048(1)  Uani  ?    ?
+      N4   .3570(3)  .5558(1)  .4167(0)  .039(1)  Uani  ?    ?
+      C5   .3000(5)  .6122(2)  .3581(1)  .045(1)  Uani  ?    ?
+      O21  .6958(5)  .4738(2)  .2874(1)  .090(2)  Uani  ?    ?
+      C31  .4869(6)  .3929(2)  .4143(2)  .059(2)  Uani  ?    ?
+     # - - - - data truncated for brevity - - - -
+      H321C  .04(1)  .318(3)   .320(2)   .14000   Uiso  ?    ?
+      H322A  .25(1)  .272(4)   .475(3)   .19000   Uiso  ?    ?
+      H322B  .34976  .22118    .40954    .19000   Uiso  calc C322
+      H322C  .08(1)  .234(4)   .397(3)   .19000   Uiso  ?    ?
+;
+;
+    Example 1 - based on data set TOZ of Willis, Beckwith & Tozer
+                [Acta Cryst. (1991), C47, 2276-2277].
+;
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+;
+    loop_
+    _atom_site_aniso_label
+    _atom_site_aniso_B_11
+    _atom_site_aniso_B_22
+    _atom_site_aniso_B_33
+    _atom_site_aniso_B_12
+    _atom_site_aniso_B_13
+    _atom_site_aniso_B_23
+    _atom_site_aniso_type_symbol
+     O1   .071(1) .076(1) .0342(9) .008(1)   .0051(9) -.0030(9) O
+     C2   .060(2) .072(2) .047(1)  .002(2)   .013(1)  -.009(1)  C
+     C3   .038(1) .060(2) .044(1)  .007(1)   .001(1)  -.005(1)  C
+     N4   .037(1) .048(1) .0325(9) .0025(9)  .0011(9) -.0011(9) N
+     C5   .043(1) .060(1) .032(1)  .001(1)  -.001(1)   .001(1)  C
+     # - - - - data truncated for brevity - - - -
+     O21  .094(2) .109(2) .068(1)  .023(2)   .038(1)  -.010(1)  O
+     C51  .048(2) .059(2) .049(1)  .002(1)  -.000(1)   .007(1)  C
+     C511 .048(2) .071(2) .097(3) -.008(2)  -.003(2)   .010(2)  C
+     C512 .078(2) .083(2) .075(2)  .009(2)  -.005(2)   .033(2)  C
+     C513 .074(2) .055(2) .075(2)  .004(2)   .001(2)  -.010(2)  C
+     # - - - - data truncated for brevity - - - -
+;
+;
+    Example 2 - based on data set TOZ of Willis, Beckwith & Tozer
+                [Acta Cryst. (1991), C47, 2276-2277].
+;
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+;
+    loop_
+    _atom_site_label
+    _atom_site_chemical_conn_number
+    _atom_site_fract_x
+    _atom_site_fract_y
+    _atom_site_fract_z
+    _atom_site_U_iso_or_equiv
+     S1  1  0.74799(9)  -0.12482(11)  0.27574(9)  0.0742(3)
+     S2  2  1.08535(10)  0.16131(9)   0.34061(9)  0.0741(3)
+     N1  3  1.0650(2)   -0.1390(2)    0.2918(2)   0.0500(5)
+     C1  4  0.9619(3)   -0.0522(3)    0.3009(2)   0.0509(6)
+     # - - - - data truncated for brevity - - - -
+;
+;
+    Example 3 - based on data set DPTD of Yamin, Suwandi, Fun, Sivakumar &
+                bin Shawkataly [Acta Cryst. (1996), C52, 951-953].
+;
+
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+;
+     loop_
+      _atom_site_label                  # *_assembly 'M' is a disordered methyl
+      _atom_site_occupancy              # with configurations 'A' and 'B':
+      _atom_site_disorder_assembly      #
+      _atom_site_disorder_group         #    H11B    H11A      H13B
+                                        #      .      |      .
+   C1     1      .       .              #        .    |    .
+   H11A   .5     M       A              #          .  |  .
+   H12A   .5     M       A              #             C1 --------C2---
+   H13A   .5     M       A              #           / .  \
+   H11B   .5     M       B              #         /   .    \
+   H12B   .5     M       B              #       /     .      \
+   H13B   .5     M       B              #    H12A    H12B    H13A
+
+;
+;
+    Example 4 - hypothetical example to illustrate the description of a
+                disordered methyl group.
+;
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+      _definition
+;              Data items in the ATOM_SITE category record details about
+               the atom sites in a crystal structure, such as the positional
+               coordinates, atomic displacement parameters, and magnetic moments
+               and directions.
+;
+
+data_atom_site_adp_type
+    _name                      '_atom_site_adp_type'
+    _category                    atom_site
+    _type                        char
+    loop_ _related_item
+          _related_function     '_atom_site_thermal_displace_type'  alternate
+    _list                        yes
+    _list_reference            '_atom_site_label'
+    loop_ _enumeration
+          _enumeration_detail    Uani   'anisotropic Uij'
+                                 Uiso   'isotropic U'
+                                 Uovl   'overall U'
+                                 Umpe   'multipole expansion U'
+                                 Bani   'anisotropic Bij'
+                                 Biso   'isotropic B'
+                                 Bovl   'overall B'
+    _definition
+;              A standard code used to describe the type of atomic displacement
+               parameters used for the site.
+;
+
+data_atom_site_aniso_B_
+    loop_ _name                '_atom_site_aniso_B_11'
+                               '_atom_site_aniso_B_12'
+                               '_atom_site_aniso_B_13'
+                               '_atom_site_aniso_B_22'
+                               '_atom_site_aniso_B_23'
+                               '_atom_site_aniso_B_33'
+    _category                    atom_site
+    _type                        numb
+    _type_conditions             esd
+    _list                        yes
+    _list_reference            '_atom_site_aniso_label'
+    loop_ _related_item
+          _related_function    '_atom_site_aniso_U_'  conversion
+    _units                       A^2^
+    _units_detail              'angstrom squared'
+    _definition
+;              These are the standard anisotropic atomic displacement
+               components in angstroms squared which appear in the
+               structure-factor term
+
+               T = exp{-(1/4) sum~i~ [ sum~j~ (B^ij^ h~i~ h~j~ a*~i~ a*~j~) ] }
+
+               h = the Miller indices
+               a* = the reciprocal-space cell lengths
+
+               The unique elements of the real symmetric matrix are
+               entered by row.
+
+               The IUCr Commission on Nomenclature recommends against the use
+               of B for reporting atomic displacement parameters. U, being
+               directly proportional to B, is preferred.
+;
+
+data_atom_site_aniso_label
+    _name                      '_atom_site_aniso_label'
+    _category                    atom_site
+    _type                        char
+    _list                        yes
+    _list_link_parent          '_atom_site_label'
+    _definition
+;              Anisotropic atomic displacement parameters are usually looped in
+               a separate list. If this is the case, this code must match the
+               _atom_site_label of the associated atom in the atom coordinate
+               list and conform with the same rules described in
+               _atom_site_label.
+;
+
+data_atom_site_aniso_ratio
+    _name                      '_atom_site_aniso_ratio'
+    _category                    atom_site
+    _type                        numb
+    _list                        yes
+    _list_reference            '_atom_site_aniso_label'
+    _enumeration_range           1.0:
+    _definition
+;              Ratio of the maximum to minimum principal axes of
+               displacement (thermal) ellipsoids.
+;
+
+data_atom_site_aniso_type_symbol
+    _name                      '_atom_site_aniso_type_symbol'
+    _category                    atom_site
+    _type                        char
+    _list                        yes
+    _list_reference            '_atom_site_aniso_label'
+    _list_link_parent          '_atom_site_type_symbol'
+    _definition
+;              This _atom_type_symbol code links the anisotropic atom
+               parameters to the atom-type data associated with this site and
+               must match one of the _atom_type_symbol codes in this list.
+;
+
+data_atom_site_aniso_U_
+    loop_ _name                '_atom_site_aniso_U_11'
+                               '_atom_site_aniso_U_12'
+                               '_atom_site_aniso_U_13'
+                               '_atom_site_aniso_U_22'
+                               '_atom_site_aniso_U_23'
+                               '_atom_site_aniso_U_33'
+    _category                    atom_site
+    _type                        numb
+    _type_conditions             esd
+    _list                        yes
+    _list_reference            '_atom_site_aniso_label'
+    loop_ _related_item
+          _related_function    '_atom_site_aniso_B_'  conversion
+    _units                      A^2^
+    _units_detail              'angstrom squared'
+    _definition
+;              These are the standard anisotropic atomic displacement
+               components in angstroms squared which appear in the
+               structure-factor term
+
+               T = exp{-2pi^2^ sum~i~ [sum~j~ (U^ij^ h~i~ h~j~ a*~i~ a*~j~) ] }
+
+               h = the Miller indices
+               a* = the reciprocal-space cell lengths
+
+               The unique elements of the real symmetric matrix are
+               entered by row.
+;
+
+data_atom_site_attached_hydrogens
+    _name                      '_atom_site_attached_hydrogens'
+    _category                    atom_site
+    _type                        numb
+    _list                        yes
+    _list_reference            '_atom_site_label'
+    _enumeration_range           0:8
+    loop_ _example
+          _example_detail        2    'water oxygen'
+                                 1    'hydroxyl oxygen'
+                                 4    'ammonium nitrogen'
+    _definition
+;              The number of hydrogen atoms attached to the atom at this site
+               excluding any hydrogen atoms for which coordinates (measured or
+               calculated) are given.
+;
+
+data_atom_site_B_equiv_geom_mean
+    _name                      '_atom_site_B_equiv_geom_mean'
+    _category                    atom_site
+    _type                        numb
+    _type_conditions             esd
+    _list                        yes
+    _list_reference            '_atom_site_label'
+    _enumeration_range           0.0:
+    loop_ _related_item
+          _related_function    '_atom_site_B_iso_or_equiv'     alternate
+                               '_atom_site_U_equiv_geom_mean'  conversion
+    _units                       A^2^
+    _units_detail              'angstrom squared'
+    _definition
+;              Equivalent isotropic atomic displacement parameter, B(equiv),
+               in angstroms squared, calculated as the geometric mean of
+               the anisotropic atomic displacement parameters.
+
+               B(equiv) = (B~i~ B~j~ B~k~)^1/3^
+
+               B~n~  = the principal components of the orthogonalized B^ij^
+
+               The IUCr Commission on Nomenclature recommends against the use
+               of B for reporting atomic displacement parameters. U, being
+               directly proportional to B, is preferred.
+;
+
+data_atom_site_B_iso_or_equiv
+    _name                      '_atom_site_B_iso_or_equiv'
+    _category                    atom_site
+    _type                        numb
+    _type_conditions             esd
+    _list                        yes
+    _list_reference            '_atom_site_label'
+    _enumeration_range           0.0:
+    loop_ _related_item
+          _related_function    '_atom_site_B_equiv_geom_mean'  alternate
+                               '_atom_site_U_iso_or_equiv'     conversion
+    _units                       A^2^
+    _units_detail              'angstrom squared'
+    _definition
+;              Isotropic atomic displacement parameter, or equivalent isotropic
+               atomic displacement parameter, B(equiv), in angstroms squared,
+               calculated from anisotropic displacement components.
+
+               B(equiv) = (1/3) sum~i~[sum~j~(B^ij^ a*~i~ a*~j~ a~i~ a~j~)]
+
+               a     = the real-space cell lengths
+               a*    = the reciprocal-space cell lengths
+               B^ij^ = 8 pi^2^ U^ij^
+
+               Ref: Fischer, R. X. & Tillmanns, E. (1988). Acta Cryst. C44,
+                    775-776.
+
+               The IUCr Commission on Nomenclature recommends against the use
+               of B for reporting atomic displacement parameters. U, being
+               directly proportional to B, is preferred.
+;
+
+data_atom_site_calc_attached_atom
+    _name                      '_atom_site_calc_attached_atom'
+    _category                    atom_site
+    _type                        char
+    _list                        yes
+    _list_reference            '_atom_site_label'
+    _definition
+;              The _atom_site_label of the atom site to which the 'geometry-
+               calculated' atom site is attached.
+;
+
+data_atom_site_calc_flag
+    _name                      '_atom_site_calc_flag'
+    _category                    atom_site
+    _type                        char
+    _list                        yes
+    _list_reference            '_atom_site_label'
+    loop_ _enumeration
+          _enumeration_detail   d     'determined from diffraction measurements'
+                                calc  'calculated from molecular geometry'
+                                c     'abbreviation for "calc"'
+                                dum   'dummy site with meaningless coordinates'
+    _definition
+;              A standard code to signal whether the site coordinates have been
+               determined from the intensities or calculated from the geometry
+               of surrounding sites, or have been assigned dummy coordinates.
+               The abbreviation 'c' may be used in place of 'calc'.
+;
+
+data_atom_site_Cartn_
+    loop_ _name                '_atom_site_Cartn_x'
+                               '_atom_site_Cartn_y'
+                               '_atom_site_Cartn_z'
+    _category                    atom_site
+    _type                        numb
+    _type_conditions             esd
+    loop_ _related_item
+          _related_function      '_atom_site_fract_'  alternate
+    _list                        yes
+    _list_reference            '_atom_site_label'
+    _units                       A
+    _units_detail                angstrom
+    _definition
+;              The atom-site coordinates in angstroms specified according to a
+               set of orthogonal Cartesian axes related to the cell axes as
+               specified by the _atom_sites_Cartn_transform_axes description.
+;
+
+data_atom_site_chemical_conn_number
+    _name                      '_atom_site_chemical_conn_number'
+    _category                    atom_site
+    _type                        numb
+    _list                        yes
+    _list_link_parent          '_chemical_conn_atom_number'
+    _list_reference            '_atom_site_label'
+    _enumeration_range           1:
+    _definition
+;              This number links an atom site to the chemical connectivity list.
+               It must match a number specified by _chemical_conn_atom_number.
+;
+
+data_atom_site_constraints
+    _name                      '_atom_site_constraints'
+    _category                    atom_site
+    _type                        char
+    _list                        yes
+    _list_reference            '_atom_site_label'
+    _example                    'pop=1.0-pop(Zn3)'
+    _definition
+;              A description of the constraints applied to parameters at this
+               site during refinement. See also _atom_site_refinement_flags
+               and _refine_ls_number_constraints.
+;
+
+data_atom_site_description
+    _name                      '_atom_site_description'
+    _category                    atom_site
+    _type                        char
+    _list                        yes
+    _list_reference            '_atom_site_label'
+    _example                    'Ag/Si disordered'
+    _definition
+;              A description of special aspects of this site. See also
+               _atom_site_refinement_flags.
+;
+
+data_atom_site_disorder_assembly
+    _name                      '_atom_site_disorder_assembly'
+    _category                    atom_site
+    _type                        char
+    _list                        yes
+    _list_reference            '_atom_site_label'
+    loop_ _example
+          _example_detail   A  'disordered methyl assembly with groups 1 and 2'
+                            B  'disordered sites related by a mirror'
+                            S  'disordered sites independent of symmetry'
+    _definition
+;              A code which identifies a cluster of atoms that show long-range
+               positional disorder but are locally ordered. Within each such
+               cluster of atoms, _atom_site_disorder_group is used to identify
+               the sites that are simultaneously occupied. This field is only
+               needed if there is more than one cluster of disordered atoms
+               showing independent local order.
+;
+
+data_atom_site_disorder_group
+    _name                      '_atom_site_disorder_group'
+    _category                    atom_site
+    _type                        char
+    _list                        yes
+    _list_reference            '_atom_site_label'
+    loop_ _example
+          _example_detail    1  'unique disordered site in group 1'
+                             2  'unique disordered site in group 2'
+                            -1  'symmetry-independent disordered site'
+    _definition
+;              A code which identifies a group of positionally disordered atom
+               sites that are locally simultaneously occupied. Atoms that are
+               positionally disordered over two or more sites (e.g. the hydrogen
+               atoms of a methyl group that exists in two orientations) can
+               be assigned to two or more groups. Sites belonging to the same
+               group are simultaneously occupied, but those belonging to
+               different groups are not. A minus prefix (e.g. "-1") is used to
+               indicate sites disordered about a special position.
+;
+
+data_atom_site_fract_
+    loop_ _name                '_atom_site_fract_x'
+                               '_atom_site_fract_y'
+                               '_atom_site_fract_z'
+    _category                    atom_site
+    _type                        numb
+    _type_conditions             esd
+    loop_ _related_item
+          _related_function    '_atom_site_Cartn_'  alternate
+    _list                        yes
+    _list_reference            '_atom_site_label'
+    _definition
+;              Atom-site coordinates as fractions of the _cell_length_ values.
+;
+
+data_atom_site_label
+    _name                      '_atom_site_label'
+    _category                    atom_site
+    _type                        char
+    _list                        yes
+    _list_mandatory              yes
+    loop_ _list_link_child     '_atom_site_aniso_label'
+                               '_geom_angle_atom_site_label_1'
+                               '_geom_angle_atom_site_label_2'
+                               '_geom_angle_atom_site_label_3'
+                               '_geom_bond_atom_site_label_1'
+                               '_geom_bond_atom_site_label_2'
+                               '_geom_contact_atom_site_label_1'
+                               '_geom_contact_atom_site_label_2'
+                               '_geom_hbond_atom_site_label_D'
+                               '_geom_hbond_atom_site_label_H'
+                               '_geom_hbond_atom_site_label_A'
+                               '_geom_torsion_atom_site_label_1'
+                               '_geom_torsion_atom_site_label_2'
+                               '_geom_torsion_atom_site_label_3'
+                               '_geom_torsion_atom_site_label_4'
+    loop_ _example               C12     Ca3g28     Fe3+17     H*251
+                                 boron2a   C_a_phe_83_a_0  Zn_Zn_301_A_0
+    _definition
+;              The _atom_site_label is a unique identifier for a particular site
+               in the crystal. This code is made up of a sequence of up to seven
+               components, _atom_site_label_component_0 to *_6, which may be
+               specified as separate data items. Component 0 usually matches one
+               of the specified _atom_type_symbol codes. This is not mandatory
+               if an _atom_site_type_symbol item is included in the atom-site
+               list. The _atom_site_type_symbol always takes precedence over
+               an _atom_site_label in the identification of the atom type. The
+               label components 1 to 6 are optional, and normally only
+               components 0 and 1 are used. Note that components 0 and 1 are
+               concatenated, while all other components, if specified, are
+               separated by an underscore. Underscores are
+               only used if higher-order components exist. If an intermediate
+               component is not used, it may be omitted provided the underscore
+               separators are inserted. For example, the label 'C233__ggg' is
+               acceptable and represents the components C, 233, '' and ggg.
+               Different labels may have a different number of components.
+;
+
+data_atom_site_label_component_
+    loop_ _name                '_atom_site_label_component_0'
+                               '_atom_site_label_component_1'
+                               '_atom_site_label_component_2'
+                               '_atom_site_label_component_3'
+                               '_atom_site_label_component_4'
+                               '_atom_site_label_component_5'
+                               '_atom_site_label_component_6'
+    _category                    atom_site
+    _type                        char
+    _list                        yes
+    _list_reference            '_atom_site_label'
+    _definition
+;              Component 0 is normally a code which matches identically with
+               one of the _atom_type_symbol codes. If this is the case, then the
+               rules governing the _atom_type_symbol code apply. If, however,
+               the data item _atom_site_type_symbol is also specified in the
+               atom-site list, component 0 need not match this symbol or adhere
+               to any of the _atom_type_symbol rules.
+               Component 1 is referred to as the "atom number". When component 0
+               is the atom-type code, it is used to number the sites with the
+               same atom type. This component code must start with at least one
+               digit which is not followed by a + or - sign (to distinguish it
+               from the component 0 rules).
+               Components 2 to 6 contain the identifier, residue, sequence,
+               asymmetry identifier and alternate codes, respectively. These
+               codes may be composed of any characters except an underscore.
+;
+
+data_atom_site_occupancy
+    _name                      '_atom_site_occupancy'
+    _category                    atom_site
+    _type                        numb
+    _type_conditions             esd
+    _list                        yes
+    _list_reference            '_atom_site_label'
+    _enumeration_range           0.0:1.0
+    _definition
+;              The fraction of the atom type present at this site.
+               The sum of the occupancies of all the atom types at this site
+               may not significantly exceed 1.0 unless it is a dummy site. The
+               value must lie in the 99.97% Gaussian confidence interval
+               -3u =< x =< 1 + 3u. The _enumeration_range of 0.0:1.0 is thus
+               correctly interpreted as meaning (0.0 - 3u) =< x =< (1.0 + 3u).
+;
+
+data_atom_site_refinement_flags
+    _name                      '_atom_site_refinement_flags'
+    _category                    atom_site
+    _type                        char
+    _list                        yes
+    _list_reference            '_atom_site_label'
+    loop_ _related_item
+          _related_function    '_atom_site_refinement_flags_posn'      replace
+                               '_atom_site_refinement_flags_adp'       replace
+                               '_atom_site_refinement_flags_occupancy' replace
+    loop_ _enumeration
+          _enumeration_detail   . 'no refinement constraints'
+                                S 'special-position constraint on site'
+                                G 'rigid-group refinement of site'
+                                R 'riding-atom site attached to non-riding atom'
+                                D 'distance or angle restraint on site'
+                                T 'thermal displacement constraints'
+                                U 'Uiso or Uij restraint (rigid bond)'
+                                P 'partial occupancy constraint'
+    _definition
+;           A concatenated series of single-letter codes which indicate the
+            refinement restraints or constraints applied to this site.  This
+            item should not be used.  It has been replaced by
+            _atom_site_refinement_flags_posn, *_adp and *_occupancy. It is
+            retained in this dictionary only to provide compatibility with
+            legacy CIFs.
+;
+
+data_atom_site_refinement_flags_adp
+    _name                      '_atom_site_refinement_flags_adp'
+    _category                    atom_site
+    _type                        char
+    _list                        yes
+    _list_reference            '_atom_site_label'
+    loop_ _related_item
+          _related_function    '_atom_site_refinement_flags'  alternate
+    loop_ _enumeration
+          _enumeration_detail
+             .  'no constraints on atomic displacement parameters'
+             T  'special-position constraints on atomic displacement parameters'
+             U  'Uiso or Uij restraint (rigid bond)'
+             TU 'both constraints applied'
+    _definition
+;              A code which indicates the refinement restraints or constraints
+               applied to the atomic displacement parameters of this site.
+;
+
+data_atom_site_refinement_flags_occupancy
+    _name                      '_atom_site_refinement_flags_occupancy'
+    _category                    atom_site
+    _type                        char
+    _list                        yes
+    _list_reference            '_atom_site_label'
+    loop_ _related_item
+          _related_function    '_atom_site_refinement_flags'  alternate
+    loop_ _enumeration
+          _enumeration_detail   . 'no constraints on site-occupancy parameters'
+                                P 'site-occupancy constraint'
+    _definition
+;              A code which indicates that refinement restraints or
+               constraints were applied to the occupancy of this site.
+;
+
+data_atom_site_refinement_flags_posn
+    _name                      '_atom_site_refinement_flags_posn'
+    _category                    atom_site
+    _type                        char
+    _list                        yes
+    _list_reference            '_atom_site_label'
+    loop_ _related_item
+          _related_function    '_atom_site_refinement_flags'  alternate
+    loop_ _enumeration
+          _enumeration_detail
+                     . 'no constraints on  positional coordinates'
+                     D 'distance or angle restraint on positional coordinates'
+                     G 'rigid-group refinement of positional coordinates'
+                     R 'riding-atom site attached to non-riding atom'
+                     S 'special-position constraint on positional coordinates'
+                     DG   'combination of the above constraints'
+                     DR   'combination of the above constraints'
+                     DS   'combination of the above constraints'
+                     GR   'combination of the above constraints'
+                     GS   'combination of the above constraints'
+                     RS    'combination of the above constraints'
+                     DGR  'combination of the above constraints'
+                     DGS  'combination of the above constraints'
+                     DRS  'combination of the above constraints'
+                     GRS  'combination of the above constraints'
+                     DGRS 'combination of the above constraints'
+    _definition
+;              A code which indicates the refinement restraints or constraints
+               applied to the positional coordinates of this site.
+;
+
+data_atom_site_restraints
+    _name                      '_atom_site_restraints'
+    _category                    atom_site
+    _type                        char
+    _list                        yes
+    _list_reference            '_atom_site_label'
+    _example                    'restrained to planar ring'
+    _definition
+;              A description of restraints applied to specific parameters at
+               this site during refinement. See also _atom_site_refinement_flags
+               and _refine_ls_number_restraints.
+;
+
+data_atom_site_site_symmetry_multiplicity
+    _name                      '_atom_site_site_symmetry_multiplicity'
+    _category                    atom_site
+    _type                        numb
+    _list                        yes
+    _list_reference            '_atom_site_label'
+    loop_ _related_item
+          _related_function    '_atom_site_symmetry_multiplicity'  alternate
+    _enumeration_range           1:192
+    _definition
+;              The number of different sites that are generated by the
+               application of the space-group symmetry to the
+               coordinates given for this site. It is equal to the
+               multiplicity given for this Wyckoff site
+               in International Tables for Crystallography Vol. A (2002).
+               It is equal to the multiplicity of the general position
+               divided by the order of the site symmetry given in
+               _atom_site_site_symmetry_order.
+;
+
+data_atom_site_site_symmetry_order
+    _name                      '_atom_site_site_symmetry_order'
+    _category                    atom_site
+    _type                        numb
+    _list                        yes
+    _list_reference            '_atom_site_label'
+    _enumeration_range           1:48
+    _definition
+;              The order of the site symmetry of the site identified by
+               _atom_site_label.
+
+               This is the number of times application of the
+               crystallographic symmetry to the coordinates given for
+               this site generates the same set of coordinates.
+               It is equal to:
+
+                          multiplicity of the general position
+                          ------------------------------------
+                              multiplicity of this site
+
+                where 'multiplicity of this site' is
+                given in _atom_site_site_symmetry_multiplicity.
+;
+
+data_atom_site_symmetry_multiplicity
+    _name                      '_atom_site_symmetry_multiplicity'
+    _category                    atom_site
+    _type                        numb
+    _list                        yes
+    _list_reference            '_atom_site_label'
+    loop_ _related_item
+          _related_function    '_atom_site_site_symmetry_multiplicity'  replace
+    _enumeration_range           1:192
+    _definition
+;              The multiplicity of a site due to the space-group symmetry as
+               given in International Tables for Crystallography Vol. A (2002).
+
+               Use of this data name is deprecated because of
+               inconsistencies in practice among structure refinement
+               software packages. The number of positions given for
+               this Wyckoff site in International Tables for
+               Crystallography Vol. A (2002). should now be expressed
+               using the data name _atom_site_site_symmetry_multiplicity.
+               In the historic archive some CIFs use this item to give values
+               that belong in _atom_site_site_symmetry_order.
+;
+
+data_atom_site_thermal_displace_type
+    _name                      '_atom_site_thermal_displace_type'
+    _category                    atom_site
+    _type                        char
+    loop_ _related_item
+          _related_function    '_atom_site_adp_type'  replace
+    _list                        yes
+    _list_reference            '_atom_site_label'
+    loop_ _enumeration
+          _enumeration_detail    Uani   'anisotropic Uij'
+                                 Uiso   'isotropic U'
+                                 Uovl   'overall U'
+                                 Umpe   'multipole expansion U'
+                                 Bani   'anisotropic Bij'
+                                 Biso   'isotropic B'
+                                 Bovl   'overall B'
+    _definition
+;              A standard code used to describe the type of atomic displacement
+               parameters used for the site.
+;
+
+data_atom_site_type_symbol
+    _name                      '_atom_site_type_symbol'
+    _category                    atom_site
+    _type                        char
+    _list                        yes
+    _list_reference            '_atom_site_label'
+    _list_link_parent          '_atom_type_symbol'
+    _list_link_child           '_atom_site_aniso_type_symbol'
+    loop_ _example               Cu   Cu2+   dummy   Fe3+Ni2+
+                                 S-   H*     H(SDS)
+    _definition
+;              A code to identify the atom species (singular or plural)
+               occupying this site.
+               This code must match a corresponding _atom_type_symbol. The
+               specification of this code is optional if component 0 of the
+               _atom_site_label is used for this purpose. See _atom_type_symbol.
+;
+
+data_atom_site_U_equiv_geom_mean
+    _name                      '_atom_site_U_equiv_geom_mean'
+    _category                    atom_site
+    _type                        numb
+    _type_conditions             esd
+    _list                        yes
+    _list_reference            '_atom_site_label'
+    _enumeration_range           0.0:
+    loop_ _related_item
+          _related_function    '_atom_site_U_iso_or_equiv'     alternate
+                               '_atom_site_B_equiv_geom_mean'  conversion
+    _units                       A^2^
+    _units_detail              'angstrom squared'
+    _definition
+;              Equivalent isotropic atomic displacement parameter, U(equiv),
+               in angstroms squared, calculated as the geometric mean of
+               the anisotropic atomic displacement parameters.
+
+               U(equiv) = (U~i~ U~j~ U~k~)^1/3^
+
+               U~n~  = the principal components of the orthogonalized U^ij^
+;
+
+data_atom_site_U_iso_or_equiv
+    _name                      '_atom_site_U_iso_or_equiv'
+    _category                    atom_site
+    _type                        numb
+    _type_conditions             esd
+    _list                        yes
+    _list_reference            '_atom_site_label'
+    _enumeration_range           0.0:
+    loop_ _related_item
+          _related_function    '_atom_site_U_equiv_geom_mean'  alternate
+                               '_atom_site_B_iso_or_equiv'     conversion
+    _units                       A^2^
+    _units_detail              'angstrom squared'
+    _definition
+;              Isotropic atomic displacement parameter, or equivalent isotropic
+               atomic  displacement parameter, U(equiv), in angstroms squared,
+               calculated from anisotropic atomic displacement  parameters.
+
+               U(equiv) = (1/3) sum~i~[sum~j~(U^ij^ a*~i~ a*~j~ a~i~ a~j~)]
+
+               a     = the real-space cell lengths
+               a*    = the reciprocal-space cell lengths
+
+               Ref: Fischer, R. X. & Tillmanns, E. (1988). Acta Cryst. C44,
+                    775-776.
+;
+
+data_atom_site_Wyckoff_symbol
+    _name                      '_atom_site_Wyckoff_symbol'
+    _category                    atom_site
+    _type                        char
+    _list                        yes
+    _list_reference            '_atom_site_label'
+    _definition
+;              The Wyckoff symbol (letter) as listed in the space-group tables
+               of International Tables for Crystallography Vol. A (2002).
+;
+
+################
+## ATOM_SITES ##
+################
+
+data_atom_sites_[]
+    _name                      '_atom_sites_[]'
+    _category                    category_overview
+    _type                        null
+    loop_ _example
+          _example_detail
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+;
+    _atom_sites_Cartn_transform_axes
+          'c along z, astar along x, b along y'
+
+    _atom_sites_Cartn_tran_matrix_11    58.39
+    _atom_sites_Cartn_tran_matrix_12     0.00
+    _atom_sites_Cartn_tran_matrix_13     0.00
+    _atom_sites_Cartn_tran_matrix_21     0.00
+    _atom_sites_Cartn_tran_matrix_22    86.70
+    _atom_sites_Cartn_tran_matrix_23     0.00
+    _atom_sites_Cartn_tran_matrix_31     0.00
+    _atom_sites_Cartn_tran_matrix_32     0.00
+    _atom_sites_Cartn_tran_matrix_33    46.27
+
+;
+;
+    Example 1 - based on PDB entry 5HVP and laboratory records for the
+                structure corresponding to PDB entry 5HVP.
+;
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+    _definition
+;              Data items in the ATOM_SITES category record details about
+               the crystallographic cell and cell transformations, which are
+               common to all atom sites.
+;
+
+data_atom_sites_Cartn_tran_matrix_
+    loop_ _name                '_atom_sites_Cartn_tran_matrix_11'
+                               '_atom_sites_Cartn_tran_matrix_12'
+                               '_atom_sites_Cartn_tran_matrix_13'
+                               '_atom_sites_Cartn_tran_matrix_21'
+                               '_atom_sites_Cartn_tran_matrix_22'
+                               '_atom_sites_Cartn_tran_matrix_23'
+                               '_atom_sites_Cartn_tran_matrix_31'
+                               '_atom_sites_Cartn_tran_matrix_32'
+                               '_atom_sites_Cartn_tran_matrix_33'
+    _category                    atom_sites
+    _type                        numb
+    _definition
+;              Matrix elements used to transform fractional coordinates in
+               the ATOM_SITE category to Cartesian  coordinates. The axial
+               alignments of this transformation are described in
+               _atom_sites_Cartn_transform_axes. The 3 x 1 translation is
+               defined in _atom_sites_Cartn_tran_vector_.
+                 x'                   |11 12 13|      x                  | 1 |
+               ( y' ) Cartesian   =   |21 22 23|    ( y ) fractional  +  | 2 |
+                 z'                   |31 32 33|      z                  | 3 |
+;
+
+data_atom_sites_Cartn_tran_vector_
+    loop_ _name                '_atom_sites_Cartn_tran_vector_1'
+                               '_atom_sites_Cartn_tran_vector_2'
+                               '_atom_sites_Cartn_tran_vector_3'
+    _category                    atom_sites
+    _type                        numb
+    _definition
+;              Elements of a 3 x 1 translation vector used in the
+               transformation of fractional coordinates in the
+               ATOM_SITE category to Cartesian  coordinates. The axial
+               alignments of this transformation are described in
+               _atom_sites_Cartn_transform_axes.
+                 x'                   |11 12 13|      x                  | 1 |
+               ( y' ) Cartesian   =   |21 22 23|    ( y ) fractional  +  | 2 |
+                 z'                   |31 32 33|      z                  | 3 |
+;
+
+data_atom_sites_Cartn_transform_axes
+    _name                      '_atom_sites_Cartn_transform_axes'
+    _category                    atom_sites
+    _type                        char
+    _example                    'a parallel to x; b in the plane of y and z'
+    _definition
+;              A description of the relative alignment of the crystal cell
+               axes to the  Cartesian orthogonal axes as applied in the
+               transformation matrix _atom_sites_Cartn_tran_matrix_.
+;
+
+
+data_atom_sites_fract_tran_matrix_
+    loop_ _name                 '_atom_sites_fract_tran_matrix_11'
+                                '_atom_sites_fract_tran_matrix_12'
+                                '_atom_sites_fract_tran_matrix_13'
+                                '_atom_sites_fract_tran_matrix_21'
+                                '_atom_sites_fract_tran_matrix_22'
+                                '_atom_sites_fract_tran_matrix_23'
+                                '_atom_sites_fract_tran_matrix_31'
+                                '_atom_sites_fract_tran_matrix_32'
+                                '_atom_sites_fract_tran_matrix_33'
+    _category                    atom_sites
+    _type                        numb
+    _definition
+;              Matrix elements used to transform Cartesian coordinates in
+               the ATOM_SITE category to fractional coordinates. The axial
+               alignments of this transformation are described in
+               _atom_sites_Cartn_transform_axes. The 3 x 1 translation is
+               defined in _atom_sites_fract_tran_vector_.
+                 x'                   |11 12 13|      x                 | 1 |
+               ( y' ) fractional  =   |21 22 23|    ( y ) Cartesian  +  | 2 |
+                 z'                   |31 32 33|      z                 | 3 |
+;
+
+data_atom_sites_fract_tran_vector_
+    loop_ _name                '_atom_sites_fract_tran_vector_1'
+                               '_atom_sites_fract_tran_vector_2'
+                               '_atom_sites_fract_tran_vector_3'
+    _category                    atom_sites
+    _type                        numb
+    _definition
+;              Elements of a 3 x 1 translation vector used in the
+               transformation of Cartesian coordinates in the
+               ATOM_SITE category to fractional  coordinates. The axial
+               alignments of this transformation are described in
+               _atom_sites_Cartn_transform_axes.
+                 x'                   |11 12 13|      x                 | 1 |
+               ( y' ) fractional  =   |21 22 23|    ( y ) Cartesian  +  | 2 |
+                 z'                   |31 32 33|      z                 | 3 |
+;
+
+data_atom_sites_solution_primary
+    _name                      '_atom_sites_solution_primary'
+    _category                    atom_sites
+    _type                        char
+    loop_ _enumeration
+          _enumeration_detail    difmap  'difference Fourier map'
+                                 vecmap  'real-space vector search'
+                                 heavy   'heavy-atom method'
+                                 direct  'structure-invariant direct methods'
+                                 geom    'inferred from neighbouring sites'
+                                 disper  'anomalous-dispersion techniques'
+                                 isomor  'isomorphous structure methods'
+                                 notdet  'coordinates were not determined'
+                                 dual
+                                    'dual-space method (Sheldrick et al., 2001)'
+                                 iterative
+;                                    iterative algorithm, e.g. charge
+                                     flipping [Oszl\'anyi, G. and S\"uto, A.
+                                     (2004). Acta Cryst. A60, 134-141]
+;
+                                 other
+                                  'a method not included elsewhere in this list'
+    _definition
+;              Codes which identify the methods used to locate the initial
+               atom sites. The *_primary code identifies how the first
+               atom sites were determined; the *_secondary code identifies
+               how the remaining non-hydrogen sites were located; and the
+               *_hydrogens code identifies how the hydrogen sites were located.
+
+               Ref: Sheldrick, G. M., Hauptman, H. A., Weeks, C. M.,
+                    Miller, R. and Us\'on, I. (2001). Ab initio phasing.
+                    In International Tables for Crystallography,
+                    Vol. F. Crystallography of biological macromolecules,
+                    edited by M. G. Rossmann and E. Arnold, ch. 16.1.
+                    Dordrecht: Kluwer Academic Publishers.
+;
+
+data_atom_sites_solution_secondary
+    _name                      '_atom_sites_solution_secondary'
+    _category                    atom_sites
+    _type                        char
+    loop_ _enumeration
+          _enumeration_detail    difmap  'difference Fourier map'
+                                 vecmap  'real-space vector search'
+                                 heavy   'heavy-atom method'
+                                 direct  'structure-invariant direct methods'
+                                 geom    'inferred from neighbouring sites'
+                                 disper  'anomalous-dispersion techniques'
+                                 isomor  'isomorphous structure methods'
+                                 notdet  'coordinates were not determined'
+                                 dual
+                                    'dual-space method (Sheldrick et al., 2001)'
+                                 iterative
+;                                    iterative algorithm, e.g. charge
+                                     flipping [Oszl\'anyi, G. and S\"uto, A.
+                                     (2004). Acta Cryst. A60, 134-141]
+;
+                                 other
+                                  'a method not included elsewhere in this list'
+    _definition
+;              Codes which identify the methods used to locate the initial
+               atom sites. The *_primary code identifies how the first
+               atom sites were determined; the *_secondary code identifies
+               how the remaining non-hydrogen sites were located; and the
+               *_hydrogens code identifies how the hydrogen sites were located.
+
+               Ref: Sheldrick, G. M., Hauptman, H. A., Weeks, C. M.,
+                    Miller, R. and Us\'on, I. (2001). Ab initio phasing.
+                    In International Tables for Crystallography,
+                    Vol. F. Crystallography of biological macromolecules,
+                    edited by M. G. Rossmann and E. Arnold, ch. 16.1.
+                    Dordrecht: Kluwer Academic Publishers.
+;
+
+data_atom_sites_solution_hydrogens
+    _name                      '_atom_sites_solution_hydrogens'
+    _category                    atom_sites
+    _type                        char
+    loop_ _enumeration
+          _enumeration_detail    difmap  'difference Fourier map'
+                                 vecmap  'real-space vector search'
+                                 heavy   'heavy-atom method'
+                                 direct  'structure-invariant direct methods'
+                                 geom    'inferred from neighbouring sites'
+                                 disper  'anomalous-dispersion techniques'
+                                 isomor  'isomorphous structure methods'
+                                 mixed   'a mixture of "geom" and "difmap"'
+                                 notdet  'coordinates were not determined'
+                                 dual
+                                    'dual-space method (Sheldrick et al., 2001)'
+                                 iterative
+;                                    iterative algorithm, e.g. charge
+                                     flipping [Oszl\'anyi, G. and S\"uto, A.
+                                     (2004). Acta Cryst. A60, 134-141]
+;
+                                 other
+                                  'a method not included elsewhere in this list'
+    _definition
+;              Codes which identify the methods used to locate the initial
+               atom sites. The *_primary code identifies how the first
+               atom sites were determined; the *_secondary code identifies
+               how the remaining non-hydrogen sites were located; and the
+               *_hydrogens code identifies how the hydrogen sites were located.
+
+               Ref: Sheldrick, G. M., Hauptman, H. A., Weeks, C. M.,
+                    Miller, R. and Us\'on, I. (2001). Ab initio phasing.
+                    In International Tables for Crystallography,
+                    Vol. F. Crystallography of biological macromolecules,
+                    edited by M. G. Rossmann and E. Arnold, ch. 16.1.
+                    Dordrecht: Kluwer Academic Publishers.
+;
+
+data_atom_sites_special_details
+    _name                      '_atom_sites_special_details'
+    _category                    atom_sites
+    _type                        char
+    _definition
+;              Additional information about the atomic coordinates not coded
+               elsewhere in the CIF.
+;
+
+###############
+## ATOM_TYPE ##
+###############
+
+data_atom_type_[]
+    _name                      '_atom_type_[]'
+    _category                    category_overview
+    _type                        null
+    loop_ _example
+          _example_detail
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+;
+    loop_
+    _atom_type_symbol
+    _atom_type_oxidation_number
+    _atom_type_number_in_cell
+    _atom_type_scat_dispersion_real
+    _atom_type_scat_dispersion_imag
+    _atom_type_scat_source
+      C 0 72  .017  .009  International_Tables_Vol_IV_Table_2.2B
+      H 0 100  0     0    International_Tables_Vol_IV_Table_2.2B
+      O 0 12  .047  .032  International_Tables_Vol_IV_Table_2.2B
+      N 0 4   .029  .018  International_Tables_Vol_IV_Table_2.2B
+;
+;
+    Example 1 - based on data set TOZ of Willis, Beckwith & Tozer
+                [Acta Cryst. (1991), C47, 2276-2277].
+;
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+    _definition
+;              Data items in the ATOM_TYPE category record details about
+               properties of the atoms that occupy the atom sites, such as the
+               atomic scattering factors.
+;
+
+data_atom_type_analytical_mass_%
+    _name                      '_atom_type_analytical_mass_%'
+    _category                    atom_type
+    _type                        numb
+    _list                        yes
+    _list_reference            '_atom_type_symbol'
+    _enumeration_range           0.0:100.0
+    _definition
+;              Mass percentage of this atom type derived from chemical analysis.
+;
+
+data_atom_type_description
+    _name                      '_atom_type_description'
+    _category                    atom_type
+    _type                        char
+    _list                        yes
+    _list_reference            '_atom_type_symbol'
+    loop_ _example               deuterium       0.34Fe+0.66Ni
+    _definition
+;              A description of the atom(s) designated by this atom type. In
+               most cases, this will be the element name and oxidation state of
+               a single atom  species. For disordered or nonstoichiometric
+               structures it will describe a combination of atom species.
+;
+
+data_atom_type_number_in_cell
+    _name                      '_atom_type_number_in_cell'
+    _category                    atom_type
+    _type                        numb
+    _list                        yes
+    _list_reference            '_atom_type_symbol'
+    _enumeration_range           0:
+    _definition
+;              Total number of atoms of this atom type in the unit cell.
+;
+
+data_atom_type_oxidation_number
+    _name                      '_atom_type_oxidation_number'
+    _category                    atom_type
+    _type                        numb
+    _list                        yes
+    _list_reference            '_atom_type_symbol'
+    _enumeration_range           -8:8
+    _definition
+;              Formal oxidation state of this atom type in the structure.
+;
+
+data_atom_type_radius_
+    loop_ _name                '_atom_type_radius_bond'
+                               '_atom_type_radius_contact'
+    _category                    atom_type
+    _type                        numb
+    _list                        yes
+    _list_reference            '_atom_type_symbol'
+    _enumeration_range           0.0:5.0
+    _units                       A
+    _units_detail                angstrom
+    _definition
+;              The effective intra- and intermolecular bonding radii in
+               angstroms of this atom type.
+;
+
+data_atom_type_scat_Cromer_Mann_
+    loop_ _name                '_atom_type_scat_Cromer_Mann_a1'
+                               '_atom_type_scat_Cromer_Mann_a2'
+                               '_atom_type_scat_Cromer_Mann_a3'
+                               '_atom_type_scat_Cromer_Mann_a4'
+                               '_atom_type_scat_Cromer_Mann_b1'
+                               '_atom_type_scat_Cromer_Mann_b2'
+                               '_atom_type_scat_Cromer_Mann_b3'
+                               '_atom_type_scat_Cromer_Mann_b4'
+                               '_atom_type_scat_Cromer_Mann_c'
+    _category                    atom_type
+    _type                        numb
+    _list                        yes
+    _list_reference            '_atom_type_symbol'
+    _definition
+;              The Cromer-Mann scattering-factor coefficients used to calculate
+               the scattering factors for this atom type.
+
+               Ref: International Tables for X-ray Crystallography (1974).
+                     Vol. IV, Table 2.2B
+               or   International Tables for Crystallography (2004). Vol. C,
+                    Tables 6.1.1.4 and 6.1.1.5
+;
+
+data_atom_type_scat_dispersion_
+    loop_ _name                '_atom_type_scat_dispersion_imag'
+                               '_atom_type_scat_dispersion_real'
+    _category                    atom_type
+    _type                        numb
+    _list                        yes
+    _list_reference            '_atom_type_symbol'
+    _definition
+;              The imaginary and real components of the anomalous-dispersion
+               scattering factor, f'' and f', in electrons for this atom type
+               and the radiation given in _diffrn_radiation_wavelength.
+;
+
+data_atom_type_scat_dispersion_source
+    _name                      '_atom_type_scat_dispersion_source'
+    _category                    atom_type
+    _type                        char
+    _list                        yes
+    _list_reference            '_atom_type_symbol'
+    _example                   'International Tables Vol. IV Table 2.3.1'
+    _definition
+;              Reference to source of real and imaginary dispersion
+               corrections for scattering factors used for this atom type.
+;
+
+data_atom_type_scat_length_neutron
+    _name                      '_atom_type_scat_length_neutron'
+    _category                    atom_type
+    _type                        numb
+    _list                        yes
+    _list_reference            '_atom_type_symbol'
+    _units                       fm
+    _units_detail                femtometre
+    _definition
+;              The bound coherent scattering length in femtometres for the
+               atom type at the isotopic composition used for the diffraction
+               experiment.
+;
+
+data_atom_type_scat_source
+    _name                      '_atom_type_scat_source'
+    _category                    atom_type
+    _type                        char
+    _list                        yes
+    _list_reference            '_atom_type_symbol'
+    _example                   'International Tables Vol. IV Table 2.4.6B'
+    _definition
+;              Reference to source of scattering factors or scattering lengths
+               used for this atom type.
+;
+
+data_atom_type_scat_versus_stol_list
+    _name                      '_atom_type_scat_versus_stol_list'
+    _category                    atom_type
+    _type                        char
+    _list                        yes
+    _list_reference            '_atom_type_symbol'
+    _definition
+;              A table of scattering factors as a function of sin theta over
+               lambda. This table should be well commented to indicate the
+               items present. Regularly formatted lists are strongly
+               recommended.
+;
+
+data_atom_type_symbol
+    _name                      '_atom_type_symbol'
+    _category                    atom_type
+    _type                        char
+    _list                        yes
+    _list_mandatory              yes
+    _list_link_child           '_atom_site_type_symbol'
+    loop_ _example               C   Cu2+   H(SDS)    dummy    FeNi
+    _definition
+;              The code used to identify the atom species (singular or plural)
+               representing this atom type. Normally this code is the element
+               symbol. The code may be composed of any character except an
+               underscore with the additional proviso that digits designate an
+               oxidation state and must be followed by a + or - character.
+;
+
+###########
+## AUDIT ##
+###########
+
+data_audit_[]
+    _name                      '_audit_[]'
+    _category                    category_overview
+    _type                        null
+    loop_ _example
+          _example_detail
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+;
+    _audit_block_code                  TOZ_1991-03-20
+    _audit_block_doi                   10.1107/S0108270191009630
+
+    _audit_creation_date               1991-03-20
+    _audit_creation_method   from_xtal_archive_file_using_CIFIO
+    _audit_update_record
+    ; 1991-04-09     text and data added by Tony Willis.
+      1991-04-15     rec'd by co-editor as manuscript HL0007.
+      1991-04-17     adjustments based on first referee report.
+      1991-04-18     adjustments based on second referee report.
+    ;
+;
+;
+    Example 1 - based on data set TOZ of Willis, Beckwith & Tozer
+                [Acta Cryst. (1991), C47, 2276-2277].
+;
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+    _definition
+;              Data items in the AUDIT category record details about the
+               creation and subsequent updating of the data block.
+;
+
+data_audit_block_code
+    _name                      '_audit_block_code'
+    _category                    audit
+    _type                        char
+    _example                     TOZ_1991-03-20
+    _definition
+;              A code intended to identify uniquely the current data block.
+;
+
+data_audit_block_doi
+    _name                      '_audit_block_doi'
+    _category                    audit
+    _type                        char
+    _example                     10.5517/CC6V9DQ
+    _definition
+;              The digital object identifier (DOI) registered to identify
+               the data set publication represented by the current
+               datablock. This can be used as a unique identifier for
+               the datablock so long as the code used is a valid DOI
+               (i.e. begins with a valid publisher prefix assigned by a
+               Registration Agency and a suffix guaranteed to be unique
+               by the publisher) and has had its metadata deposited
+               with a DOI Registration Agency.
+
+               A DOI is a unique character string identifying any
+               object of intellectual property. It provides a
+               persistent identifier for an object on a digital network
+               and permits the association of related current data in a
+               structured extensible way. A DOI is an implementation
+               of the Internet concepts of Uniform Resource Name and
+               Universal Resource Locator managed according to the
+               specifications of the International DOI Foundation (see
+               http://www.doi.org).
+;
+
+data_audit_creation_date
+    _name                      '_audit_creation_date'
+    _category                    audit
+    _type                        char
+    _example                     1990-07-12
+    _definition
+;              The date that the data block was created. The date format
+               is yyyy-mm-dd.
+;
+
+data_audit_creation_method
+    _name                      '_audit_creation_method'
+    _category                    audit
+    _type                        char
+    _example                    'spawned by the program QBEE'
+    _definition
+;              A description of how data were entered into the data block.
+;
+
+data_audit_update_record
+    _name                      '_audit_update_record'
+    _category                    audit
+    _type                        char
+    _example                    '1990-07-15   Updated by the Co-editor'
+    _definition
+;              A record of any changes to the data block. The update format
+               is a date (yyyy-mm-dd) followed by a description of the
+               changes. The latest update entry is added to the bottom of
+               this record.
+;
+
+##################
+## AUDIT_AUTHOR ##
+##################
+
+data_audit_author_[]
+    _name                      '_audit_author_[]'
+    _category                    category_overview
+    _type                        null
+    loop_ _example
+          _example_detail
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+;
+    loop_
+    _audit_author_name
+    _audit_author_address
+        'Fitzgerald, Paula M. D.'
+    ;  Department of Biophysical Chemistry
+       Merck Research Laboratories
+       PO Box 2000, Ry80M203
+       Rahway
+       New Jersey 07065
+       USA
+    ;
+        'Van Middlesworth, J. F.'
+    ;  Department of Biophysical Chemistry
+       Merck Research Laboratories
+       PO Box 2000, Ry80M203
+       Rahway
+       New Jersey 07065
+       USA
+    ;
+;
+;
+    Example 1 - based on PDB entry 5HVP and laboratory records for the
+                structure corresponding to PDB entry 5HVP.
+;
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+    _definition
+;              Data items in the AUDIT_AUTHOR category record details about
+               the author(s) of the data block.
+;
+
+data_audit_author_address
+    _name                      '_audit_author_address'
+    _category                    audit_author
+    _type                        char
+    _list                        yes
+    _list_reference            '_audit_author_name'
+    _example
+;                       Department
+                        Institute
+                        Street
+                        City and postcode
+                        COUNTRY
+;
+    _definition
+;              The address of an author of this data block. If there are
+               multiple authors, _audit_author_address is looped with
+               _audit_author_name.
+;
+
+data_audit_author_name
+    _name                      '_audit_author_name'
+    _category                    audit_author
+    _type                        char
+    _list                        yes
+    _list_mandatory              yes
+    loop_ _example             'Bleary, Percival R.'
+                               "O'Neil, F.K."
+                               'Van den Bossche, G.'
+                               'Yang, D.-L.'
+                               'Simonov, Yu.A.'
+                               'M\"uller, H.A.'
+                               'Ross II, C.R.'
+    _definition
+;              The name of an author of this data block. If there are multiple
+               authors, _audit_author_name is looped with _audit_author_address.
+               The family name(s), followed by a comma and including any
+               dynastic components, precedes the first name(s) or initial(s).
+;
+
+###################
+## AUDIT_CONFORM ##
+###################
+
+data_audit_conform_[]
+    _name                      '_audit_conform_[]'
+    _category                    category_overview
+    _type                        null
+    loop_ _example
+          _example_detail
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+;
+    _audit_conform_dict_name         cif_core.dic
+    _audit_conform_dict_version      2.4
+    _audit_conform_dict_location
+          ftp://ftp.iucr.org/pub/cif_core.2.4.dic
+;
+;
+    Example 1 - any file conforming to the current CIF core dictionary.
+;
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+    _definition
+;              Data items in the AUDIT_CONFORM category describe the
+               dictionary versions against which the data names appearing in
+               the current data block are conformant.
+;
+
+data_audit_conform_dict_location
+    _name                      '_audit_conform_dict_location'
+    _category                    audit_conform
+    _type                        char
+    _list                        both
+    _list_reference            '_audit_conform_dict_name'
+    _definition
+;              A file name or uniform resource locator (URL) for the
+               dictionary to which the current data block conforms.
+;
+
+data_audit_conform_dict_name
+    _name                      '_audit_conform_dict_name'
+    _category                    audit_conform
+    _type                        char
+    _list                        both
+    _list_mandatory              yes
+    _definition
+;              The string identifying the highest-level dictionary defining
+               data names used in this file.
+;
+
+data_audit_conform_dict_version
+    _name                      '_audit_conform_dict_version'
+    _category                    audit_conform
+    _type                        char
+    _list                        both
+    _list_reference            '_audit_conform_dict_name'
+    _definition
+;              The version number of the dictionary to which the
+               current data block conforms.
+;
+
+##########################
+## AUDIT_CONTACT_AUTHOR ##
+##########################
+
+data_audit_contact_author_[]
+    _name                      '_audit_contact_author_[]'
+    _category                    category_overview
+    _type                        null
+    loop_ _example
+          _example_detail
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+;
+    loop_
+    _audit_contact_author_name
+    _audit_contact_author_address
+    _audit_contact_author_email
+    _audit_contact_author_fax
+    _audit_contact_author_phone
+        'Fitzgerald, Paula M. D.'
+    ;  Department of Biophysical Chemistry
+       Merck Research Laboratories
+       PO Box 2000, Ry80M203
+       Rahway
+       New Jersey 07065
+       USA
+    ;
+        'paula_fitzgerald@merck.com'
+        '1(908)5945510'
+        '1(908)5945510'
+;
+;
+    Example 1 - based on PDB entry 5HVP and laboratory records for the
+                structure corresponding to PDB entry 5HVP.
+;
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+    _definition
+;              Data items in the AUDIT_CONTACT_AUTHOR category record details
+               about the name and address of the author to be contacted
+               concerning the contents of this data block.
+;
+
+data_audit_contact_author_address
+    _name                      '_audit_contact_author_address'
+    _category                    audit_contact_author
+    _type                        char
+    _example
+;                       Department
+                        Institute
+                        Street
+                        City and postcode
+                        COUNTRY
+;
+    _definition
+;              The mailing address of the author of the data block to whom
+               correspondence should be addressed.
+;
+
+data_audit_contact_author_email
+    _name                      '_audit_contact_author_email'
+    _category                    audit_contact_author
+    _type                        char
+    loop_ _example               name@host.domain.country
+                                 bm@iucr.org
+    _definition
+;              The electronic mail address of the author of the data block
+               to whom correspondence should be addressed, in a form
+               recognizable to international networks. The format of e-mail
+               addresses is given in Section 3.4, Address Specification, of
+               Internet Message Format, RFC 2822, P. Resnick (Editor),
+               Network Standards Group, April 2001.
+;
+
+data_audit_contact_author_fax
+    _name                      '_audit_contact_author_fax'
+    _category                    audit_contact_author
+    _type                        char
+     loop_
+    _example                    '12(34)9477334'
+                                '12()349477334'
+    _definition
+;              The facsimile telephone number of the author of the data
+               block to whom correspondence should be addressed.
+
+               The recommended style starts with the international dialing
+               prefix, followed by the area code in parentheses, followed by the
+               local number with no spaces.
+;
+
+data_audit_contact_author_name
+    _name                      '_audit_contact_author_name'
+    _category                    audit_contact_author
+    _type                        char
+    loop_ _example             'Bleary, Percival R.'
+                               "O'Neil, F.K."
+                               'Van den Bossche, G.'
+                               'Yang, D.-L.'
+                               'Simonov, Yu.A.'
+                               'M\"uller, H.A.'
+                               'Ross II, C.R.'
+    _definition
+;              The name of the author of the data block to whom correspondence
+               should be addressed.
+
+               The family name(s), followed by a comma and including any
+               dynastic components, precedes the first name(s) or initial(s).
+;
+
+data_audit_contact_author_phone
+    _name                      '_audit_contact_author_phone'
+    _category                    audit_contact_author
+    _type                        char
+     loop_
+    _example                    '12(34)9477330'
+                                '12()349477330'
+                                '12(34)9477330x5543'
+    _definition
+;              The telephone number of the author of the data block to whom
+               correspondence should be addressed.
+
+               The recommended style starts with the international dialing
+               prefix, followed by the area code in parentheses, followed by the
+               local number and any extension number prefixed by 'x',
+               with no spaces.
+;
+
+################
+## AUDIT_LINK ##
+################
+
+data_audit_link_[]
+    _name                      '_audit_link_[]'
+    _category                    category_overview
+    _type                        null
+    loop_ _example
+          _example_detail
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+;
+    loop_
+    _audit_link_block_code
+    _audit_link_block_description
+       .         'discursive text of paper with two structures'
+       morA_(1)  'structure 1 of 2'
+       morA_(2)  'structure 2 of 2'
+;
+;
+    Example 1 - multiple structure paper, as illustrated
+                in A Guide to CIF for Authors (1995). IUCr: Chester.
+;
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+;
+    loop_
+    _audit_link_block_code
+    _audit_link_block_description
+      .       'publication details'
+      KSE_COM 'experimental data common to ref./mod. structures'
+      KSE_REF 'reference structure'
+      KSE_MOD 'modulated structure'
+;
+;
+    Example 2 - example file for the one-dimensional incommensurately
+                modulated structure of K~2~SeO~4~.
+;
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+    _definition
+;              Data items in the AUDIT_LINK category record details about the
+               relationships between data blocks in the current CIF.
+;
+
+data_audit_link_block_code
+    _name                      '_audit_link_block_code'
+    _category                    audit_link
+    _type                        char
+    _list                        yes
+    _list_mandatory              yes
+    _definition
+;              The value of _audit_block_code associated with a data block
+               in the current file related to the current data block. The
+               special value '.' may be used to refer to the current data
+               block for completeness.
+;
+
+data_audit_link_block_description
+    _name                      '_audit_link_block_description'
+    _category                    audit_link
+    _type                        char
+    _list                        yes
+    _list_reference            '_audit_link_block_code'
+    _definition
+;              A textual description of the relationship of the referenced
+               data block to the current one.
+;
+
+##########
+## CELL ##
+##########
+
+data_cell_[]
+    _name                      '_cell_[]'
+    _category                    category_overview
+    _type                        null
+    loop_ _example
+          _example_detail
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+;
+    _cell_length_a                     5.959(1)
+    _cell_length_b                     14.956(1)
+    _cell_length_c                     19.737(3)
+    _cell_angle_alpha                  90
+    _cell_angle_beta                   90
+    _cell_angle_gamma                  90
+    _cell_volume                       1759.0(3)
+
+    _cell_measurement_temperature      293
+    _cell_measurement_reflns_used      25
+    _cell_measurement_theta_min        25
+    _cell_measurement_theta_max        31
+;
+;
+    Example 1 - based on data set TOZ of Willis, Beckwith & Tozer
+                [Acta Cryst. (1991), C47, 2276-2277].
+;
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+    _definition
+;              Data items in the CELL category record details about the
+               crystallographic cell parameters and their measurement.
+;
+
+data_cell_angle_
+    loop_ _name                '_cell_angle_alpha'
+                               '_cell_angle_beta'
+                               '_cell_angle_gamma'
+    _category                    cell
+    _type                        numb
+    _type_conditions             esd
+    _enumeration_range           0.0:180.0
+    _units                       deg
+    _units_detail              'degree of arc'
+    _definition
+;              Unit-cell angles of the reported structure in degrees.
+               The values of _refln_index_h, *_k, *_l must correspond to the
+               cell defined by these values and _cell_length_a, *_b and *_c.
+               The values of _diffrn_refln_index_h, *_k, *_l may not correspond
+               to these values if a cell transformation took place following
+               the measurement of the diffraction intensities. See also
+               _diffrn_reflns_transf_matrix_.
+;
+
+data_cell_formula_units_Z
+    _name                      '_cell_formula_units_Z'
+    _category                    cell
+    _type                        numb
+    _enumeration_range           1:
+    _definition
+;              The number of the formula units in the unit cell as specified
+               by _chemical_formula_structural, _chemical_formula_moiety or
+               _chemical_formula_sum.
+;
+
+data_cell_length_
+    loop_ _name                '_cell_length_a'
+                               '_cell_length_b'
+                               '_cell_length_c'
+    _category                    cell
+    _type                        numb
+    _type_conditions             esd
+    _enumeration_range           1.0:
+    _units                       A
+    _units_detail                angstrom
+    _definition
+;              Unit-cell lengths in angstroms corresponding to the structure
+               reported. The values of _refln_index_h, *_k, *_l must
+               correspond to the cell defined by these values and _cell_angle_
+               values. The values of _diffrn_refln_index_h, *_k, *_l may not
+               correspond to these values if a cell transformation took place
+               following the measurement of the diffraction intensities. See
+               also _diffrn_reflns_transf_matrix_.
+;
+
+data_cell_measurement_pressure
+    _name                      '_cell_measurement_pressure'
+    _category                    cell
+    _type                        numb
+    _type_conditions             esd
+    _enumeration_range           0.0:
+    _units                       kPa
+    _units_detail                kilopascal
+    _definition
+;              The pressure in kilopascals at which the unit-cell parameters
+               were measured (not the pressure at which the sample was
+               synthesized).
+;
+
+data_cell_measurement_radiation
+    _name                      '_cell_measurement_radiation'
+    _category                    cell
+    _type                        char
+    loop_ _example              'neutron'  'Cu K\a' 'synchrotron'
+    _definition
+;              Description of the radiation used to measure the unit-cell data.
+               See also  _cell_measurement_wavelength.
+;
+
+data_cell_measurement_reflns_used
+    _name                      '_cell_measurement_reflns_used'
+    _category                    cell
+    _type                        numb
+    _definition
+;              The total number of reflections used to determine the unit cell.
+               These reflections may be specified as _cell_measurement_refln_
+               data items.
+;
+
+data_cell_measurement_temperature
+    _name                      '_cell_measurement_temperature'
+    _category                    cell
+    _type                        numb
+    _type_conditions             esd
+    _enumeration_range           0.0:
+    _units                       K
+    _units_detail                kelvin
+    _definition
+;              The temperature in kelvins at which the unit-cell parameters
+               were measured (not the temperature of synthesis).
+;
+
+data_cell_measurement_theta_
+    loop_ _name                '_cell_measurement_theta_max'
+                               '_cell_measurement_theta_min'
+    _category                    cell
+    _type                        numb
+    _enumeration_range           0.0:90.0
+    _units                       deg
+    _units_detail              'degree of arc'
+    _definition
+;              The maximum and minimum theta angles of reflections
+               used to measure the unit cell in degrees.
+;
+
+data_cell_measurement_wavelength
+    _name                      '_cell_measurement_wavelength'
+    _category                    cell
+    _type                        numb
+    _enumeration_range           0.0:
+    _units                       A
+    _units_detail                angstrom
+    _definition
+;              The wavelength in angstroms of the radiation used to measure
+               the unit cell. If this is not specified, the wavelength is
+               assumed to be the same as that given in
+               _diffrn_radiation_wavelength.
+;
+data_cell_reciprocal_angle_
+    loop_ _name                '_cell_reciprocal_angle_alpha'
+                               '_cell_reciprocal_angle_beta'
+                               '_cell_reciprocal_angle_gamma'
+    _category                    cell
+    _type                        numb
+    _type_conditions             esd
+    _enumeration_range           0.0:180.0
+    _units                       deg
+    _units_detail              'degree of arc'
+    _definition
+;              The angles defining the reciprocal cell in degrees. These
+               are related to those in the real cell by:
+
+               cos(recip-alpha)
+                   = [cos(beta)*cos(gamma) - cos(alpha)]/[sin(beta)*sin(gamma)]
+
+               cos(recip-beta)
+                   = [cos(gamma)*cos(alpha) - cos(beta)]/[sin(gamma)*sin(alpha)]
+
+               cos(recip-gamma)
+                   = [cos(alpha)*cos(beta) - cos(gamma)]/[sin(alpha)*sin(beta)]
+
+               Ref: Buerger, M. J. (1942). X-ray Crystallography, p. 360.
+                       New York: John Wiley & Sons Inc.
+;
+
+data_cell_reciprocal_length_
+    loop_ _name                '_cell_reciprocal_length_a'
+                               '_cell_reciprocal_length_b'
+                               '_cell_reciprocal_length_c'
+    _category                    cell
+    _type                        numb
+    _type_conditions             esd
+    _enumeration_range           0.0:
+    _units                       A^-1^
+    _units_detail              'reciprocal angstrom'
+    _definition
+;              The reciprocal-cell lengths in inverse angstroms.  These are
+               related to the real cell by:
+
+               recip-a = b*c*sin(alpha)/V
+
+               recip-b = c*a*sin(beta)/V
+
+               recip-c = a*b*sin(gamma)/V
+
+               where V is the cell volume.
+
+               Ref: Buerger, M. J. (1942). X-ray Crystallography, p. 360.
+                       New York: John Wiley & Sons Inc.
+;
+
+data_cell_special_details
+    _name                      '_cell_special_details'
+    _category                    cell
+    _type                        char
+    loop_ _example              'pseudo-orthorhombic'
+                                'standard setting from 45 deg rotation around c'
+    _definition
+;              A description of special aspects of the cell choice, noting
+               possible alternative settings.
+;
+
+data_cell_volume
+    _name                      '_cell_volume'
+    _category                    cell
+    _type                        numb
+    _type_conditions             esd
+    _enumeration_range           0.0:
+    _units                       A^3^
+    _units_detail              'angstrom cubed'
+    _definition
+;              Cell volume V in angstroms cubed.
+
+               V = a b c [1 - cos^2^(alpha) - cos^2^(beta) - cos^2^(gamma)
+                           + 2 cos(alpha) cos(beta) cos(gamma) ] ^1/2^
+
+               a     = _cell_length_a
+               b     = _cell_length_b
+               c     = _cell_length_c
+               alpha = _cell_angle_alpha
+               beta  = _cell_angle_beta
+               gamma = _cell_angle_gamma
+;
+
+############################
+## CELL_MEASUREMENT_REFLN ##
+############################
+
+data_cell_measurement_refln_[]
+    _name                      '_cell_measurement_refln_[]'
+    _category                    category_overview
+    _type                        null
+    loop_ _example
+          _example_detail
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+;
+    loop_
+     _cell_measurement_refln_index_h
+     _cell_measurement_refln_index_k
+     _cell_measurement_refln_index_l
+     _cell_measurement_refln_theta
+       -2    4    1          8.67
+        0    3    2          9.45
+        3    0    2          9.46
+       -3    4    1          8.93
+       -2    1   -2          7.53
+       10    0    0         23.77
+        0   10    0         23.78
+       -5    4    1         11.14
+      # - - - - data truncated for brevity - - - -
+;
+;
+    Example 1 - extracted from the CAD-4 listing for Rb~2~S~2~O~6~ at room
+                temperature (unpublished).
+;
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+    _definition
+;              Data items in the CELL_MEASUREMENT_REFLN category record
+               details about the reflections used in the determination of the
+               crystallographic cell parameters.
+
+               The _cell_measurement_refln_ data items would in general be used
+               only for diffractometer measurements.
+;
+
+data_cell_measurement_refln_index_
+    loop_ _name                '_cell_measurement_refln_index_h'
+                               '_cell_measurement_refln_index_k'
+                               '_cell_measurement_refln_index_l'
+    _category                    cell_measurement_refln
+    _type                        numb
+    _list                        yes
+    _list_mandatory              yes
+    _definition
+;              Miller indices of a reflection used for measurement of
+               the unit cell.
+;
+
+data_cell_measurement_refln_theta
+    _name                      '_cell_measurement_refln_theta'
+    _category                    cell_measurement_refln
+    _type                        numb
+    _list                        yes
+    _list_reference            '_cell_measurement_refln_index_'
+    _enumeration_range           0.0:90.0
+    _units                       deg
+    _units_detail              'degree of arc'
+    _definition
+;              Theta angle in degrees for the reflection used for
+               measurement of the unit cell with the indices
+               _cell_measurement_refln_index_.
+;
+
+##############
+## CHEMICAL ##
+##############
+
+data_chemical_[]
+    _name                      '_chemical_[]'
+    _category                    category_overview
+    _type                        null
+    loop_ _example
+          _example_detail
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+;
+    _chemical_name_systematic
+      trans-bis(tricyclohexylphosphine)tetracarbonylmolybdenum(0)
+;
+;
+    Example 1 - based on data set 9597gaus of Alyea, Ferguson & Kannan
+                [Acta Cryst. (1996), C52, 765-767].
+;
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+    _definition
+;              Data items in the CHEMICAL category record details about the
+               composition and chemical properties of the compound. The
+               formula data items must agree with those that specify the
+               density, unit-cell and Z values.
+;
+
+data_chemical_absolute_configuration
+    _name                      '_chemical_absolute_configuration'
+    _category                    chemical
+    _type                        char
+    loop_ _enumeration
+          _enumeration_detail    rm
+;                                        Absolute configuration established by
+                                         the structure determination of a
+                                         compound containing a chiral reference
+                                         molecule of known absolute
+                                         configuration.
+;
+                                 ad
+;                                        Absolute configuration established by
+                                         anomalous-dispersion effects in
+                                         diffraction measurements on the
+                                         crystal.
+;
+                                 rmad
+;                                        Absolute configuration established by
+                                         the structure determination of a
+                                         compound containing a chiral reference
+                                         molecule of known absolute
+                                         configuration and confirmed by
+                                         anomalous-dispersion effects in
+                                         diffraction measurements on the
+                                         crystal.
+;
+                                 syn
+;                                        Absolute configuration has not been
+                                         established by anomalous-dispersion
+                                         effects in diffraction measurements on
+                                         the crystal. The enantiomer has been
+                                         assigned by reference to an unchanging
+                                         chiral centre in the synthetic
+                                         procedure.
+;
+                                 unk
+;                                        Absolute configuration is unknown,
+                                         there being no firm chemical evidence
+                                         for its assignment to hand and it
+                                         having not been established by
+                                         anomalous-dispersion effects in
+                                         diffraction measurements on the
+                                         crystal. An arbitrary choice of
+                                         enantiomer has been made.
+;
+                                 .      'Inapplicable.'
+    _definition
+;              Necessary conditions for the assignment of
+               _chemical_absolute_configuration are given by H. D. Flack and
+               G. Bernardinelli (1999, 2000).
+
+               Ref: Flack, H. D. & Bernardinelli, G. (1999). Acta Cryst. A55,
+                       908-915. (http://www.iucr.org/paper?sh0129)
+                    Flack, H. D. & Bernardinelli, G. (2000). J. Appl. Cryst.
+                       33, 1143-1148. (http://www.iucr.org/paper?ks0021)
+;
+
+data_chemical_compound_source
+    _name                      '_chemical_compound_source'
+    _category                    chemical
+    _type                        char
+    loop_ _example              'From Norilsk (USSR)'
+                                'Extracted from the bark of Cinchona Naturalis'
+    _definition
+;              Description of the source of the compound under study, or of the
+               parent  molecule if a simple derivative is studied. This includes
+               the place of  discovery for minerals or the actual source of a
+               natural product.
+;
+
+data_chemical_enantioexcess_bulk
+    _name                      '_chemical_enantioexcess_bulk'
+    _category                    chemical
+    _type                        numb
+    _type_conditions             esd
+    _enumeration_range           0.0:1.0
+    _units                       .
+    _units_detail                dimensionless
+    _definition
+;              The enantioexcess of the bulk material from which the
+               crystals were grown. A value of 0.0 indicates the
+               racemate. A value of 1.0 indicates that the compound
+               is enantiomerically pure.
+
+               Enantioexcess is defined in the IUPAC Recommendations
+               (Moss et al., 1996). The composition of the crystal
+               and bulk must be the same.
+
+               Ref: Moss G. P. et al. (1996). Basic Terminology of
+                    Stereochemistry. Pure Appl. Chem., 68, 2193-2222.
+                    http://www.chem.qmul.ac.uk/iupac/stereo/index.html
+;
+
+data_chemical_enantioexcess_bulk_technique
+    _name                      '_chemical_enantioexcess_bulk_technique'
+    _category                    chemical
+    _type                        char
+    loop_ _enumeration
+          _enumeration_detail    OA
+;                                     Enantioexcess determined by
+                                      measurement of the specific rotation
+                                      of the optical activity of the bulk
+                                      compound in solution.
+;
+                                 CD
+;                                     Enantioexcess determined by
+                                      measurement of the visible/near UV
+                                      circular dichroism spectrum of the
+                                      bulk compound in solution.
+;
+                                 EC
+;                                     Enantioexcess determined by
+                                      enantioselective chromatography of
+                                      the bulk compound in solution.
+;
+                                 other
+;                                     Enantioexcess determined by
+                                      a technique not included elsewhere
+                                      in this list.
+;
+    _definition
+;              The experimental technique used to determine the
+               enantioexcess of the bulk compound.
+;
+
+data_chemical_enantioexcess_crystal
+    _name                      '_chemical_enantioexcess_crystal'
+    _category                    chemical
+    _type                        numb
+    _type_conditions             esd
+    _enumeration_range           0.0:1.0
+    _units                       .
+    _units_detail                dimensionless
+    _definition
+;              The enantioexcess of the crystal used for the diffraction
+               study. A value of 0.0 indicates the racemate. A value of
+               1.0 indicates that the crystal is enantiomerically pure.
+
+               Enantioexcess is defined in the IUPAC Recommendations
+               (Moss et al., 1996).
+
+               Ref: Moss G. P. et al. (1996). Basic Terminology of
+                    Stereochemistry. Pure Appl. Chem., 68, 2193-2222.
+                    http://www.chem.qmul.ac.uk/iupac/stereo/index.html
+;
+
+
+data_chemical_enantioexcess_crystal_technique
+    _name                      '_chemical_enantioexcess_crystal_technique'
+    _category                    chemical
+    _type                        char
+    loop_ _enumeration
+          _enumeration_detail    CD
+;                                     Enantioexcess determined by
+                                      measurement of the visible/near UV
+                                      circular dichroism spectrum of the
+                                      crystal taken into solution.
+;
+                                 EC
+;                                     Enantioexcess determined by
+                                      enantioselective chromatography of
+                                      the crystal taken into solution.
+;
+                                 other
+;                                     Enantioexcess determined by
+                                      a technique not included elsewhere
+                                      in this list.
+;
+    _definition
+;              The experimental technique used to determine the
+               enantioexcess of the crystal.
+;
+
+data_chemical_identifier_inchi
+    _name                      '_chemical_identifier_inchi'
+    _category                    chemical
+    _type                        char
+    loop_ _example
+          _example_detail
+                               'InChI=1/C10H8/c1-2-6-10-8-4-3-7-9(10)5-1/h1-8H'
+                                 naphthalene
+    _definition
+;              The IUPAC International Chemical Identifier (InChI) is
+               a textual identifier  for chemical substances, designed
+               to provide a standard and human-readable way to
+               encode molecular information and to facilitate the
+               search for such information in databases and on the
+               web.
+
+               Ref: McNaught, A. (2006). Chem. Int. (IUPAC), 28 (6), 12-14.
+                    http://www.iupac.org/inchi/
+;
+
+data_chemical_identifier_inchi_key
+    _name                      '_chemical_identifier_inchi_key'
+    _category                    chemical
+    _type                        char
+    loop_ _example
+          _example_detail
+                               'InChIKey=OROGSEYTTFOCAN-DNJOTXNNBG'
+                                 codeine
+    _definition
+;              The InChIKey is a compact hashed version of the full InChI
+               (IUPAC International Chemical Identifier), designed to allow
+               for easy web searches of chemical compounds. See
+               http://www.iupac.org/inchi/
+;
+
+data_chemical_identifier_inchi_version
+    _name                      '_chemical_identifier_inchi_version'
+    _category                    chemical
+    _type                        char
+    _example                     1.03
+    _definition
+;              The version number of the InChI standard to which the
+               associated chemical identifier string applies.
+;
+
+data_chemical_melting_point
+    _name                      '_chemical_melting_point'
+    _category                    chemical
+    _type                        numb
+    _type_conditions             esd
+    _enumeration_range           0.0:
+    _units                       K
+    _units_detail                kelvin
+    _definition
+;              The temperature in kelvins at which the crystalline solid changes
+               to a liquid.
+;
+
+data_chemical_melting_point_
+    loop_  _name               '_chemical_melting_point_gt'
+                               '_chemical_melting_point_lt'
+    _category                    chemical
+    _type                        numb
+    loop_ _related_item
+          _related_function    '_chemical_melting_point'  alternate
+    _enumeration_range           0.0:
+    _units                       K
+    _units_detail                kelvin
+    _definition
+;              A temperature in kelvins below which (*_lt) or above
+               which (*_gt) the melting point (the temperature at which the
+               crystalline solid changes to a liquid) lies. These items allow a
+               range of temperatures to be given.
+
+               _chemical_melting_point should always be used in preference
+               to these items whenever possible.
+;
+
+data_chemical_name_common
+    _name                      '_chemical_name_common'
+    _category                    chemical
+    _type                        char
+    _example                    '1-bromoestradiol'
+    _definition
+;              Trivial name by which the compound is commonly known.
+;
+
+data_chemical_name_mineral
+    _name                      '_chemical_name_mineral'
+    _category                    chemical
+    _type                        char
+    _example                     chalcopyrite
+    _definition
+;              Mineral name accepted by the International Mineralogical
+               Association. Use only for natural minerals. See also
+               _chemical_compound_source.
+;
+
+data_chemical_name_structure_type
+    _name                      '_chemical_name_structure_type'
+    _category                    chemical
+    _type                        char
+    loop_ _example               perovskite   sphalerite    A15
+    _definition
+;              Commonly used structure-type name. Usually only applied to
+               minerals or inorganic compounds.
+;
+
+data_chemical_name_systematic
+    _name                      '_chemical_name_systematic'
+    _category                    chemical
+    _type                        char
+    _example                    '1-bromoestra-1,3,5(10)-triene-3,17\b-diol'
+    _definition
+;              IUPAC or Chemical Abstracts full name of the compound.
+;
+
+data_chemical_optical_rotation
+    _name                      '_chemical_optical_rotation'
+    _category                    chemical
+    _type                        char
+    _example                   '[\a]^25^~D~ = +108 (c = 3.42, CHCl~3~)'
+    _definition
+;              The optical rotation in solution of the compound is
+               specified in the following format:
+                    '[\a]^TEMP^~WAVE~ = SORT (c = CONC, SOLV)'
+               where:
+                 TEMP is the temperature of the measurement in degrees
+                      Celsius,
+                 WAVE is an indication of the wavelength of the light
+                      used for the measurement,
+                 CONC is the concentration of the solution given as the
+                      mass of the substance in g per 100 ml of solution,
+                 SORT is the signed value (preceded by a + or a - sign)
+                      of 100.\a/(l.c), where \a is the signed optical
+                      rotation in degrees measured in a cell of length l in
+                      dm and c is the value of CONC as defined above, and
+                 SOLV is the chemical formula of the solvent.
+;
+
+data_chemical_properties_biological
+    _name                      '_chemical_properties_biological'
+    _category                    chemical
+    _type                        char
+   loop_    _example
+;              diverse biological activities including use as a
+               laxative and strong antibacterial activity against
+               S. aureus and weak activity against
+               cyclooxygenase-1 (COX-1)
+;
+
+;              antibiotic activity against Bacillus subtilis
+               (ATCC 6051) but no significant activity against
+               Candida albicans (ATCC 14053), Aspergillus flavus
+               (NRRL 6541) and Fusarium verticillioides (NRRL
+               25457)
+;
+
+;              weakly potent lipoxygenase nonredox inhibitor
+;
+
+;              no influenza A virus sialidase inhibitory and
+               plaque reduction activities
+;
+
+;              low toxicity against Drosophila melanogaster
+;
+
+    _definition
+;              A free-text description of the biological properties of the
+               material.
+;
+
+data_chemical_properties_physical
+    _name                      '_chemical_properties_physical'
+    _category                    chemical
+    _type                        char
+  loop_  _example                air-sensitive
+                                 moisture-sensitive
+                                 hygroscopic
+                                 deliquescent
+                                 oxygen-sensitive
+                                 photo-sensitive
+                                 pyrophoric
+                                 semiconductor
+                                 'ferromagnetic at low temperature'
+                                 'paramagnetic and thermochromic'
+    _definition
+;              A free-text description of the physical properties of the
+               material.
+;
+
+data_chemical_temperature_decomposition
+    _name                      '_chemical_temperature_decomposition'
+    _category                    chemical
+    _type                        numb
+    _type_conditions             esd
+    _enumeration_range           0.0:
+    _units                       K
+    _units_detail                kelvin
+    _example                     350
+    _definition
+;              The temperature in kelvins at which the solid decomposes.
+;
+
+data_chemical_temperature_decomposition_
+    loop_ _name     '_chemical_temperature_decomposition_gt'
+                    '_chemical_temperature_decomposition_lt'
+    _category                   chemical
+    _type                       numb
+    _enumeration_range           0.0:
+    _units                      K
+    _units_detail               kelvin
+    loop_  _related_item
+           _related_function   '_chemical_temperature_decomposition' alternate
+    _example                    350
+    _definition
+;              A temperature in kelvins below which (*_lt) or above which
+               (*_gt) the solid is known to decompose. These items allow
+               a range of temperatures to be given.
+
+               _chemical_temperature_decomposition should always be used in
+               preference to these items whenever possible.
+;
+
+data_chemical_temperature_sublimation
+    _name                      '_chemical_temperature_sublimation'
+    _category                    chemical
+    _type                        numb
+    _type_conditions             esd
+    _enumeration_range           0.0:
+    _units                       K
+    _units_detail                kelvin
+    _example                     350
+    _definition
+;              The temperature in kelvins at which the solid sublimes.
+;
+
+data_chemical_temperature_sublimation_
+    loop_ _name                '_chemical_temperature_sublimation_gt'
+                               '_chemical_temperature_sublimation_lt'
+    _category                    chemical
+    _type                        numb
+    _enumeration_range           0.0:
+    _units                       K
+    _units_detail                kelvin
+    loop_ _related_item
+          _related_function      '_chemical_temperature_sublimation' alternate
+    _example                     350
+    _definition
+;             A temperature in kelvins below which (*_lt) or above which
+              (*_gt) the solid is known to sublime. These items allow a
+              range of temperatures to be given.
+
+              _chemical_temperature_sublimation should always be used in
+              preference to these items whenever possible.
+;
+
+
+########################
+## CHEMICAL_CONN_ATOM ##
+########################
+
+data_chemical_conn_atom_[]
+    _name                      '_chemical_conn_atom_[]'
+    _category                    category_overview
+    _type                        null
+    loop_ _example
+          _example_detail
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+;
+    loop_
+    _chemical_conn_atom_number
+    _chemical_conn_atom_type_symbol
+    _chemical_conn_atom_display_x
+    _chemical_conn_atom_display_y
+    _chemical_conn_atom_NCA
+    _chemical_conn_atom_NH
+        1   S    .39  .81   1   0
+        2   S    .39  .96   2   0
+        3   N    .14  .88   3   0
+        4   C    .33  .88   3   0
+        5   C    .11  .96   2   2
+        6   C    .03  .96   2   2
+        7   C    .03  .80   2   2
+        8   C    .11  .80   2   2
+        9   S    .54  .81   1   0
+        10  S    .54  .96   2   0
+        11  N    .80  .88   3   0
+        12  C    .60  .88   3   0
+        13  C    .84  .96   2   2
+        14  C    .91  .96   2   2
+        15  C    .91  .80   2   2
+        16  C    .84  .80   2   2
+;
+;
+    Example 1 - based on data set DPTD of Yamin, Suwandi, Fun, Sivakumar &
+                bin Shawkataly [Acta Cryst. (1996), C52, 951-953].
+;
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+    _definition
+;              Data items in the _chemical_conn_atom_ and _chemical_conn_bond_
+               categories record details about the two-dimensional (2D)
+               chemical structure of the molecular species. They allow a 2D
+               chemical diagram to be reconstructed for use in a publication or
+               in a database search for structural and substructural
+               relationships.
+
+               The _chemical_conn_atom_ data items provide information about
+               the chemical properties of the atoms in the structure. In cases
+               where crystallographic and molecular symmetry elements coincide,
+               they must also contain symmetry-generated atoms, so that the
+               _chemical_conn_atom_ and _chemical_conn_bond_ data items will
+               always describe a complete chemical entity.
+;
+
+data_chemical_conn_atom_charge
+    _name                      '_chemical_conn_atom_charge'
+    _category                    chemical_conn_atom
+    _type                        numb
+    _list                        yes
+    _list_reference            '_chemical_conn_atom_type_symbol'
+    _enumeration_range           -6:6
+    loop_ _example
+          _example_detail        1  'for an ammonium nitrogen'
+                                -1  'for a chloride ion'
+    _definition
+;               The net integer charge assigned to this atom. This is the
+               formal charge assignment normally found in chemical diagrams.
+;
+
+data_chemical_conn_atom_display_
+    loop_ _name                '_chemical_conn_atom_display_x'
+                               '_chemical_conn_atom_display_y'
+    _category                    chemical_conn_atom
+    _type                        numb
+    _list                        yes
+    _list_reference            '_chemical_conn_atom_type_symbol'
+    _enumeration_range           0.0:1.0
+    _definition
+;              The 2D Cartesian coordinates (x,y) of the position of this atom
+               in a recognizable chemical diagram. The coordinate origin is at
+               the lower left corner, the x axis is horizontal and the y axis is
+               vertical. The coordinates must lie in the range 0.0 to 1.0. These
+               coordinates can be obtained from projections of a suitable
+               uncluttered view of the molecular structure.
+;
+
+data_chemical_conn_atom_NCA
+    _name                      '_chemical_conn_atom_NCA'
+    _category                    chemical_conn_atom
+    _type                        numb
+    _list                        yes
+    _list_reference            '_chemical_conn_atom_type_symbol'
+    _enumeration_range           0:
+    _definition
+;              The number of connected atoms excluding terminal hydrogen atoms.
+;
+
+data_chemical_conn_atom_NH
+    _name                      '_chemical_conn_atom_NH'
+    _category                    chemical_conn_atom
+    _type                        numb
+    _list                        yes
+    _list_reference            '_chemical_conn_atom_type_symbol'
+    _enumeration_range           0:
+    _definition
+;              The total number of hydrogen atoms attached to this atom,
+               regardless of whether they are included in the refinement or
+               the _atom_site_ list. This number will be the same as
+               _atom_site_attached_hydrogens only if none of the hydrogen
+               atoms appear in the _atom_site_ list.
+;
+
+data_chemical_conn_atom_number
+    _name                      '_chemical_conn_atom_number'
+    _category                    chemical_conn_atom
+    _type                        numb
+    _list                        yes
+    loop_ _list_link_child     '_atom_site_chemical_conn_number'
+                               '_chemical_conn_bond_atom_1'
+                               '_chemical_conn_bond_atom_2'
+    _list_reference            '_chemical_conn_atom_type_symbol'
+    _enumeration_range           1:
+    _definition
+;              The chemical sequence number to be associated with this atom.
+;
+
+data_chemical_conn_atom_type_symbol
+    _name                      '_chemical_conn_atom_type_symbol'
+    _category                    chemical_conn_atom
+    _type                        char
+    _list                        yes
+    _list_mandatory              yes
+    _definition
+;              A code identifying the atom type. This code must match an
+               _atom_type_symbol code in the _atom_type_ list or be a
+               recognizable element symbol.
+;
+
+########################
+## CHEMICAL_CONN_BOND ##
+########################
+
+data_chemical_conn_bond_[]
+    _name                      '_chemical_conn_bond_[]'
+    _category                    category_overview
+    _type                        null
+    loop_ _example
+          _example_detail
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+;
+    loop_
+    _chemical_conn_bond_atom_1
+    _chemical_conn_bond_atom_2
+    _chemical_conn_bond_type
+       4     1     doub     4     3     sing
+       4     2     sing     5     3     sing
+       6     5     sing     7     6     sing
+       8     7     sing     8     3     sing
+       10    2     sing     12    9     doub
+       12    11    sing     12    10    sing
+       13    11    sing     14    13    sing
+       15    14    sing     16    15    sing
+       16    11    sing     17    5     sing
+       18    5     sing     19    6     sing
+       20    6     sing     21    7     sing
+       22    7     sing     23    8     sing
+       24    8     sing     25    13    sing
+       26    13    sing     27    14    sing
+       28    14    sing     29    15    sing
+       30    15    sing     31    16    sing
+       32    16    sing
+;
+;
+    Example 1 - based on data set DPTD of Yamin, Suwandi, Fun, Sivakumar &
+                bin Shawkataly [Acta Cryst. (1996), C52, 951-953].
+;
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+    _definition
+;              Data items in the _chemical_conn_atom_ and _chemical_conn_bond_
+               categories record details about the two-dimensional (2D)
+               chemical structure of the molecular species. They allow a 2D
+               chemical diagram to be reconstructed for use in a publication
+               or in a database search for structural and substructural
+               relationships.
+
+               The _chemical_conn_bond_ data items specify the connections
+               between the atoms in the _chemical_conn_atom_ list and the nature
+               of the chemical bond between these atoms.
+;
+
+data_chemical_conn_bond_atom_
+    loop_ _name                '_chemical_conn_bond_atom_1'
+                               '_chemical_conn_bond_atom_2'
+    _category                    chemical_conn_bond
+    _type                        numb
+    _list                        yes
+    _list_link_parent          '_chemical_conn_atom_number'
+    _enumeration_range           1:
+    _definition
+;              Atom numbers which must match with chemical sequence numbers
+               specified as _chemical_conn_atom_number values. These link the
+               bond connection to the chemical numbering and atom sites.
+;
+
+data_chemical_conn_bond_type
+    _name                      '_chemical_conn_bond_type'
+    _category                    chemical_conn_bond
+    _type                        char
+    _list                        yes
+    _list_reference            '_chemical_conn_bond_atom_'
+    loop_ _enumeration
+          _enumeration_detail    sing    'single bond'
+                                 doub    'double bond'
+                                 trip    'triple bond'
+                                 quad    'quadruple bond'
+                                 arom    'aromatic bond'
+                                 poly    'polymeric bond'
+                                 delo    'delocalized double bond'
+                                 pi      'pi bond'
+    _definition
+;              The chemical bond type associated with the connection between
+               the two sites _chemical_conn_bond_atom_1 and *_2.
+;
+
+######################
+## CHEMICAL_FORMULA ##
+######################
+
+data_chemical_formula_[]
+    _name                       '_chemical_formula_[]'
+    _category                     category_overview
+    _type                         null
+    loop_ _example
+          _example_detail
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+;
+    _chemical_formula_moiety            'C18 H25 N O3'
+    _chemical_formula_sum               'C18 H25 N O3'
+    _chemical_formula_weight            303.40
+;
+;
+    Example 1 - based on data set TOZ of Willis, Beckwith & Tozer
+                [Acta Cryst. (1991), C47, 2276-2277].
+;
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+;
+    _chemical_formula_iupac      '[Mo (C O)4 (C18 H33 P)2]'
+    _chemical_formula_moiety     'C40 H66 Mo O4 P2'
+    _chemical_formula_structural '((C O)4 (P (C6 H11)3)2)Mo'
+    _chemical_formula_sum         'C40 H66 Mo O4 P2'
+    _chemical_formula_weight      768.81
+;
+;
+    Example 2 - based on data set 9597gaus of Alyea, Ferguson & Kannan
+                [Acta Cryst. (1996), C52, 765-767].
+;
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+    _definition
+;              _chemical_formula_ items specify the composition and chemical
+              properties of the compound. The formula data items must agree
+              with those that specify the density, unit-cell and Z values.
+
+              The following rules apply to the construction of the data items
+              _chemical_formula_analytical, *_structural and *_sum. For the
+              data item *_moiety, the formula construction is broken up into
+              residues or moieties, i.e. groups of atoms that form a molecular
+              unit or molecular ion. The  rules given below apply within each
+              moiety but different requirements apply to the way that moieties
+              are connected (see _chemical_formula_moiety).
+
+              (1) Only recognized element symbols may be used.
+
+              (2) Each element symbol is followed by a 'count' number. A
+                 count of '1' may be omitted.
+
+              (3) A space or parenthesis must separate each cluster of (element
+                 symbol + count).
+
+              (4) Where a group of elements is enclosed in parentheses, the
+                 multiplier for the group must follow the closing parenthesis.
+                 That is, all element and group multipliers are assumed to be
+                 printed as subscripted numbers. (An exception to this rule
+                 exists for *_moiety formulae where pre- and post-multipliers
+                 are permitted for molecular units.)
+
+              (5) Unless the elements are ordered in a manner that corresponds
+                 to their chemical structure, as in
+                 _chemical_formula_structural, the order of the elements within
+                 any group or moiety depends on whether carbon is present or
+                 not. If carbon is present, the order should be: C, then H,
+                 then the other elements in alphabetical order of their
+                 symbol. If carbon is not present, the elements are listed
+                 purely in alphabetical order of their symbol. This is the
+                 'Hill' system used by Chemical Abstracts. This ordering is
+                 used in _chemical_formula_moiety and _chemical_formula_sum.
+;
+
+data_chemical_formula_analytical
+    _name                      '_chemical_formula_analytical'
+    _category                    chemical_formula
+    _type                        char
+    _example                    'Fe2.45(2)  Ni1.60(3)  S4'
+    _definition
+;              Formula determined by standard chemical analysis including trace
+               elements. See the _chemical_formula_[] category description for
+               rules for writing chemical formulae. Parentheses are used only
+               for standard uncertainties (e.s.d.'s).
+;
+
+data_chemical_formula_iupac
+    _name                      '_chemical_formula_iupac'
+    _category                    chemical_formula
+    _type                        char
+    _example                    '[Co Re (C12 H22 P)2 (C O)6].0.5C H3 O H'
+    _definition
+;              Formula expressed in conformance with IUPAC rules for inorganic
+               and metal-organic compounds where these conflict with the rules
+               for any other _chemical_formula_ entries. Typically used for
+               formatting a formula in accordance with journal rules. This
+               should appear in the data block in addition to the most
+               appropriate of the other _chemical_formula_ data names.
+
+               Ref: IUPAC (1990). Nomenclature of Inorganic Chemistry.
+                    Oxford: Blackwell Scientific Publications.
+;
+
+data_chemical_formula_moiety
+    _name                      '_chemical_formula_moiety'
+    _category                    chemical_formula
+    _type                        char
+    loop_ _example              'C7 H4 Cl Hg N O3 S'
+                                'C12 H17 N4 O S 1+, C6 H2 N3 O7 1-'
+                                'C12 H16 N2 O6, 5(H2 O1)'
+                                "(Cd 2+)3, (C6 N6 Cr 3-)2, 2(H2 O)"
+    _definition
+;              Formula with each discrete bonded residue or ion shown as a
+               separate moiety. See the _chemical_formula_[] category
+               description for rules for writing chemical formulae. In addition
+               to the general formulae requirements, the following rules apply:
+                  (1) Moieties are separated by commas ','.
+                  (2) The order of elements within a moiety follows general rule
+                     (5) in the _chemical_formula_[] category description.
+                  (3) Parentheses are not used within moieties but may surround
+                     a moiety. Parentheses may not be nested.
+                  (4) Charges should be placed at the end of the moiety. The
+                     charge '+' or '-' may be preceded by a numerical multiplier
+                     and should be separated from the last (element symbol +
+                     count) by a space. Pre- or post-multipliers may be used for
+                     individual moieties.
+;
+
+data_chemical_formula_structural
+    _name                      '_chemical_formula_structural'
+    _category                    chemical_formula
+    _type                        char
+    loop_ _example              'Ca ((Cl O3)2 O)2 (H2 O)6'
+                                '(Pt (N H3)2 (C5 H7 N3 O)2) (Cl O4)2'
+    _definition
+;              See the _chemical_formula_[] category description for the rules
+               for writing chemical formulae for inorganics, organometallics,
+               metal complexes etc., in which  bonded groups are preserved
+               as discrete entities within parentheses, with post-multipliers
+               as required. The order of the elements should give as much
+               information as possible about the chemical structure.
+               Parentheses may be used and nested as required. This formula
+               should correspond to the structure as actually reported,
+               i.e. trace elements not included in atom-type and atom-site
+               lists should not be included in this formula (see also
+               _chemical_formula_analytical).
+;
+
+data_chemical_formula_sum
+    _name                      '_chemical_formula_sum'
+    _category                    chemical_formula
+    _type                        char
+    loop_ _example              'C18 H19 N7 O8 S'
+    _definition
+;              See the _chemical_formula_[] category description for the rules
+               for writing chemical formulae in which all discrete bonded
+               residues and ions are summed over the constituent elements,
+               following the ordering given in general rule (5) in the
+               _chemical_formula_[] category description. Parentheses are not
+               normally used.
+;
+
+data_chemical_formula_weight
+    _name                      '_chemical_formula_weight'
+    _category                    chemical_formula
+    _type                        numb
+    _enumeration_range           1.0:
+    _units                       Da
+    _units_detail                dalton
+    _definition
+;              Formula mass in daltons. This mass should correspond to the
+               formulae given under _chemical_formula_structural, *_iupac,
+               *_moiety or *_sum and, together with the Z value and cell
+               parameters, should yield the density given as
+               _exptl_crystal_density_diffrn.
+;
+
+data_chemical_formula_weight_meas
+    _name                      '_chemical_formula_weight_meas'
+    _category                    chemical_formula
+    _type                        numb
+    _enumeration_range           1.0:
+    _units                       Da
+    _units_detail                dalton
+    _definition
+;              Formula mass in daltons measured by a non-diffraction experiment.
+;
+
+
+##############
+## CITATION ##
+##############
+
+data_citation_[]
+    _name                      '_citation_[]'
+    _category                    category_overview
+    _type                        null
+    loop_ _example
+          _example_detail
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+;
+    loop_
+    _citation_id
+    _citation_coordinate_linkage
+    _citation_title
+    _citation_country
+    _citation_page_first
+    _citation_page_last
+    _citation_year
+    _citation_journal_abbrev
+    _citation_journal_volume
+    _citation_journal_issue
+    _citation_journal_id_ASTM
+    _citation_journal_id_ISSN
+    _citation_book_title
+    _citation_book_publisher
+    _citation_book_id_ISBN
+    _citation_special_details
+      primary  yes
+    ; Crystallographic analysis of a complex between human
+      immunodeficiency virus type 1 protease and
+      acetyl-pepstatin at 2.0-Angstroms resolution.
+    ;
+      US  14209  14219  1990  'J. Biol. Chem.'  265  .
+      HBCHA3  0021-9258  .  .  .
+    ; The publication that directly relates to this coordinate
+      set.
+    ;
+      2  no
+    ; Three-dimensional structure of aspartyl-protease from
+      human immunodeficiency virus HIV-1.
+    ;
+      UK  615  619  1989  'Nature'  337  .
+      NATUAS  0028-0836  .  .  .
+    ; Determination of the structure of the unliganded enzyme.
+    ;
+      3 no
+    ; Crystallization of the aspartylprotease from human
+      immunodeficiency virus, HIV-1.
+    ;
+      US  1919  1921  1989  'J. Biol. Chem.'  264  .
+      HBCHA3  0021-9258  .  .  .
+    ; Crystallization of the unliganded enzyme.
+    ;
+;
+;
+    Example 1 - based on PDB entry 5HVP and laboratory records for the
+                structure corresponding to PDB entry 5HVP.
+;
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+    _definition
+;              Data items in the CITATION category record details about the
+               literature cited as being relevant to the contents of the data
+               block.
+;
+
+data_citation_abstract
+    _name                      '_citation_abstract'
+    _category                    citation
+    _type                        char
+    _list                        yes
+    _list_reference            '_citation_id'
+    _definition
+;              Abstract for the citation. This is used most when the
+               citation is extracted from a bibliographic database that
+               contains full text or abstract information.
+;
+
+data_citation_abstract_id_CAS
+    _name                      '_citation_abstract_id_CAS'
+    _category                    citation
+    _type                        char
+    _list                        yes
+    _list_reference            '_citation_id'
+    _definition
+;              The Chemical Abstracts Service (CAS) abstract identifier;
+               relevant for journal articles.
+;
+
+data_citation_book_id_ISBN
+    _name                      '_citation_book_id_ISBN'
+    _category                    citation
+    _type                        char
+    _list                        yes
+    _list_reference            '_citation_id'
+    _definition
+;              The International Standard Book Number (ISBN) code assigned to
+               the book cited;  relevant for books or book chapters.
+;
+
+data_citation_book_publisher
+    _name                      '_citation_book_publisher'
+    _category                    citation
+    _type                        char
+    _list                        yes
+    _list_reference            '_citation_id'
+    _example                    'John Wiley'
+    _definition
+;              The name of the publisher of the citation; relevant
+               for books or book chapters.
+;
+
+data_citation_book_publisher_city
+    _name                      '_citation_book_publisher_city'
+    _category                    citation
+    _type                        char
+    _list                        yes
+    _list_reference            '_citation_id'
+    _example                    'New York'
+    _definition
+;              The location of the publisher of the citation; relevant
+               for books or book chapters.
+;
+
+data_citation_book_title
+    _name                      '_citation_book_title'
+    _category                    citation
+    _type                        char
+    _list                        yes
+    _list_reference            '_citation_id'
+    _definition
+;              The title of the book in which the citation appeared;  relevant
+               for books or book chapters.
+;
+
+data_citation_coordinate_linkage
+    _name                      '_citation_coordinate_linkage'
+    _category                    citation
+    _type                        char
+    _list                        yes
+    _list_reference            '_citation_id'
+    loop_ _enumeration
+          _enumeration_detail    no  'citation unrelated to current coordinates'
+                                 n   'abbreviation for "no"'
+                                 yes 'citation related to current coordinates'
+                                 y   'abbreviation for "yes"'
+    _definition
+;              _citation_coordinate_linkage states whether or not this citation
+               is concerned with precisely the set of coordinates given in the
+               data block. If, for instance, the publication described the same
+               structure, but the coordinates had undergone further refinement
+               prior to creation of the data block, the value of this data item
+               would be 'no'.
+;
+
+data_citation_country
+    _name                      '_citation_country'
+    _category                    citation
+    _type                        char
+    _list                        yes
+    _list_reference            '_citation_id'
+    _definition
+;              The country of publication;  relevant for books and book
+               chapters.
+;
+
+data_citation_database_id_CSD
+    _name                      '_citation_database_id_CSD'
+    _category                    citation
+    _type                        char
+    _list                        yes
+    _list_reference            '_citation_id'
+    _example                     LEKKUH
+    _definition
+;           Identifier ('refcode') of the database record in the Cambridge
+            Structural Database that contains details of the cited structure.
+;
+
+data_citation_database_id_Medline
+    _name                      '_citation_database_id_Medline'
+    _category                    citation
+    _type                        char
+    _list                        yes
+    _list_reference            '_citation_id'
+    _example                     89064067
+    _definition
+;              Accession number used by Medline to categorize a specific
+               bibliographic entry.
+;
+
+data_citation_doi
+    _name                      '_citation_doi'
+    _category                    citation
+    _type                        char
+    _list                        yes
+    _list_reference            '_citation_id'
+    _example                    '10.5517/CC6V9DQ'
+    _definition
+;              The Digital Object Identifier (DOI) of the cited work.
+
+               A DOI is a unique character string identifying any
+               object of intellectual property. It provides a
+               persistent identifier for an object on a digital network
+               and permits the association of related current data in a
+               structured extensible way. A DOI is an implementation
+               of the Internet concepts of Uniform Resource Name and
+               Universal Resource Locator managed according to the
+               specifications of the International DOI Foundation (see
+               http://www.doi.org).
+;
+
+data_citation_id
+    _name                      '_citation_id'
+    _category                    citation
+    _type                        char
+    _list                        yes
+    _list_mandatory              yes
+    loop_ _list_link_child     '_citation_author_citation_id'
+                               '_citation_editor_citation_id'
+    loop_ _example               primary  1  2  3
+    _definition
+;              The value of _citation_id must uniquely identify a record in the
+               _citation_ list.
+
+               The _citation_id 'primary' should be used to indicate the
+               citation that the author(s) consider to be the most pertinent to
+               the contents of the data block.
+
+               Note that this item need not be a number;  it can be any unique
+               identifier.
+;
+
+data_citation_journal_abbrev
+    _name                      '_citation_journal_abbrev'
+    _category                    citation
+    _type                        char
+    _list                        yes
+    _list_reference            '_citation_id'
+    _example                    'J. Mol. Biol.'
+    _definition
+;              Abbreviated name of the journal cited as given in the Chemical
+               Abstracts Service Source Index.
+;
+
+data_citation_journal_full
+    _name                      '_citation_journal_full'
+    _category                    citation
+    _type                        char
+    _list                        yes
+    _list_reference            '_citation_id'
+    _example                    'Journal of Molecular Biology'
+    _definition
+;              Full name of the journal cited; relevant for journal articles.
+;
+
+data_citation_journal_id_ASTM
+    _name                      '_citation_journal_id_ASTM'
+    _category                    citation
+    _type                        char
+    _list                        yes
+    _list_reference            '_citation_id'
+    _definition
+;              The American Society for Testing and Materials (ASTM) code
+               assigned to the journal cited (also referred to as the CODEN
+               designator of the Chemical Abstracts Service); relevant for
+               journal articles.
+;
+
+data_citation_journal_id_CSD
+    _name                      '_citation_journal_id_CSD'
+    _category                    citation
+    _type                        char
+    _list                        yes
+    _list_reference            '_citation_id'
+    _example                    '0070'
+    _definition
+;              The Cambridge Structural Database (CSD) code assigned to the
+               journal cited; relevant for journal articles. This is also the
+               system used at the Protein Data Bank (PDB).
+;
+
+data_citation_journal_id_ISSN
+    _name                      '_citation_journal_id_ISSN'
+    _category                    citation
+    _type                        char
+    _list                        yes
+    _list_reference            '_citation_id'
+    _definition
+;              The International Standard Serial Number (ISSN) code assigned to
+               the journal cited;  relevant for journal articles.
+;
+
+data_citation_journal_issue
+    _name                      '_citation_journal_issue'
+    _category                    citation
+    _type                        char
+    _list                        yes
+    _list_reference            '_citation_id'
+    _example                     2
+    _definition
+;              Issue number of the journal cited;  relevant for journal
+               articles.
+;
+
+data_citation_journal_volume
+    _name                      '_citation_journal_volume'
+    _category                    citation
+    _type                        char
+    _list                        yes
+    _list_reference            '_citation_id'
+    _example                     174
+    _definition
+;              Volume number of the journal cited;  relevant for journal
+               articles.
+;
+
+data_citation_language
+    _name                      '_citation_language'
+    _category                    citation
+    _type                        char
+    _list                        yes
+    _list_reference            '_citation_id'
+    _example                     German
+    _definition
+;              Language in which the cited article is written.
+;
+
+data_citation_page_
+    loop_ _name                '_citation_page_first'
+                               '_citation_page_last'
+    _category                    citation
+    _type                        char
+    _list                        yes
+    _list_reference            '_citation_id'
+    _definition
+;              The first and last pages of the citation;  relevant for
+               journal articles, books and book chapters.
+;
+
+data_citation_publisher
+    _name                      '_citation_publisher'
+    _category                    citation
+    _type                        char
+    _list                        yes
+    _list_reference            '_citation_id'
+    _example                    'Cambridge Crystallographic Data Centre'
+    _definition
+;              The name of the publisher of the cited work. This
+               should be used for citations of journal articles or
+               datasets (in the latter case the publisher could be a
+               curated database). For books or book chapters use
+               _citation_book_publisher.
+;
+
+data_citation_special_details
+    _name                      '_citation_special_details'
+    _category                    citation
+    _type                        char
+    _list                        yes
+    _list_reference            '_citation_id'
+    loop_ _example
+;                       citation relates to this precise coordinate set
+;
+;                       citation relates to earlier low-resolution structure
+;
+;                       citation relates to further refinement of structure
+                        reported in citation 2
+;
+    _definition
+;              A description of special aspects of the relationship
+               of the contents of the data block to the literature item cited.
+;
+
+data_citation_title
+    _name                      '_citation_title'
+    _category                    citation
+    _type                        char
+    _list                        yes
+    _list_reference            '_citation_id'
+    _example
+;                       Structure of diferric duck ovotransferrin at 2.35 \%A
+                        resolution.
+;
+    _definition
+;              The title of the citation;  relevant for journal articles, books
+               and book chapters.
+;
+
+data_citation_year
+    _name                      '_citation_year'
+    _category                    citation
+    _type                        numb
+    _list                        yes
+    _list_reference            '_citation_id'
+    _example                     1984
+    _definition
+;              The year of the citation;  relevant for journal articles, books
+               and book chapters.
+;
+
+#####################
+## CITATION_AUTHOR ##
+#####################
+
+data_citation_author_[]
+    _name                      '_citation_author_[]'
+    _category                    category_overview
+    _type                        null
+    loop_ _example
+          _example_detail
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+;
+    loop_
+    _citation_author_citation_id
+    _citation_author_name
+      primary  'Fitzgerald, P.M.D.'
+      primary  'McKeever, B.M.'
+      primary  'Van Middlesworth, J.F.'
+      primary  'Springer, J.P.'
+      primary  'Heimbach, J.C.'
+      primary  'Leu, C.-T.'
+      primary  'Herber, W.K.'
+      primary  'Dixon, R.A.F.'
+      primary  'Darke, P.L.'
+      2        'Navia, M.A.'
+      2        'Fitzgerald, P.M.D.'
+      2        'McKeever, B.M.'
+      2        'Leu, C.-T.'
+      2        'Heimbach, J.C.'
+      2        'Herber, W.K.'
+      2        'Sigal, I.S.'
+      2        'Darke, P.L.'
+      2        'Springer, J.P.'
+      3        'McKeever, B.M.'
+      3        'Navia, M.A.'
+      3        'Fitzgerald, P.M.D.'
+      3        'Springer, J.P.'
+      3        'Leu, C.-T.'
+      3        'Heimbach, J.C.'
+      3        'Herber, W.K.'
+      3        'Sigal, I.S.'
+      3        'Darke, P.L.'
+;
+;
+    Example 1 - based on PDB entry 5HVP and laboratory records for the
+                structure corresponding to PDB entry 5HVP.
+;
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+    _definition
+;              Data items in the CITATION_AUTHOR category record details
+               about the authors associated with the citations in the
+               _citation_ list.
+;
+
+data_citation_author_citation_id
+    _name                      '_citation_author_citation_id'
+    _category                    citation_author
+    _type                        char
+    _list                        yes
+    _list_mandatory              yes
+    _list_link_parent          '_citation_id'
+    _definition
+;              The value of _citation_author_citation_id must match an
+               identifier specified by _citation_id in the _citation_ list.
+;
+
+data_citation_author_name
+    _name                      '_citation_author_name'
+    _category                    citation_author
+    _type                        char
+    _list                        yes
+    _list_mandatory              yes
+    loop_ _example             'Bleary, Percival R.'
+                               "O'Neil, F.K."
+                               'Van den Bossche, G.'
+                               'Yang, D.-L.'
+                               'Simonov, Yu.A.'
+                               'M\"uller, H.A.'
+                               'Ross II, C.R.'
+    _definition
+;              Name of an author of the citation; relevant for journal
+               articles, books and book chapters.
+
+               The family name(s), followed by a comma and including any
+               dynastic components, precedes the first name(s) or initial(s).
+;
+
+data_citation_author_ordinal
+    _name                      '_citation_author_ordinal'
+    _category                    citation_author
+    _type                        char
+    _list                        yes
+    _definition
+;              This data name defines the order of the author's name in the
+               list of authors of a citation.
+;
+
+#####################
+## CITATION_EDITOR ##
+#####################
+
+data_citation_editor_[]
+    _name                      '_citation_editor_[]'
+    _category                    category_overview
+    _type                        null
+    loop_ _example
+          _example_detail
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+;
+    loop_
+    _citation_editor_citation_id
+    _citation_editor_name
+      5        'McKeever, B.M.'
+      5        'Navia, M.A.'
+      5        'Fitzgerald, P.M.D.'
+      5        'Springer, J.P.'
+;
+;
+    Example 1 - hypothetical example.
+;
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+    _definition
+;              Data items in the CITATION_EDITOR category record details
+               about the editor associated with the book or book chapter
+               citations in the _citation_ list.
+;
+
+data_citation_editor_citation_id
+    _name                      '_citation_editor_citation_id'
+    _category                    citation_editor
+    _type                        char
+    _list                        yes
+    _list_mandatory              yes
+    _list_link_parent          '_citation_id'
+    _definition
+;              The value of _citation_editor_citation_id must match an
+               identifier specified by _citation_id in the _citation_ list.
+;
+
+data_citation_editor_name
+    _name                      '_citation_editor_name'
+    _category                    citation_editor
+    _type                        char
+    _list                        yes
+    _list_mandatory              yes
+    loop_ _example             'Bleary, Percival R.'
+                               "O'Neil, F.K."
+                               'Van den Bossche, G.'
+                               'Yang, D.-L.'
+                               'Simonov, Yu.A.'
+                               'M\"uller, H.A.'
+                               'Ross II, C.R.'
+    _definition
+;              Name of an editor of the citation;  relevant for books and
+               book chapters.
+
+               The family name(s), followed by a comma and including any
+               dynastic components, precedes the first name(s) or initial(s).
+;
+
+data_citation_editor_ordinal
+    _name                      '_citation_editor_ordinal'
+    _category                    citation_editor
+    _type                        char
+    _list                        yes
+    _definition
+;              This data name defines the order of the editor's name in the
+               list of editors of a citation.
+;
+
+###############
+## COMPUTING ##
+###############
+
+data_computing_[]
+    _name                      '_computing_[]'
+    _category                    category_overview
+    _type                        null
+    loop_ _example
+          _example_detail
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+;
+    _computing_data_collection       'CAD-4 (Enraf-Nonius, 1989)'
+    _computing_cell_refinement       'CAD-4 (Enraf-Nonius, 1989)'
+    _computing_data_reduction        'CFEO (Solans, 1978)'
+    _computing_structure_solution    'SHELXS86 (Sheldrick, 1990)'
+    _computing_structure_refinement  'SHELXL93 (Sheldrick, 1993)'
+    _computing_molecular_graphics    'ORTEPII (Johnson, 1976)'
+    _computing_publication_material  'PARST (Nardelli, 1983)'
+;
+;
+    Example 1 - Rodr\'iguez-Romero, Ruiz-P\'erez & Solans
+                [Acta Cryst. (1996), C52, 1415-1417].
+;
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+    _definition
+;              Data items in the COMPUTING category record details about the
+               computer programs used in the crystal structure analysis.
+;
+
+data_computing_
+    loop_ _name                '_computing_cell_refinement'
+                               '_computing_data_collection'
+                               '_computing_data_reduction'
+                               '_computing_molecular_graphics'
+                               '_computing_publication_material'
+                               '_computing_structure_refinement'
+                               '_computing_structure_solution'
+    _category                    computing
+    _type                        char
+    loop_ _example              'CAD-4 (Enraf-Nonius, 1989)'
+                                'DIFDAT, SORTRF, ADDREF (Hall & Stewart, 1990)'
+                                'FRODO (Jones, 1986), ORTEP (Johnson, 1965)'
+                                'CRYSTALS (Watkin, 1988)'
+                                'SHELX85 (Sheldrick, 1985)'
+    _definition
+;              Software used in the processing of the data. Give the program
+               or package name and a brief reference.
+;
+
+##############
+## DATABASE ##
+##############
+
+data_database_[]
+    _name                      '_database_[]'
+    _category                    category_overview
+    _type                        null
+    loop_ _example
+          _example_detail
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+;
+    _database_code_CSD                  'VOBYUG'
+;
+;
+    Example 1 - based on data set TOZ of Willis, Beckwith & Tozer
+                [Acta Cryst. (1991), C47, 2276-2277].
+;
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+    _definition
+;              Data items in the DATABASE category record details about the
+               database identifiers of the data block.
+
+               These data items are assigned by database managers and should
+               only appear in a CIF if they originate from that source.
+;
+
+data_database_code_
+    loop_ _name                '_database_code_CAS'
+                               '_database_code_COD'
+                               '_database_code_CSD'
+                               '_database_code_ICSD'
+                               '_database_code_MDF'
+                               '_database_code_NBS'
+                               '_database_code_PDB'
+                               '_database_code_PDF'
+    _category                    database
+    _type                        char
+    _definition
+;              The codes are assigned by databases: Chemical Abstracts;
+               Crystallography Open Database (COD);
+               Cambridge Structural Database (organic and metal-organic
+               compounds); Inorganic Crystal Structure Database; Metals
+               Data File (metal structures); NBS (NIST) Crystal Data
+               Database (lattice parameters); Protein Data Bank; and the
+               Powder Diffraction File (JCPDS/ICDD).
+;
+
+data_database_code_depnum_ccdc_archive
+    _name                      '_database_code_depnum_ccdc_archive'
+    _category                    database
+    _type                        char
+    _definition
+;              Deposition numbers assigned by the Cambridge Crystallographic
+               Data Centre (CCDC) to files containing structural information
+               archived by the CCDC.
+;
+
+data_database_code_depnum_ccdc_fiz
+    _name                      '_database_code_depnum_ccdc_fiz'
+    _category                    database
+    _type                        char
+    _definition
+;              Deposition numbers assigned by the Fachinformationszentrum
+               Karlsruhe (FIZ) to files containing structural information
+               archived by the Cambridge Crystallographic Data Centre (CCDC).
+;
+
+data_database_code_depnum_ccdc_journal
+    _name                      '_database_code_depnum_ccdc_journal'
+    _category                    database
+    _type                        char
+    _definition
+;              Deposition numbers assigned by various journals to files
+               containing structural information archived by the Cambridge
+               Crystallographic Data Centre (CCDC).
+;
+
+data_database_CSD_history
+    _name                      '_database_CSD_history'
+    _category                    database
+    _type                        char
+    _definition
+;              A history of changes made by the Cambridge Crystallographic Data
+               Centre and incorporated into the Cambridge Structural Database
+               (CSD).
+;
+
+data_database_dataset_doi
+    _name                      '_database_dataset_doi'
+    _category                    database
+    _type                        char
+    _example                     '10.2210/pdb4hhb/pdb'
+    _definition
+;              The digital object identifier (DOI) registered to identify
+               a data set publication associated with the structure
+               described in the current datablock. This should be used
+               for a dataset obtained from a curated database such as
+               CSD or PDB.
+
+               A DOI is a unique character string identifying any
+               object of intellectual property. It provides a
+               persistent identifier for an object on a digital network
+               and permits the association of related current data in a
+               structured extensible way. A DOI is an implementation
+               of the Internet concepts of Uniform Resource Name and
+               Universal Resource Locator managed according to the
+               specifications of the International DOI Foundation (see
+               http://www.doi.org).
+;
+
+data_database_journal_
+    loop_ _name                '_database_journal_ASTM'
+                               '_database_journal_CSD'
+    _category                    database
+    _type                        char
+    _definition
+;              The ASTM CODEN designator for a journal as given in the
+               Chemical Source List maintained by the Chemical Abstracts
+               Service, and the journal code used in the Cambridge Structural
+               Database.
+;
+
+############
+## DIFFRN ##
+############
+
+data_diffrn_[]
+    _name                      '_diffrn_[]'
+    _category                    category_overview
+    _type                        null
+    loop_ _example
+          _example_detail
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+;
+    _diffrn_special_details
+    ; \q scan width (1.0 + 0.14tan\q)\%, \q scan rate
+      1.2\% min^-1^. Background counts for 5 s on each side
+      every scan.
+    ;
+
+    _diffrn_ambient_temperature         293
+;
+;
+    Example 1 - based on data set TOZ of Willis, Beckwith & Tozer
+                [Acta Cryst. (1991), C47, 2276-2277].
+;
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+    _definition
+;              Data items in the DIFFRN category record details about the
+               intensity measurements.
+;
+
+data_diffrn_ambient_environment
+    _name                      '_diffrn_ambient_environment'
+    _category                    diffrn
+    _type                        char
+    loop_ _example               He      vacuum     'mother liquor'
+    _definition
+;              The gas or liquid surrounding the sample, if not air.
+;
+
+data_diffrn_ambient_pressure
+    _name                      '_diffrn_ambient_pressure'
+    _category                    diffrn
+    _type                        numb
+    _type_conditions             esd
+    _enumeration_range           0.0:
+    _units                       kPa
+    _units_detail                kilopascal
+    _definition
+;              The mean hydrostatic pressure in kilopascals at which the
+               intensities were measured.
+;
+
+data_diffrn_ambient_pressure_
+    loop_ _name                '_diffrn_ambient_pressure_gt'
+                               '_diffrn_ambient_pressure_lt'
+    _category                    diffrn
+    _type                        numb
+    loop_ _related_item
+          _related_function    '_diffrn_ambient_pressure'  alternate
+    _enumeration_range           0.0:
+    _units                       kPa
+    _units_detail                kilopascal
+    _definition
+;              The mean hydrostatic pressure in kilopascals above which (*_gt)
+               or below which (*_lt) the intensities were measured. These
+               items allow for a pressure range to be given.
+
+               _diffrn_ambient_pressure should always be used in
+               preference to these items whenever possible.
+;
+
+data_diffrn_ambient_temperature
+    _name                      '_diffrn_ambient_temperature'
+    _category                    diffrn
+    _type                        numb
+    _type_conditions             esd
+    _enumeration_range           0.0:
+    _units                       K
+    _units_detail                kelvin
+    _definition
+;             The mean temperature in kelvins at which the intensities
+              were measured.
+;
+
+data_diffrn_ambient_temperature_
+    loop_  _name               '_diffrn_ambient_temperature_gt'
+                               '_diffrn_ambient_temperature_lt'
+    _category                    diffrn
+    _type                        numb
+    loop_ _related_item
+          _related_function    '_diffrn_ambient_temperature'  alternate
+    _enumeration_range           0.0:
+    _units                       K
+    _units_detail                kelvin
+    _definition
+;             The mean temperature in kelvins above which (*_gt) or below
+              which (*_lt) the intensities were measured.  These items allow
+              a range of temperatures to be given.
+
+              _diffrn_ambient_temperature should always be used in preference
+              to these items whenever possible.
+;
+
+data_diffrn_crystal_treatment
+    _name                      '_diffrn_crystal_treatment'
+    _category                    diffrn
+    _type                        char
+    loop_ _example             'equilibrated in hutch for 24 hours'
+                               'flash frozen in liquid nitrogen'
+                               'slow cooled with direct air stream'
+    _definition
+;              Remarks about how the crystal was treated prior to the intensity
+               measurements. Particularly relevant when intensities were
+               measured at low temperature.
+;
+
+data_diffrn_measured_fraction_theta_full
+     _name               '_diffrn_measured_fraction_theta_full'
+     _category             diffrn
+     _type                 numb
+     _enumeration_range    0:1.0
+     _definition
+;         Fraction of unique (symmetry-independent) reflections measured
+          out to _diffrn_reflns_theta_full.
+;
+
+data_diffrn_measured_fraction_theta_max
+     _name               '_diffrn_measured_fraction_theta_max'
+     _category             diffrn
+     _type                 numb
+     _enumeration_range    0:1.0
+     _definition
+;         Fraction of unique (symmetry-independent) reflections measured
+          out to _diffrn_reflns_theta_max.
+;
+
+data_diffrn_special_details
+    _name                      '_diffrn_special_details'
+    _category                    diffrn
+    _type                        char
+    _example
+;              The results may not be entirely reliable
+               as the measurement was made during a heat
+               wave when the air-conditioning had failed.
+;
+    _definition
+;              Special details of the intensity-measurement process. Should
+               include information about source instability, crystal motion,
+               degradation and so on.
+;
+
+data_diffrn_symmetry_description
+    _name                      '_diffrn_symmetry_description'
+    _category                    diffrn
+    _type                        char
+    _definition
+;              Observed diffraction point symmetry, systematic absences and
+               possible space group(s) or superspace group(s) compatible with
+               these.
+;
+
+#######################
+## DIFFRN_ATTENUATOR ##
+#######################
+
+data_diffrn_attenuator_[]
+    _name                      '_diffrn_attenuator_[]'
+    _category                    category_overview
+    _type                        null
+    loop_ _example
+          _example_detail
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+;
+      loop_
+        _diffrn_attenuator_code
+        _diffrn_attenuator_scale
+            0         1.00
+            1        16.97
+            2        33.89
+;
+;
+    Example 1 - hypothetical example.
+;
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+    _definition
+;              Data items in the DIFFRN_ATTENUATOR category record details
+               about the diffraction attenuator scales employed.
+;
+
+data_diffrn_attenuator_code
+    _name                      '_diffrn_attenuator_code'
+    _category                    diffrn_attenuator
+    _type                        char
+    _list                        yes
+    _list_mandatory              yes
+    _list_link_child           '_diffrn_refln_attenuator_code'
+    _definition
+;              A code associated with a particular attenuator setting. This code
+               is referenced by the _diffrn_refln_attenuator_code which is
+               stored with the intensities. See _diffrn_attenuator_scale.
+;
+
+data_diffrn_attenuator_material
+    _name                      '_diffrn_attenuator_material'
+    _category                    diffrn_attenuator
+    _type                        char
+    _list                        yes
+    _list_reference            '_diffrn_attenuator_code'
+    _definition
+;              Material from which the attenuator is made.
+;
+
+data_diffrn_attenuator_scale
+    _name                      '_diffrn_attenuator_scale'
+    _category                    diffrn_attenuator
+    _type                        numb
+    _list                        yes
+    _list_reference            '_diffrn_attenuator_code'
+    _enumeration_range           1.0:
+    _definition
+;               The scale factor applied when an intensity measurement is
+                reduced by an attenuator identified by _diffrn_attenuator_code.
+                The measured intensity must be multiplied by this scale to
+                convert it to the same scale as unattenuated intensities.
+;
+
+#####################
+## DIFFRN_DETECTOR ##
+#####################
+
+data_diffrn_detector_[]
+    _name                      '_diffrn_detector_[]'
+    _category                    category_overview
+    _type                        null
+    loop_ _example
+          _example_detail
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+;
+    _diffrn_detector                    'multiwire'
+    _diffrn_detector_type               'Siemens'
+;
+;
+    Example 1 - based on PDB entry 5HVP and laboratory records for the
+                structure corresponding to PDB entry 5HVP.
+;
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+    _definition
+;              Data items in the DIFFRN_DETECTOR category describe the
+               detector used to measure the scattered radiation, including
+               any analyser and post-sample collimation.
+;
+
+data_diffrn_detector
+    _name                      '_diffrn_detector'
+    _category                    diffrn_detector
+    _type                        char
+    loop_ _related_item
+          _related_function    '_diffrn_radiation_detector'  alternate
+    loop_
+    _example                   'photographic film'
+                               'scintillation counter'
+                               'CCD plate'
+                               'BF~3~ counter'
+    _definition
+;              The general class of the radiation detector.
+;
+
+data_diffrn_detector_area_resol_mean
+    _name                      '_diffrn_detector_area_resol_mean'
+    _category                    diffrn_detector
+    _type                        numb
+    _enumeration_range           0.0:
+    _units                       pixel/mm
+    _units_detail              'pixel per millimetre'
+    _definition
+;              The resolution of an area detector, in pixels/mm.
+;
+
+data_diffrn_detector_details
+    _name                      '_diffrn_detector_details'
+    _category                    diffrn_detector
+    _type                        char
+    _definition
+;              A description of special aspects of the radiation detector.
+;
+
+data_diffrn_detector_dtime
+    _name                      '_diffrn_detector_dtime'
+    _category                    diffrn_detector
+    loop_ _related_item
+          _related_function    '_diffrn_radiation_detector_dtime'  alternate
+    _type                        numb
+    _enumeration_range           0.0:
+    _units                       \ms
+    _units_detail                microsecond
+    _definition
+;              The deadtime in microseconds of the detector used to measure
+               the diffraction intensities.
+;
+
+data_diffrn_detector_type
+    _name                      '_diffrn_detector_type'
+    _category                    diffrn_detector
+    _type                        char
+    _definition
+;              The make, model or name of the detector device used.
+;
+
+data_diffrn_radiation_detector
+    _name                      '_diffrn_radiation_detector'
+    _category                    diffrn_detector
+    _type                        char
+    loop_ _related_item
+          _related_function    '_diffrn_detector'  replace
+    _definition
+;              The detector used to measure the diffraction intensities.
+;
+
+data_diffrn_radiation_detector_dtime
+    _name                      '_diffrn_radiation_detector_dtime'
+    _category                    diffrn_detector
+    _type                        numb
+    _enumeration_range           0.0:
+    _units                       \ms
+    _units_detail                microsecond
+    loop_ _related_item
+          _related_function    '_diffrn_detector_dtime'  replace
+    _definition
+;              The deadtime in microseconds of the detector used to measure
+               the diffraction intensities.
+;
+
+########################
+## DIFFRN_MEASUREMENT ##
+########################
+
+data_diffrn_measurement_[]
+    _name                      '_diffrn_measurement_[]'
+    _category                    category_overview
+    _type                        null
+    loop_ _example
+          _example_detail
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+;
+    _diffrn_measurement_device_type
+                              'Philips PW1100/20 diffractometer'
+    _diffrn_measurement_method          \q/2\q
+;
+;
+    Example 1 - based on data set TOZ of Willis, Beckwith & Tozer
+                [Acta Cryst. (1991), C47, 2276-2277].
+;
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+    _definition
+;              Data items in the DIFFRN_MEASUREMENT category refer to the
+               mounting of the sample and to the goniometer on which it is
+               mounted.
+;
+
+data_diffrn_measurement_details
+    _name                      '_diffrn_measurement_details'
+    _category                    diffrn_measurement
+    _type                        char
+    _example                   '440 frames of 0.25\%'
+    _definition
+;              A description of special aspects of the intensity measurement.
+;
+
+data_diffrn_measurement_device
+    _name                      '_diffrn_measurement_device'
+    _category                    diffrn_measurement
+    _type                        char
+    loop_
+    _example                    'three-circle diffractometer'
+                                'four-circle diffractometer'
+                                '\k-geometry diffractometer'
+                                'oscillation camera'
+                                'precession camera'
+    _definition
+;              The general class of goniometer or device used to support
+               and orient the specimen.
+;
+
+data_diffrn_measurement_device_details
+    _name                      '_diffrn_measurement_device_details'
+    _category                    diffrn_measurement
+    _type                        char
+    _example
+;                                commercial goniometer modified locally to
+                                 allow for 90\% \t arc
+;
+    _definition
+;              A description of special aspects of the device used to measure
+               the diffraction intensities.
+;
+
+data_diffrn_measurement_device_type
+    _name                      '_diffrn_measurement_device_type'
+    _category                    diffrn_measurement
+    _type                        char
+    _definition
+;              The make, model or name of the measurement device
+               (goniometer) used.
+;
+
+data_diffrn_measurement_method
+    _name                      '_diffrn_measurement_method'
+    _category                    diffrn_measurement
+    _type                        char
+    _example                    'profile data from \q/2\q scans'
+    _definition
+;              Method used to measure the intensities.
+;
+
+data_diffrn_measurement_specimen_support
+    _name                      '_diffrn_measurement_specimen_support'
+    _category                    diffrn_measurement
+    _type                        char
+    loop_ _example             'glass capillary'
+                               'quartz capillary'
+                               'fiber'
+                               'metal loop'
+    _definition
+;              The physical device used to support the crystal during data
+               collection.
+;
+
+##########################
+## DIFFRN_ORIENT_MATRIX ##
+##########################
+
+data_diffrn_orient_matrix_[]
+    _name                      '_diffrn_orient_matrix_[]'
+    _category                    category_overview
+    _type                        null
+    loop_ _example
+          _example_detail
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+;
+    _diffrn_orient_matrix_UB_11           -0.04170
+    _diffrn_orient_matrix_UB_12           -0.01429
+    _diffrn_orient_matrix_UB_13           -0.02226
+    _diffrn_orient_matrix_UB_21           -0.00380
+    _diffrn_orient_matrix_UB_22           -0.05578
+    _diffrn_orient_matrix_UB_23           -0.05048
+    _diffrn_orient_matrix_UB_31            0.00587
+    _diffrn_orient_matrix_UB_32           -0.13766
+    _diffrn_orient_matrix_UB_33            0.02277
+
+    _diffrn_orient_matrix_type 'TEXSAN convention (MSC, 1989)'
+;
+;
+    Example 1 - data set n-alkylation_C-4 of Hussain, Fleming, Norman & Chang
+                [Acta Cryst. (1996), C52, 1010-1012].
+;
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+    _definition
+;              Data items in the DIFFRN_ORIENT_MATRIX category record details
+               about the orientation matrix used in the measurement of the
+               diffraction intensities.
+;
+
+data_diffrn_orient_matrix_type
+    _name                      '_diffrn_orient_matrix_type'
+    _category                    diffrn_orient_matrix
+    _type                        char
+    _definition
+;              A description of the orientation matrix type and how it should
+               be applied to define the orientation of the crystal precisely
+               with respect to the diffractometer axes.
+;
+
+data_diffrn_orient_matrix_UB_
+    loop_ _name                '_diffrn_orient_matrix_UB_11'
+                               '_diffrn_orient_matrix_UB_12'
+                               '_diffrn_orient_matrix_UB_13'
+                               '_diffrn_orient_matrix_UB_21'
+                               '_diffrn_orient_matrix_UB_22'
+                               '_diffrn_orient_matrix_UB_23'
+                               '_diffrn_orient_matrix_UB_31'
+                               '_diffrn_orient_matrix_UB_32'
+                               '_diffrn_orient_matrix_UB_33'
+    _category                    diffrn_orient_matrix
+    _type                        numb
+    _definition
+;              The elements of the diffractometer orientation matrix. These
+               define the dimensions of the reciprocal cell and its orientation
+               to the local diffractometer axes. See _diffrn_orient_matrix_type.
+;
+
+#########################
+## DIFFRN_ORIENT_REFLN ##
+#########################
+
+data_diffrn_orient_refln_[]
+    _name                      '_diffrn_orient_refln_[]'
+    _category                    category_overview
+    _type                        null
+    loop_ _example
+          _example_detail
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+;
+    loop_
+    _diffrn_orient_refln_index_h
+    _diffrn_orient_refln_index_k
+    _diffrn_orient_refln_index_l
+    _diffrn_orient_refln_angle_theta
+    _diffrn_orient_refln_angle_phi
+    _diffrn_orient_refln_angle_omega
+    _diffrn_orient_refln_angle_kappa
+      -3   2   3    7.35   44.74   2.62    17.53
+      -4   1   0    9.26   83.27   8.06     5.79
+       0   0   6    5.85  -43.93 -25.36    86.20
+       2   1   3    7.36  -57.87   6.26     5.42
+       0   0  -6    5.85 -161.59  36.96   -86.79
+      -3   1   0    6.74   80.28   5.87     2.60
+       2   0   3    5.86  -76.86  -0.17    21.34
+       0   0  12   11.78  -44.02 -19.51    86.41
+       0   0 -12   11.78 -161.67  42.81   -86.61
+      -5   1   0   11.75   86.24   9.16     7.44
+       0   4   6   11.82  -19.82  10.45     4.19
+       5   0   6   14.13  -77.28  10.17    15.34
+       8   0   0   20.79  -77.08  25.30   -13.96
+;
+;
+    Example 1 - typical output listing from an Enraf-Nonius CAD-4
+    diffractometer.
+;
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+    _definition
+;              Data items in the DIFFRN_ORIENT_REFLN category record details
+               about the reflections that define the orientation matrix used in
+               the measurement of the diffraction intensities.
+;
+
+data_diffrn_orient_refln_angle_
+    loop_ _name                '_diffrn_orient_refln_angle_chi'
+                               '_diffrn_orient_refln_angle_kappa'
+                               '_diffrn_orient_refln_angle_omega'
+                               '_diffrn_orient_refln_angle_phi'
+                               '_diffrn_orient_refln_angle_psi'
+                               '_diffrn_orient_refln_angle_theta'
+    _category                    diffrn_orient_refln
+    _type                        numb
+    _list                        yes
+    _list_reference            '_diffrn_orient_refln_index_'
+    _units                       deg
+    _units_detail              'degree of arc'
+    _definition
+;              Diffractometer angles of a reflection used to define
+               the orientation matrix in degrees. See
+               _diffrn_orient_matrix_UB_ and
+               _diffrn_orient_refln_index_h, *_k and *_l.
+;
+
+data_diffrn_orient_refln_index_
+    loop_ _name                '_diffrn_orient_refln_index_h'
+                               '_diffrn_orient_refln_index_k'
+                               '_diffrn_orient_refln_index_l'
+    _category                    diffrn_orient_refln
+    _type                        numb
+    _list                        yes
+    _list_mandatory              yes
+    _definition
+;              The indices of a reflection used to define the orientation
+               matrix. See _diffrn_orient_matrix_.
+;
+
+######################
+## DIFFRN_RADIATION ##
+######################
+
+data_diffrn_radiation_[]
+    _name                      '_diffrn_radiation_[]'
+    _category                    category_overview
+    _type                        null
+    loop_ _example
+          _example_detail
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+;
+    _diffrn_radiation_type             'Cu K\a'
+    _diffrn_radiation_monochromator    'graphite'
+;
+;
+    Example 1 - based on data set TOZ of Willis, Beckwith & Tozer
+                [Acta Cryst. (1991), C47, 2276-2277].
+;
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+    _definition
+;              Data items in the DIFFRN_RADIATION category describe the
+               radiation used in measuring the diffraction intensities, its
+               collimation and monochromatization before the sample.
+
+               Post-sample treatment of the beam is described by data items
+               in the DIFFRN_DETECTOR category.
+;
+
+data_diffrn_radiation_collimation
+    _name                      '_diffrn_radiation_collimation'
+    _category                    diffrn_radiation
+    _type                        char
+    loop_ _example             '0.3 mm double-pinhole'
+                               '0.5 mm'
+                               'focusing mirrors'
+    _definition
+;              The collimation or focusing applied to the radiation.
+;
+
+data_diffrn_radiation_filter_edge
+    _name                      '_diffrn_radiation_filter_edge'
+    _category                    diffrn_radiation
+    _type                        numb
+    _enumeration_range           0.0:
+    _units                       A
+    _units_detail                angstrom
+    _definition
+;              Absorption edge in angstroms of the radiation filter used.
+;
+
+data_diffrn_radiation_inhomogeneity
+    _name                      '_diffrn_radiation_inhomogeneity'
+    _category                    diffrn_radiation
+    _type                        numb
+    _enumeration_range           0.0:
+    _units                       mm
+    _units_detail                millimetre
+    _definition
+;              Half-width in millimetres of the incident beam in the
+               direction perpendicular to the diffraction plane.
+;
+
+data_diffrn_radiation_monochromator
+    _name                      '_diffrn_radiation_monochromator'
+    _category                    diffrn_radiation
+    _type                        char
+    loop_ _example              'Zr filter'   'Ge 220'   'none'
+                                'equatorial mounted graphite'
+    _definition
+;              The method used to obtain monochromatic radiation. If a mono-
+               chromator crystal is used, the material and the indices of the
+               Bragg reflection are specified.
+;
+
+data_diffrn_radiation_polarisn_norm
+    _name                      '_diffrn_radiation_polarisn_norm'
+    _category                    diffrn_radiation
+    _type                        numb
+    _enumeration_range           -180.0:180.0
+    _units                       deg
+    _units_detail              'degree of arc'
+    _definition
+;              The angle in degrees, as viewed from the specimen, between the
+               perpendicular component of the polarization and the diffraction
+               plane. See _diffrn_radiation_polarisn_ratio.
+;
+
+data_diffrn_radiation_polarisn_ratio
+    _name                      '_diffrn_radiation_polarisn_ratio'
+    _category                    diffrn_radiation
+    _type                        numb
+    _enumeration_range           0.0:
+    _definition
+;              Polarization ratio of the diffraction beam incident on the
+               crystal. It is the ratio of the perpendicularly polarized to the
+               parallel polarized components of the radiation. The perpendicular
+               component forms an angle of _diffrn_radiation_polarisn_norm to
+               the normal to the diffraction plane of the sample (i.e. the plane
+               containing the incident and reflected beams).
+;
+
+data_diffrn_radiation_probe
+    _name                      '_diffrn_radiation_probe'
+    _category                    diffrn_radiation
+    _type                        char
+    loop_ _enumeration           x-ray
+                                 neutron
+                                 electron
+                                 gamma
+    _definition
+;             The nature of the radiation used (i.e. the name of the
+              subatomic particle or the region of the electromagnetic
+              spectrum). It is strongly recommended that this information
+              be given, so that the probe radiation can be simply determined.
+;
+
+data_diffrn_radiation_type
+    _name                      '_diffrn_radiation_type'
+    _category                    diffrn_radiation
+    _type                        char
+    loop_ _example               'Cu K\a'        'Cu K\a~1~'
+                                 'Cu K-L~2,3~'   white-beam
+    _definition
+;              The type of the radiation. This is used to give a more
+               detailed description than _diffrn_radiation_probe and is
+               typically a description of the X-ray wavelength in Siegbahn
+               notation.
+;
+
+data_diffrn_radiation_xray_symbol
+    _name                      '_diffrn_radiation_xray_symbol'
+    _category                    diffrn_radiation
+    _type                        char
+    loop_ _enumeration
+          _enumeration_detail
+          K-L~3~        'K\a~1~ in older Siegbahn notation'
+          K-L~2~        'K\a~2~ in older Siegbahn notation'
+          K-M~3~        'K\b~1~ in older Siegbahn notation'
+          K-L~2,3~      'use where K-L~3~ and K-L~2~ are not resolved'
+    _definition
+;              The IUPAC symbol for the X-ray wavelength for the probe
+               radiation.
+;
+
+###################################
+### DIFFRN_RADIATION_WAVELENGTH ###
+###################################
+
+data_diffrn_radiation_wavelength_[]
+    _name                      '_diffrn_radiation_wavelength_[]'
+    _category                    category_overview
+    _type                        null
+    loop_ _example
+          _example_detail
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+;
+    _diffrn_radiation_wavelength       1.5418
+;
+;
+    Example 1 - based on data set TOZ of Willis, Beckwith & Tozer
+                [Acta Cryst. (1991), C47, 2276-2277].
+;
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+    _definition
+;              Data items in the DIFFRN_RADIATION_WAVELENGTH category describe
+               the wavelength of the radiation used in measuring the diffraction
+               intensities. Items may be looped to identify and assign weights
+               to distinct wavelength components from a polychromatic beam.
+;
+
+data_diffrn_radiation_wavelength
+    _name                      '_diffrn_radiation_wavelength'
+    _category                    diffrn_radiation_wavelength
+    _type                        numb
+    _type_conditions             su
+    _list                        both
+    _list_reference            '_diffrn_radiation_wavelength_id'
+    _enumeration_range           0.0:
+    _units                       A
+    _units_detail                angstrom
+    _definition
+;              The radiation wavelength in angstroms.
+;
+
+data_diffrn_radiation_wavelength_details
+    _name                      '_diffrn_radiation_wavelength_details'
+    _category                    diffrn_radiation_wavelength
+    _type                        char
+    _list                        both
+    _list_reference            '_diffrn_radiation_wavelength_id'
+    _definition
+;              Information about the determination of the radiation
+               wavelength that is not conveyed completely by an
+               enumerated value of _diffrn_radiation_wavelength_determination.
+;
+
+data_diffrn_radiation_wavelength_determination
+    _name                      '_diffrn_radiation_wavelength_determination'
+    _category                    diffrn_radiation_wavelength
+    _type                        char
+    _list                        both
+    _list_reference            '_diffrn_radiation_wavelength_id'
+    loop_ _enumeration
+          _enumeration_detail
+                                 fundamental
+;                                        Wavelength that is a
+                                         fundamental property of matter
+                                         e.g. MoK\alpha.
+;
+                                 estimated
+;                                        Estimated from secondary information
+                                         e.g. monochromator angle or time
+                                         of flight.
+;
+                                 refined
+;                                        Based on refinement using a standard
+                                         material with known cell parameters.
+;
+    _definition
+;              The method of determination of incident wavelength.
+;
+
+data_diffrn_radiation_wavelength_id
+    _name                      '_diffrn_radiation_wavelength_id'
+    _category                    diffrn_radiation_wavelength
+    _type                        char
+    _list                        both
+    _list_mandatory              yes
+    loop_ _list_link_child     '_diffrn_refln_wavelength_id'
+                               '_refln_wavelength_id'
+    loop_ _example               x1  x2  neut
+    _definition
+;              An arbitrary code identifying each value of
+               _diffrn_radiation_wavelength. Items in the DIFFRN_RADIATION
+               category are looped when multiple wavelengths are used.
+               This code is used to link with the _diffrn_refln_ list. It
+               must match with one of the _diffrn_refln_wavelength_id codes.
+;
+
+data_diffrn_radiation_wavelength_wt
+    _name                      '_diffrn_radiation_wavelength_wt'
+    _category                    diffrn_radiation_wavelength
+    _type                        numb
+    _list                        both
+    _list_reference            '_diffrn_radiation_wavelength_id'
+    _enumeration_range           0.0:1.0
+    _definition
+;              The relative weight of a wavelength identified by the code
+               _diffrn_radiation_wavelength_id in the list of wavelengths.
+;
+
+##################
+## DIFFRN_REFLN ##
+##################
+
+data_diffrn_refln_[]
+    _name                      '_diffrn_refln_[]'
+    _category                    category_overview
+    _type                        null
+    loop_ _example
+          _example_detail
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+;
+    loop_
+        _diffrn_refln_index_h
+        _diffrn_refln_index_k
+        _diffrn_refln_index_l
+        _diffrn_refln_angle_chi
+        _diffrn_refln_scan_rate
+        _diffrn_refln_counts_bg_1
+        _diffrn_refln_counts_total
+        _diffrn_refln_counts_bg_2
+        _diffrn_refln_angle_theta
+        _diffrn_refln_angle_phi
+        _diffrn_refln_angle_omega
+        _diffrn_refln_angle_kappa
+        _diffrn_refln_scan_width
+        _diffrn_refln_elapsed_time
+
+ 0  0 -16  0. 4.12  28 127  36  33.157  -75.846  16.404   50.170  1.516 19.43
+ 0  0 -15  0. 4.12  38 143  28  30.847  -75.846  14.094   50.170  1.516 19.82
+ 0  0 -14  0. 1.03 142 742 130  28.592  -75.846  11.839   50.170  1.516 21.32
+ 0  0 -13  0. 4.12  26 120  37  26.384  -75.846   9.631   50.170  1.450 21.68
+ 0  0 -12  0. 0.97 129 618 153  24.218  -75.846   7.464   50.170  1.450 23.20
+ 0  0 -11  0. 4.12  33 107  38  22.087  -75.846   5.334   50.170  1.384 23.55
+ 0  0 -10  0. 4.12  37 146  33  19.989  -75.846   3.235   50.170  1.384 23.90
+ 0  0  -9  0. 4.12  50 179  49  17.918  -75.846   1.164   50.170  1.384 24.25
+    # - - - - data truncated for brevity - - - -
+ 3  4  -4  0. 1.03  69 459  73  30.726  -53.744  46.543  -47.552  1.516 2082.58
+ 3  4  -5  0. 1.03  91 465  75  31.407  -54.811  45.519  -42.705  1.516 2084.07
+ 3 14  -6  0. 1.03  84 560  79  32.228  -55.841  44.745  -38.092  1.516 2085.57
+    # - - - - data truncated for brevity - - - -
+;
+;
+    Example 1 - extracted from the CAD-4 listing for Tl~2~Cd~2~(SO~4~)~3~ at
+                85 K (unpublished).
+;
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+    _definition
+;              Data items in the DIFFRN_REFLN category record details about
+               the intensities measured in the diffraction experiment.
+
+               The DIFFRN_REFLN data items refer to individual intensity
+               measurements and must be included in looped lists.
+
+               (The DIFFRN_REFLNS data items specify the parameters that apply
+               to all intensity  measurements. The DIFFRN_REFLNS data items
+               are not looped.)
+;
+
+data_diffrn_refln_angle_
+    loop_ _name                '_diffrn_refln_angle_chi'
+                               '_diffrn_refln_angle_kappa'
+                               '_diffrn_refln_angle_omega'
+                               '_diffrn_refln_angle_phi'
+                               '_diffrn_refln_angle_psi'
+                               '_diffrn_refln_angle_theta'
+    _category                    diffrn_refln
+    _type                        numb
+    _list                        yes
+    _list_reference            '_diffrn_refln_index_'
+    _units                       deg
+    _units_detail              'degree of arc'
+    _definition
+;              The diffractometer angles of a reflection in degrees. These
+               correspond to the specified orientation matrix and the original
+               measured cell before any subsequent cell transformations.
+;
+
+data_diffrn_refln_attenuator_code
+    _name                      '_diffrn_refln_attenuator_code'
+    _category                    diffrn_refln
+    _type                        char
+    _list                        yes
+    _list_reference            '_diffrn_refln_index_'
+    _list_link_parent          '_diffrn_attenuator_code'
+    _definition
+;              The code identifying the attenuator setting for this reflection.
+               This code must match one of the _diffrn_attenuator_code values.
+;
+
+data_diffrn_refln_class_code
+    _name                      '_diffrn_refln_class_code'
+    _category                    diffrn_refln
+    _type                        char
+    _list                        yes
+    _list_reference            '_diffrn_refln_index_'
+    _list_link_parent          '_diffrn_reflns_class_code'
+    _definition
+;              The code identifying the class to which this reflection has
+               been assigned. This code must match a value of
+               _diffrn_reflns_class_code. Reflections may be grouped into
+               classes for a variety of purposes. For example, for modulated
+               structures each reflection class may be defined by the
+               number m=sum|m~i~|, where the m~i~ are the integer coefficients
+               that, in addition to h,k,l, index the corresponding diffraction
+               vector in the basis defined for the reciprocal lattice.
+;
+
+data_diffrn_refln_counts_
+    loop_ _name                '_diffrn_refln_counts_bg_1'
+                               '_diffrn_refln_counts_bg_2'
+                               '_diffrn_refln_counts_net'
+                               '_diffrn_refln_counts_peak'
+                               '_diffrn_refln_counts_total'
+    _category                    diffrn_refln
+    _type                        numb
+    _list                        yes
+    _list_reference            '_diffrn_refln_index_'
+    _definition
+;              The diffractometer counts for the measurements: background
+               before the peak, background after the peak, net counts after
+               background removed, counts for peak scan or position, and the
+               total counts (background plus peak).
+;
+
+data_diffrn_refln_crystal_id
+    _name                      '_diffrn_refln_crystal_id'
+    _category                    diffrn_refln
+    _type                        char
+    _list                        yes
+    _list_reference            '_diffrn_refln_index_'
+    _list_link_parent          '_exptl_crystal_id'
+    _definition
+;              Code identifying each crystal if multiple crystals are used. Is
+               used to link with _exptl_crystal_id in the _exptl_crystal_ list.
+;
+
+data_diffrn_refln_detect_slit_
+    loop_ _name                '_diffrn_refln_detect_slit_horiz'
+                               '_diffrn_refln_detect_slit_vert'
+    _category                    diffrn_refln
+    _type                        numb
+    _list                        yes
+    _list_reference            '_diffrn_refln_index_'
+    _enumeration_range           0.0:90.0
+    _units                       deg
+    _units_detail              'degree of arc'
+    _definition
+;              Total slit apertures in degrees in the diffraction plane
+               (*_horiz) and perpendicular to the diffraction plane (*_vert).
+;
+
+data_diffrn_refln_elapsed_time
+    _name                      '_diffrn_refln_elapsed_time'
+    _category                    diffrn_refln
+    _type                        numb
+    _list                        yes
+    _list_reference            '_diffrn_refln_index_'
+    _enumeration_range           0.0:
+    _units                       min
+    _units_detail                minute
+    _definition
+;              Elapsed time in minutes from the start of the diffraction
+               experiment to the measurement of this intensity.
+;
+
+data_diffrn_refln_index_
+    loop_ _name                '_diffrn_refln_index_h'
+                               '_diffrn_refln_index_k'
+                               '_diffrn_refln_index_l'
+    _category                    diffrn_refln
+    _type                        numb
+    _list                        yes
+    _list_mandatory              yes
+    _definition
+;              Miller indices of a measured reflection. These need not match
+               the _refln_index_h, *_k, *_l values if a transformation of the
+               original measured cell has taken place. Details of the cell
+               transformation are given in _diffrn_reflns_reduction_process.
+               See also _diffrn_reflns_transf_matrix_.
+;
+
+data_diffrn_refln_intensity_net
+    _name                      '_diffrn_refln_intensity_net'
+    _category                    diffrn_refln
+    _type                        numb
+    _list                        yes
+    _list_reference            '_diffrn_refln_index_'
+    _enumeration_range           0:
+    _definition
+;              Net intensity calculated from the diffraction counts after
+               the attenuator and standard scales have been applied.
+;
+
+data_diffrn_refln_intensity_sigma
+    _name                      '_diffrn_refln_intensity_sigma'
+    _category                    diffrn_refln
+    _type                        numb
+    loop_ _related_item
+          _related_function    '_diffrn_refln_intensity_u'  replace
+    _list                        yes
+    _list_reference            '_diffrn_refln_index_'
+    _enumeration_range           0:
+    _definition
+;              Standard uncertainty (e.s.d.) of the net intensity calculated
+               from the diffraction counts after the attenuator and standard
+               scales have been applied.
+;
+
+data_diffrn_refln_intensity_u
+    _name                      '_diffrn_refln_intensity_u'
+    _category                    diffrn_refln
+    _type                        numb
+    loop_ _related_item
+          _related_function    '_diffrn_refln_intensity_sigma'  alternate
+    _list                        yes
+    _list_reference            '_diffrn_refln_index_'
+    _enumeration_range           0:
+    _definition
+;              Standard uncertainty of the net intensity calculated from
+               the diffraction counts after the attenuator and standard
+               scales have been applied.
+;
+
+data_diffrn_refln_scale_group_code
+    _name                      '_diffrn_refln_scale_group_code'
+    _category                    diffrn_refln
+    _type                        char
+    _list                        yes
+    _list_link_parent          '_diffrn_scale_group_code'
+    _list_reference            '_diffrn_refln_index_'
+    _definition
+;              The code identifying the scale applicable to this reflection.
+               This code must match with a specified _diffrn_scale_group_code
+               value.
+;
+
+data_diffrn_refln_scan_mode
+    _name                      '_diffrn_refln_scan_mode'
+    _category                    diffrn_refln
+    _type                        char
+    _list                        yes
+    _list_reference            '_diffrn_refln_index_'
+    loop_ _enumeration
+          _enumeration_detail    om  'omega scan'
+                                 ot  'omega/2theta scan'
+                                 q   'Q scans (arbitrary reciprocal directions)'
+    _definition
+;              The code identifying the mode of scanning for measurements
+               using a diffractometer. See _diffrn_refln_scan_width and
+               _diffrn_refln_scan_mode_backgd.
+;
+
+data_diffrn_refln_scan_mode_backgd
+    _name                      '_diffrn_refln_scan_mode_backgd'
+    _category                    diffrn_refln
+    _type                        char
+    _list                        yes
+    _list_reference            '_diffrn_refln_index_'
+    loop_ _enumeration
+          _enumeration_detail    st  'stationary counter background'
+                                 mo  'moving counter background'
+    _definition
+;              The code identifying the mode of scanning a reflection to measure
+               the background intensity.
+;
+
+data_diffrn_refln_scan_rate
+    _name                      '_diffrn_refln_scan_rate'
+    _category                    diffrn_refln
+    _type                        numb
+    _list                        yes
+    _list_reference            '_diffrn_refln_index_'
+    _enumeration_range           0.0:
+    _units                      deg/min
+    _units_detail              'degree of arc per minute'
+    _definition
+;              The rate of scanning a reflection in
+               degrees per minute to measure the intensity.
+;
+
+data_diffrn_refln_scan_time_backgd
+    _name                      '_diffrn_refln_scan_time_backgd'
+    _category                    diffrn_refln
+    _type                        numb
+    _list                        yes
+    _list_reference            '_diffrn_refln_index_'
+    _enumeration_range           0.0:
+    _units                      s
+    _units_detail               second
+    _definition
+;              The time spent measuring each background in seconds.
+;
+
+data_diffrn_refln_scan_width
+    _name                      '_diffrn_refln_scan_width'
+    _category                    diffrn_refln
+    _type                        numb
+    _list                        yes
+    _list_reference            '_diffrn_refln_index_'
+    _enumeration_range           0.0:90.0
+    _units                       deg
+    _units_detail              'degree of arc'
+    _definition
+;              The scan width in degrees of the scan mode defined by the code
+               _diffrn_refln_scan_mode.
+;
+
+data_diffrn_refln_sint/lambda
+    _name                      '_diffrn_refln_sint/lambda'
+    _category                    diffrn_refln
+    _type                        numb
+    _list                        yes
+    _list_reference            '_diffrn_refln_index_'
+    _enumeration_range           0.0:
+    _units                       A^-1^
+    _units_detail              'reciprocal angstrom'
+    _definition
+;              The (sin theta)/lambda value in reciprocal angstroms for
+               this reflection.
+;
+
+data_diffrn_refln_standard_code
+    _name                      '_diffrn_refln_standard_code'
+    _category                    diffrn_refln
+    _type                        char
+    _list                        yes
+    _list_link_parent          '_diffrn_standard_refln_code'
+    _list_reference            '_diffrn_refln_index_'
+    loop_ _example              1 2 3 s1 s2 s3 A B C
+    _definition
+;              A code indicating that this reflection was measured as a
+               standard reflection. The value must be '.' or match one of
+               the _diffrn_standard_refln_code values.
+;
+
+data_diffrn_refln_wavelength
+    _name                      '_diffrn_refln_wavelength'
+    _category                    diffrn_refln
+    _type                        numb
+    _list                        yes
+    _list_reference            '_diffrn_refln_index_'
+    _enumeration_range           0.0:
+    _units                       A
+    _units_detail                angstrom
+    _definition
+;              The mean wavelength in angstroms of the radiation used to measure
+               the intensity of this reflection. This is an important parameter
+               for reflections measured using energy-dispersive detectors or the
+               Laue method.
+;
+
+
+data_diffrn_refln_wavelength_id
+    _name                      '_diffrn_refln_wavelength_id'
+    _category                    diffrn_refln
+    _type                        char
+    _list                        yes
+    _list_link_parent          '_diffrn_radiation_wavelength_id'
+    _list_reference            '_diffrn_refln_index_'
+    loop_ _example               x1  x2  neut
+    _definition
+;              Code identifying the wavelength in the _diffrn_radiation_ list.
+;
+
+###################
+## DIFFRN_REFLNS ##
+###################
+
+data_diffrn_reflns_[]
+    _name                      '_diffrn_reflns_[]'
+    _category                    category_overview
+    _type                        null
+    loop_ _example
+          _example_detail
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+;
+    _diffrn_reflns_number              1592
+    _diffrn_reflns_av_R_equivalents    0
+    _diffrn_reflns_av_unetI/netI       .027
+    _diffrn_reflns_limit_h_min         0
+    _diffrn_reflns_limit_h_max         6
+    _diffrn_reflns_limit_k_min        -17
+    _diffrn_reflns_limit_k_max         0
+    _diffrn_reflns_limit_l_min         0
+    _diffrn_reflns_limit_l_max         22
+    _diffrn_reflns_theta_min           3.71
+    _diffrn_reflns_theta_max           61.97
+;
+;
+        Example 1 - based on data set TOZ of Willis, Beckwith & Tozer
+                [Acta Cryst. (1991), C47, 2276-2277].
+;
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+    _definition
+;              Data items in the DIFFRN_REFLNS category record details about
+               the set of intensities measured in the diffraction experiment.
+
+               The DIFFRN_REFLNS data items specify the parameters that apply
+               to all intensity measurements. The DIFFRN_REFLNS data items
+               are not looped.
+
+               (The DIFFRN_REFLN data items refer to individual intensity
+               measurements and must be included in looped lists.)
+;
+
+data_diffrn_reflns_av_R_equivalents
+    _name                      '_diffrn_reflns_av_R_equivalents'
+    _category                    diffrn_reflns
+    _type                        numb
+    _enumeration_range           0.0:
+    _definition
+;              The residual [sum av|del(I)| / sum |av(I)|] for
+               symmetry-equivalent reflections used to calculate the
+               average intensity av(I). The av|del(I)| term is the
+               average absolute difference between av(I) and the
+               individual symmetry-equivalent intensities.
+;
+
+data_diffrn_reflns_av_sigmaI/netI
+    _name                      '_diffrn_reflns_av_sigmaI/netI'
+    _category                    diffrn_reflns
+    _type                        numb
+    loop_ _related_item
+          _related_function    '_diffrn_reflns_av_unetI/netI'  replace
+    _enumeration_range           0.0:
+    _definition
+;              Measure [sum |u(net I)|/sum|net I|] for all measured reflections.
+;
+
+data_diffrn_reflns_av_unetI/netI
+    _name                      '_diffrn_reflns_av_unetI/netI'
+    _category                    diffrn_reflns
+    _type                        numb
+    loop_ _related_item
+          _related_function    '_diffrn_reflns_av_sigmaI/netI'  alternate
+    _enumeration_range           0.0:
+    _definition
+;              Measure [sum |u(net I)|/sum|net I|] for all measured reflections.
+;
+
+data_diffrn_reflns_Laue_measured_fraction_full
+    _name                      '_diffrn_reflns_Laue_measured_fraction_full'
+    _category                    diffrn_reflns
+    _type                        numb
+    loop_ _related_item
+          _related_function    '_diffrn_measured_fraction_theta_full'  alternate
+    _enumeration_range           0.95:1.0
+    _definition
+;              Fraction of Laue unique reflections (symmetry-independent in
+               the Laue group) measured out to the resolution given in
+               _diffrn_reflns_resolution_full or _diffrn_reflns_theta_full.
+               The Laue group always contains a centre of symmetry so that
+               the reflection h,k,l is always equivalent to the reflection
+               -h,-k,-l even in space groups without a centre of symmetry.
+               This number should not be less than 0.95, since it represents
+               the fraction of reflections measured in the part of the
+               diffraction pattern that is essentially complete.
+;
+
+data_diffrn_reflns_Laue_measured_fraction_max
+    _name                      '_diffrn_reflns_Laue_measured_fraction_max'
+    _category                    diffrn_reflns
+    _type                        numb
+    loop_ _related_item
+          _related_function    '_diffrn_measured_fraction_theta_max'  alternate
+    _enumeration_range           0:1.0
+    _definition
+;              Fraction of Laue unique reflections (symmetry-independent in
+               the Laue group) measured out to the resolution given in
+               _diffrn_reflns_resolution_max or _diffrn_reflns_theta_max.
+               The Laue group always contains a centre of symmetry so that the
+               reflection h,k,l is always equivalent to the reflection -h,-k,-l
+               even in space groups without a centre of symmetry.
+;
+
+data_diffrn_reflns_limit_
+    loop_ _name                '_diffrn_reflns_limit_h_max'
+                               '_diffrn_reflns_limit_h_min'
+                               '_diffrn_reflns_limit_k_max'
+                               '_diffrn_reflns_limit_k_min'
+                               '_diffrn_reflns_limit_l_max'
+                               '_diffrn_reflns_limit_l_min'
+    _category                    diffrn_reflns
+    _type                        numb
+    _definition
+;              The limits on the Miller indices of the intensities specified
+               by _diffrn_refln_index_h, *_k, *_l.
+;
+
+data_diffrn_reflns_number
+    _name                      '_diffrn_reflns_number'
+    _category                    diffrn_reflns
+    _type                        numb
+    _enumeration_range           0:
+    _definition
+;              The total number of measured intensities, excluding
+               reflections that are classed as systematically absent arising
+               from translational symmetry in the crystal unit cell.
+;
+
+data_diffrn_reflns_point_group_measured_fraction_full
+    _name                    '_diffrn_reflns_point_group_measured_fraction_full'
+    _category                    diffrn_reflns
+    _type                        numb
+    loop_ _related_item
+          _related_function  '_diffrn_measured_fraction_theta_full'  alternate
+    _enumeration_range           0.95:1.0
+    _definition
+;              Fraction of crystal point-group unique reflections (i.e.
+               symmetry-independent in the crystal point group) measured
+               out to the resolution given in _diffrn_reflns_resolution_full
+               or _diffrn_reflns_theta_full. For space groups that do not
+               contain a centre of symmetry the reflections h,k,l and
+               -h,-k,-l are independent. This number should not be less
+               than 0.95, since it represents the fraction of reflections
+               measured in the part of the diffraction pattern that is
+               essentially complete.
+;
+
+data_diffrn_reflns_point_group_measured_fraction_max
+    _name                    '_diffrn_reflns_point_group_measured_fraction_max'
+    _category                    diffrn_reflns
+    _type                        numb
+    loop_ _related_item
+          _related_function  '_diffrn_measured_fraction_theta_max'  alternate
+    _enumeration_range           0:1.0
+    _definition
+;              Fraction of crystal point-group unique reflections (i.e.
+               symmetry-independent in the crystal point group) measured
+               out to the resolution given in _diffrn_reflns_resolution_max
+               or _diffrn_reflns_theta_max. For space groups that do not
+               contain a centre of symmetry the reflections h,k,l and
+               -h,-k,-l are independent.
+;
+
+data_diffrn_reflns_reduction_process
+    _name                      '_diffrn_reflns_reduction_process'
+    _category                    diffrn_reflns
+    _type                        char
+    _example                    'data averaged using Fisher test'
+    _definition
+;              A description of the process used to reduce the intensities
+               into structure-factor magnitudes.
+;
+
+data_diffrn_reflns_resolution_full
+    _name                      '_diffrn_reflns_resolution_full'
+    _category                    diffrn_reflns
+    _type                        numb
+    _enumeration_range           0.0:
+    _units                       A^-1^
+    _units_detail              'reciprocal angstrom'
+    loop_ _related_item
+          _related_function    '_diffrn_reflns_theta_full'  alternate
+    _definition
+;              The resolution in reciprocal angstroms at which the measured
+               reflection count is close to complete. The fraction of unique
+               reflections measured out to this angle is given by
+               _diffrn_measured_fraction_theta_full.
+;
+
+data_diffrn_reflns_resolution_max
+    _name                      '_diffrn_reflns_resolution_max'
+    _category                    diffrn_reflns
+    _type                        numb
+    _enumeration_range           0.0:
+    _units                       A^-1^
+    _units_detail              'reciprocal angstrom'
+    loop_ _related_item
+          _related_function    '_diffrn_reflns_theta_max'  alternate
+    _definition
+;              Maximum resolution in reciprocal angstroms of the measured
+               diffraction pattern. The fraction of unique reflections
+               measured out to this angle is given by
+               _diffrn_measured_fraction_theta_max
+;
+
+data_diffrn_reflns_theta_full
+    _name                      '_diffrn_reflns_theta_full'
+    _category                    diffrn_reflns
+    _type                        numb
+    _enumeration_range           0.0:90.0
+    _units                       deg
+    _units_detail              'degree of arc'
+    _definition
+;              The theta angle (in degrees) at which the measured reflection
+               count is close to complete. The fraction of unique reflections
+               measured out to this angle is given by
+               _diffrn_measured_fraction_theta_full.
+;
+
+data_diffrn_reflns_theta_max
+    _name                      '_diffrn_reflns_theta_max'
+    _category                    diffrn_reflns
+    _type                        numb
+    _enumeration_range           0.0:90.0
+    _units                       deg
+    _units_detail              'degree of arc'
+    _definition
+;              Maximum theta angle in degrees for the measured intensities.
+               The fraction of unique reflections measured out to this angle
+               is given by _diffrn_measured_fraction_theta_max
+;
+
+data_diffrn_reflns_theta_min
+    _name                      '_diffrn_reflns_theta_min'
+    _category                    diffrn_reflns
+    _type                        numb
+    _enumeration_range           0.0:90.0
+    _units                       deg
+    _units_detail              'degree of arc'
+    _definition
+;              Minimum theta angle in degrees for the measured intensities.
+;
+
+data_diffrn_reflns_transf_matrix_
+    loop_ _name                '_diffrn_reflns_transf_matrix_11'
+                               '_diffrn_reflns_transf_matrix_12'
+                               '_diffrn_reflns_transf_matrix_13'
+                               '_diffrn_reflns_transf_matrix_21'
+                               '_diffrn_reflns_transf_matrix_22'
+                               '_diffrn_reflns_transf_matrix_23'
+                               '_diffrn_reflns_transf_matrix_31'
+                               '_diffrn_reflns_transf_matrix_32'
+                               '_diffrn_reflns_transf_matrix_33'
+    _category                    diffrn_reflns
+    _type                        numb
+    _definition
+;              Elements of the matrix used to transform the diffraction
+               reflection indices _diffrn_refln_index_h, *_k, *_l into the
+               _refln_index_h, *_k, *_l indices.
+                                          |11 12 13|
+                     (h k l) diffraction  |21 22 23|  =  (h' k' l')
+                                          |31 32 33|
+;
+#########################
+## DIFFRN_REFLNS_CLASS ##
+#########################
+
+data_diffrn_reflns_class_[]
+    _name                      '_diffrn_reflns_class_[]'
+    _category                    category_overview
+    _type                        null
+    loop_ _example
+          _example_detail
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+;
+    loop_
+        _diffrn_reflns_class_number
+        _diffrn_reflns_class_d_res_high
+        _diffrn_reflns_class_d_res_low
+        _diffrn_reflns_class_av_R_eq
+        _diffrn_reflns_class_code
+        _diffrn_reflns_class_description
+            1580 0.551 6.136 0.015 'Main'
+                                    'm=0; main reflections'
+            1045 0.551 6.136 0.010
+                       'Sat1' 'm=1; first-order satellites'
+;
+;
+    Example 1 - example corresponding to the one-dimensional incommensurately
+                modulated structure of K~2~SeO~4~. Each reflection class is
+                defined by the number m=sum|m~i~|, where the m~i~ are the
+                integer coefficients that, in addition to h,k,l, index the
+                corresponding diffraction vector in the basis defined for
+                the reciprocal lattice.
+;
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+      _definition
+;              Data items in the DIFFRN_REFLNS_CLASS category record details
+               about the classes of reflections measured in the diffraction
+               experiment.
+;
+
+data_diffrn_reflns_class_av_R_eq
+    _name                      '_diffrn_reflns_class_av_R_eq'
+    _category                    diffrn_reflns_class
+    _type                        numb
+    _list                        yes
+    _list_reference            '_diffrn_reflns_class_code'
+    _enumeration_range           0.0:
+    _definition
+;              For each reflection class, the residual
+               [sum av|del(I)|/sum|av(I)|] for symmetry-equivalent reflections
+               used to calculate the average intensity av(I). The av|del(I)|
+               term is the average absolute difference between av(I) and the
+               individual intensities.
+;
+
+data_diffrn_reflns_class_av_sgI/I
+    _name                      '_diffrn_reflns_class_av_sgI/I'
+    _category                    diffrn_reflns_class
+    _type                        numb
+    loop_ _related_item
+          _related_function    '_diffrn_reflns_class_av_uI/I'  replace
+    _list                        yes
+    _list_reference            '_diffrn_reflns_class_code'
+    _enumeration_range           0.0:
+    _definition
+;              Measure [sum|u(net I)|/sum|net I|] for all measured intensities
+               in a reflection class.
+;
+
+data_diffrn_reflns_class_av_uI/I
+    _name                      '_diffrn_reflns_class_av_uI/I'
+    _category                    diffrn_reflns_class
+    _type                        numb
+    loop_ _related_item
+          _related_function    '_diffrn_reflns_class_av_sgI/I'  alternate
+    _list                        yes
+    _list_reference            '_diffrn_reflns_class_code'
+    _enumeration_range           0.0:
+    _definition
+;              Measure [sum|u(net I)|/sum|net I|] for all measured intensities
+               in a reflection class.
+;
+
+data_diffrn_reflns_class_code
+    _name                      '_diffrn_reflns_class_code'
+    _category                    diffrn_reflns_class
+    _type                        char
+    _list                        yes
+    _list_mandatory              yes
+    _list_link_child           '_diffrn_refln_class_code'
+    loop_ _example               '1'
+                                 'm1'
+                                 's2'
+    _definition
+;              The code identifying a certain reflection class.
+;
+
+data_diffrn_reflns_class_d_res_high
+    _name                      '_diffrn_reflns_class_d_res_high'
+    _category                    diffrn_reflns_class
+    _type                        numb
+    _list                        yes
+    _list_reference            '_diffrn_reflns_class_code'
+    _enumeration_range           0.0:
+    _units                       A
+    _units_detail                angstrom
+    _definition
+;              The smallest value in angstroms of the interplanar
+               spacings of the reflections in each reflection class.
+               This is called the highest resolution for this reflection class.
+;
+
+data_diffrn_reflns_class_d_res_low
+    _name                      '_diffrn_reflns_class_d_res_low'
+    _category                    diffrn_reflns_class
+    _type                        numb
+    _list                        yes
+    _list_reference            '_diffrn_reflns_class_code'
+    _enumeration_range           0.0:
+    _units                       A
+    _units_detail                angstrom
+    _definition
+;              The highest value in angstroms of the interplanar
+               spacings of the reflections in each reflection class.
+               This is called the lowest resolution for this reflection class.
+;
+
+data_diffrn_reflns_class_description
+    _name                      '_diffrn_reflns_class_description'
+    _category                    diffrn_reflns_class
+    _type                        char
+    _list                        yes
+    _list_reference            '_diffrn_reflns_class_code'
+    loop_ _example               'm=1 first order satellites'
+                                 'H0L0 common projection reflections'
+    _definition
+;              Description of each reflection class.
+;
+
+data_diffrn_reflns_class_number
+    _name                      '_diffrn_reflns_class_number'
+    _category                    diffrn_reflns_class
+    _type                        numb
+    _list                        yes
+    _list_reference            '_diffrn_reflns_class_code'
+    _enumeration_range           0:
+    _definition
+;              The total number of measured intensities for each reflection
+               class, excluding the systematic absences arising from
+               centring translations.
+;
+
+########################
+## DIFFRN_SCALE_GROUP ##
+########################
+
+data_diffrn_scale_group_[]
+    _name                      '_diffrn_scale_group_[]'
+    _category                    category_overview
+    _type                        null
+    loop_ _example
+          _example_detail
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+;
+    loop_
+    _diffrn_scale_group_code
+    _diffrn_scale_group_I_net
+      1    .86473
+      2   1.0654
+;
+;
+    Example 1 - hypothetical example.
+;
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+    _definition
+;              Data items in the DIFFRN_SCALE_GROUP category record details
+               of the scaling factors applied to place all intensities in
+               the reflection lists on a common scale.
+
+               Scaling groups might, for instance, correspond to each film
+               in a multi-film data set or each crystal in a multi-crystal
+               data set.
+;
+
+data_diffrn_scale_group_code
+    _name                      '_diffrn_scale_group_code'
+    _category                    diffrn_scale_group
+    _type                        char
+    _list                        yes
+    _list_mandatory              yes
+    _list_link_child           '_diffrn_refln_scale_group_code'
+    loop_ _example               1 2 3 s1 A B c1 c2 c3
+    _definition
+;              The code identifying a specific measurement group (e.g. for
+               multi-film or multi-crystal data). The code must match a
+               _diffrn_refln_scale_group_code in the reflection list.
+;
+
+data_diffrn_scale_group_I_net
+    _name                      '_diffrn_scale_group_I_net'
+    _category                    diffrn_scale_group
+    _type                        numb
+    _list                        yes
+    _list_reference            '_diffrn_scale_group_code'
+    _enumeration_range           0.0:
+    _definition
+;              The scale for a specific measurement group which is to be
+               multiplied with the net intensity to place all intensities
+               in the _diffrn_refln_ or _refln_ list on a common scale.
+;
+
+###################
+## DIFFRN_SOURCE ##
+###################
+
+data_diffrn_source_[]
+    _name                      '_diffrn_source_[]'
+    _category                    category_overview
+    _type                        null
+    loop_ _example
+          _example_detail
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+;
+    _diffrn_source               'rotating anode X-ray tube'
+    _diffrn_source_type          'Rigaku RU-200'
+    _diffrn_source_power         50
+    _diffrn_source_current       180
+    _diffrn_source_size          '8 mm x 0.4 mm broad focus'
+;
+;
+    Example 1 - based on PDB entry 5HVP and laboratory records for the
+                structure corresponding to PDB entry 5HVP.
+;
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+    _definition
+;              Data items in the DIFFRN_SOURCE category record details of
+               the source of radiation used in the diffraction experiment.
+;
+
+data_diffrn_radiation_source
+    _name                      '_diffrn_radiation_source'
+    _category                    diffrn_source
+    _type                        char
+    loop_ _related_item
+          _related_function    '_diffrn_source' replace
+    _definition
+;              The source of radiation.
+;
+
+data_diffrn_source
+    _name                      '_diffrn_source'
+    _category                    diffrn_source
+    _type                        char
+    loop_ _related_item
+          _related_function    '_diffrn_radiation_source'  alternate
+    loop_
+    _example                   'sealed X-ray tube'
+                               'nuclear reactor'
+                               'spallation source'
+                               'electron microscope'
+                               'rotating-anode X-ray tube'
+                               'synchrotron'
+    _definition
+;              The general class of the source of radiation.
+;
+
+data_diffrn_source_current
+    _name                      '_diffrn_source_current'
+    _category                    diffrn_source
+    _type                        numb
+    _enumeration_range           0.0:
+    _units                       mA
+    _units_detail                milliampere
+    _definition
+;              The current in milliamperes at which the radiation source was
+               operated.
+;
+
+data_diffrn_source_details
+    _name                      '_diffrn_source_details'
+    _category                    diffrn_source
+    _type                        char
+    _definition
+;              A description of special aspects of the source.
+;
+
+data_diffrn_source_power
+    _name                      '_diffrn_source_power'
+    _category                    diffrn_source
+    _type                        numb
+    _enumeration_range           0.0:
+    _units                       kW
+    _units_detail                kilowatt
+    _definition
+;              The power in kilowatts at which the radiation source was
+               operated.
+;
+
+data_diffrn_source_size
+    _name                      '_diffrn_source_size'
+    _category                    diffrn_source
+    _type                        char
+    loop_
+    _example                   '8mm x 0.4 mm fine-focus'
+                               'broad focus'
+    _definition
+;              The dimensions of the source as viewed from the sample.
+;
+
+data_diffrn_source_take-off_angle
+    _name                      '_diffrn_source_take-off_angle'
+    _category                    diffrn_source
+    _type                        numb
+    _enumeration_range           0:90
+    _units                       deg
+    _units_detail              'degree of arc'
+    _example                     1.53
+    _definition
+;              The complement of the angle in degrees between the normal
+               to the surface of the X-ray tube target and the primary
+               X-ray beam for beams generated by traditional X-ray tubes.
+;
+
+data_diffrn_source_target
+    _name                      '_diffrn_source_target'
+    _category                    diffrn_source
+    _type                        char
+    loop_ _enumeration
+        H  He  Li  Be  B  C  N  O  F  Ne  Na  Mg  Al  Si  P  S  Cl
+        Ar  K  Ca  Sc  Ti  V  Cr  Mn  Fe  Co  Ni  Cu  Zn  Ga  Ge
+        As  Se  Br  Kr  Rb  Sr  Y  Zr  Nb  Mo  Tc  Ru  Rh  Pd  Ag
+        Cd  In  Sn  Sb  Te  I  Xe  Cs  Ba  La  Ce  Pr  Nd  Pm  Sm
+        Eu  Gd  Tb  Dy  Ho  Er  Tm  Yb  Lu  Hf  Ta  W  Re  Os  Ir
+        Pt  Au  Hg  Tl  Pb  Bi  Po  At  Rn  Fr  Ra  Ac  Th  Pa  U
+        Np  Pu  Am  Cm  Bk  Cf  Es  Fm  Md  No  Lr  Rf  Db  Sg  Bh
+        Hs  Mt  Ds  Rg  Cn
+    _definition
+;              The chemical element symbol for the X-ray target
+               (usually the anode) used to generate X-rays.
+               This can also be used for spallation sources.
+;
+
+data_diffrn_source_type
+    _name                      '_diffrn_source_type'
+    _category                    diffrn_source
+    _type                        char
+    loop_
+    _example                   'NSLS beamline X8C'
+                               'Rigaku RU200'
+    _definition
+;              The make, model or name of the source of radiation.
+;
+
+data_diffrn_source_voltage
+    _name                      '_diffrn_source_voltage'
+    _category                    diffrn_source
+    _type                        numb
+    _enumeration_range           0.0:
+    _units                       kV
+    _units_detail                kilovolt
+    _definition
+;              The voltage in kilovolts at which the radiation source was
+               operated.
+;
+
+###########################
+## DIFFRN_STANDARD_REFLN ##
+###########################
+
+data_diffrn_standard_refln_[]
+    _name                      '_diffrn_standard_refln_[]'
+    _category                    category_overview
+    _type                        null
+    loop_ _example
+          _example_detail
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+;
+    loop_
+    _diffrn_standard_refln_index_h
+    _diffrn_standard_refln_index_k
+    _diffrn_standard_refln_index_l
+    3 2 4    1 9 1    3 0 10
+;
+;
+    Example 1 - based on data set TOZ of Willis, Beckwith & Tozer
+                [Acta Cryst. (1991), C47, 2276-2277].
+;
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+    _definition
+;              Data items in the DIFFRN_STANDARD_REFLN category record details
+               about the reflections treated as standards during the measurement
+               of the diffraction intensities.
+
+               Note that these are the individual standard reflections, not the
+               results of the analysis of the standard reflections.
+;
+
+data_diffrn_standard_refln_code
+    _name                      '_diffrn_standard_refln_code'
+    _category                    diffrn_standard_refln
+    _type                        char
+    _list                        yes
+    _list_link_child           '_diffrn_refln_standard_code'
+    _list_reference            '_diffrn_standard_refln_index_'
+    loop_ _example               1 2 3 s1 A B
+    _definition
+;              The code identifying a reflection measured as a standard
+               reflection with the indices _diffrn_standard_refln_index_.
+               This is the same code as the  _diffrn_refln_standard_code in
+               the _diffrn_refln_ list.
+;
+
+data_diffrn_standard_refln_index_
+    loop_ _name                '_diffrn_standard_refln_index_h'
+                               '_diffrn_standard_refln_index_k'
+                               '_diffrn_standard_refln_index_l'
+    _category                    diffrn_standard_refln
+    _type                        numb
+    _list                        yes
+    _list_mandatory              yes
+    _definition
+;              Miller indices of standard reflections used in the diffraction
+               measurement process.
+;
+
+######################
+## DIFFRN_STANDARDS ##
+######################
+
+data_diffrn_standards_[]
+    _name                      '_diffrn_standards_[]'
+    _category                    category_overview
+    _type                        null
+    loop_ _example
+          _example_detail
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+;
+    _diffrn_standards_number            3
+    _diffrn_standards_interval_time     120
+    _diffrn_standards_decay_%           0
+;
+;
+     Example 1 - based on data set TOZ of Willis, Beckwith & Tozer
+                [Acta Cryst. (1991), C47, 2276-2277].
+;
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+    _definition
+;              Data items in the DIFFRN_STANDARDS category record details
+               about the set of standard reflections used to monitor intensity
+               stability during the measurement of diffraction intensities.
+
+               Note that these records describe properties common to the set of
+               standard reflections, not the standard reflections themselves.
+;
+
+data_diffrn_standards_decay_%
+    _name                      '_diffrn_standards_decay_%'
+    _category                    diffrn_standards
+    _type                        numb
+    _type_conditions             esd
+    _enumeration_range           :100
+    loop_ _example
+          _example_detail
+                                 0.5(1)
+                               'represents a decay between 0.2% and 0.8%'
+                                 -1(1)
+;                              the change in the standards lies between
+                               a decay of 2% and an increase of 4%
+;
+                                  0.0(2)
+;                              the change in the standards lies between a
+                               decay of 0.6% and an increase of 0.6%.
+;
+    _definition
+;              The percentage decrease in the mean
+               intensity of the set of standard reflections measured at the
+               start of the measurement process and at the finish.  This value
+               usually affords a measure of the overall decay in crystal
+               quality during the diffraction measurement process.  Negative
+               values are used in exceptional instances where the final
+               intensities are greater than the initial ones.  If no
+               measurable decay has occurred, the standard uncertainty should
+               be quoted to indicate the maximum possible value the decay
+               might have.  A range of 3 standard uncertainties is considered
+               possible.  Thus 0.0(1) would indicate a decay of less than
+               0.3% or an enhancement of less than 0.3%.
+;
+
+data_diffrn_standards_interval_count
+    _name                      '_diffrn_standards_interval_count'
+    _category                    diffrn_standards
+    _type                        numb
+    _enumeration_range           0:
+    _definition
+;              The number of reflection intensities between the measurements
+               of standard reflection intensities.
+;
+
+data_diffrn_standards_interval_time
+    _name                      '_diffrn_standards_interval_time'
+    _category                    diffrn_standards
+    _type                        numb
+    _enumeration_range           0:
+    _units                       min
+    _units_detail                minute
+    _definition
+;              The time in minutes between the measurements
+               of standard reflection intensities.
+;
+
+data_diffrn_standards_number
+    _name                      '_diffrn_standards_number'
+    _category                    diffrn_standards
+    _type                        numb
+    _enumeration_range           0:
+    _definition
+;              The number of unique standard reflections used during the
+               measurement of the diffraction intensities.
+;
+
+data_diffrn_standards_scale_sigma
+    _name                      '_diffrn_standards_scale_sigma'
+    _category                    diffrn_standards
+    _type                        numb
+    loop_ _related_item
+          _related_function    '_diffrn_standards_scale_u'  replace
+    _enumeration_range           0.0:
+    _definition
+;              The standard uncertainty (e.s.d.) of the individual mean
+               standard scales applied to the intensity data.
+;
+
+data_diffrn_standards_scale_u
+    _name                      '_diffrn_standards_scale_u'
+    _category                    diffrn_standards
+    _type                        numb
+    loop_ _related_item
+          _related_function    '_diffrn_standards_scale_sigma'  alternate
+    _enumeration_range           0.0:
+    _definition
+;              The standard uncertainty of the individual mean
+               standard scales applied to the intensity data.
+;
+
+###########
+## EXPTL ##
+###########
+
+data_exptl_[]
+    _name                      '_exptl_[]'
+    _category                    category_overview
+    _type                        null
+    loop_ _example
+          _example_detail
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+;
+    _exptl_absorpt_coefficient_mu     0.962
+    _exptl_absorpt_correction_type    psi-scan
+    _exptl_absorpt_process_details
+                               'North, Phillips & Mathews (1968)'
+    _exptl_absorpt_correction_T_min   0.929
+    _exptl_absorpt_correction_T_max   0.997
+;
+;
+    Example 1 - based on a paper by Steiner [Acta Cryst. (1996), C52,
+                2554-2556].
+;
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+    _definition
+;              Data items in the EXPTL category record details about the
+               experimental work prior to the intensity measurements and
+               details about the absorption-correction technique employed.
+;
+
+data_exptl_absorpt_coefficient_mu
+    _name                      '_exptl_absorpt_coefficient_mu'
+    _category                    exptl
+    _type                        numb
+    _enumeration_range           0.0:
+    _units                       mm^-1^
+    _units_detail              'reciprocal millimetre'
+    _definition
+;              The absorption coefficient mu in reciprocal millimetres
+               calculated from the atomic content of the cell, the density and
+               the radiation wavelength.
+;
+
+data_exptl_absorpt_correction_T_
+    loop_ _name                '_exptl_absorpt_correction_T_max'
+                               '_exptl_absorpt_correction_T_min'
+    _category                    exptl
+    _type                        numb
+    _enumeration_range           0.0:1.0
+    _definition
+;              The maximum and minimum transmission factors applied to the
+               diffraction pattern measured in this experiment. These
+               factors are also referred to as the absorption correction
+               A or 1/A*. As this value is the one that is applied to
+               the measured intensities, it includes the correction for
+               absorption by the specimen mount and diffractometer as well
+               as by the specimen itself.
+;
+
+data_exptl_absorpt_correction_type
+    _name                      '_exptl_absorpt_correction_type'
+    _category                    exptl
+    _type                        char
+    loop_ _enumeration
+          _enumeration_detail    analytical  'analytical from crystal shape'
+                                 cylinder    'cylindrical'
+                                 empirical   'empirical from intensities'
+                                 gaussian    'Gaussian from crystal shape'
+                                 integration 'integration from crystal shape'
+                                 multi-scan  'symmetry-related measurements'
+                                 none        'no absorption correction applied'
+                                 numerical   'numerical from crystal shape'
+                                 psi-scan    'psi-scan corrections'
+                                 refdelf     'refined from delta-F'
+                                 sphere      'spherical'
+    _definition
+;              The absorption-correction type and method. The value 'empirical'
+               should NOT be used unless more detailed information is not
+               available.
+;
+
+data_exptl_absorpt_process_details
+    _name                      '_exptl_absorpt_process_details'
+    _category                    exptl
+    _type                        char
+    loop_ _example               'Tompa analytical'
+                                 'MolEN (Fair, 1990)'
+                                 '(North, Phillips & Mathews, 1968)'
+    _definition
+;              Description of the absorption process applied to the
+               intensities. A literature reference should be supplied
+               for psi-scan techniques.
+;
+
+data_exptl_crystals_number
+    _name                      '_exptl_crystals_number'
+    _category                    exptl
+    _type                        numb
+    _enumeration_range           1:
+    _definition
+;              The total number of crystals used for the measurement of
+               intensities.
+;
+
+data_exptl_special_details
+    _name                      '_exptl_special_details'
+    _category                    exptl
+    _type                        char
+    _definition
+;              Any special information about the experimental work prior to the
+               intensity measurements. See also _exptl_crystal_preparation.
+;
+
+data_exptl_transmission_factor_max
+    _name                      '_exptl_transmission_factor_max'
+    _category                    exptl
+    _type                        numb
+    _type_conditions             su
+    _enumeration_range           0.0:1.0
+    _definition
+;              The calculated maximum value of the transmission factor for
+               the specimen. Its value does not include the effects of
+               absorption in the specimen mount. The presence of this
+               item does not imply that the structure factors have been
+               corrected for absorption. The applied correction should be
+               given by _exptl_absorpt_correction_T_max.
+;
+
+data_exptl_transmission_factor_min
+    _name                      '_exptl_transmission_factor_min'
+    _category                    exptl
+    _type                        numb
+    _type_conditions             su
+    _enumeration_range           0.0:1.0
+    _definition
+;              The calculated minimum value of the transmission factor for
+               the specimen. Its value does not include the effects of
+               absorption in the specimen mount. The presence of this
+               item does not imply that the structure factors have been
+               corrected for absorption. The applied correction should be
+               given by _exptl_absorpt_correction_T_min.
+;
+
+###################
+## EXPTL_CRYSTAL ##
+###################
+
+data_exptl_crystal_[]
+    _name                      '_exptl_crystal_[]'
+    _category                    category_overview
+    _type                        null
+    loop_ _example
+          _example_detail
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+;
+    _exptl_crystal_description          prism
+    _exptl_crystal_colour               colourless
+    _exptl_crystal_size_max             0.32
+    _exptl_crystal_size_mid             0.27
+    _exptl_crystal_size_min             0.10
+    _exptl_crystal_density_diffrn       1.146
+    _exptl_crystal_density_meas         ?
+    _exptl_crystal_density_method       'not measured'
+    _exptl_crystal_F_000                656
+;
+;
+    Example 1 - based on data set TOZ of Willis, Beckwith & Tozer
+                [Acta Cryst. (1991), C47, 2276-2277].
+;
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+;   _exptl_crystal_density_meas_gt       2.5
+    _exptl_crystal_density_meas_lt       5.0
+;
+;
+    Example 2 - using separate items to define upper and lower
+                limits for a value.
+;
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+;   _exptl_crystal_density_meas_temp_lt 300
+;
+;
+    Example 3 - here the density was measured at some
+                    unspecified temperature below room temperature.
+;
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+    _definition
+;              Data items in the EXPTL_CRYSTAL category record details about
+               experimental measurements on the crystal or crystals used,
+               such as shape, size or density.
+;
+
+data_exptl_crystal_colour
+    _name                      '_exptl_crystal_colour'
+    _category                    exptl_crystal
+    _type                        char
+    _list                        both
+    _list_reference            '_exptl_crystal_id'
+    loop_ _related_item
+          _related_function    '_exptl_crystal_colour_lustre'    alternate
+                               '_exptl_crystal_colour_modifier'  alternate
+                               '_exptl_crystal_colour_primary'   alternate
+    _example                   'dark green'
+    _definition
+;              The colour of the crystal.
+;
+
+data_exptl_crystal_colour_lustre
+    _name                      '_exptl_crystal_colour_lustre'
+    _category                    exptl_crystal
+    _type                        char
+    _list                        both
+    _list_reference            '_exptl_crystal_id'
+    loop_ _enumeration           metallic
+                                 lustrous
+                                 transparent
+                                 translucent
+                                 opaque
+                                 dull
+                                 clear
+                                 .
+    loop_ _related_item
+          _related_function    '_exptl_crystal_colour'  alternate
+    _definition
+;             The enumeration list of standardized names developed for the
+              International Centre for Diffraction Data.
+              The colour of a crystal is given by the combination of
+              _exptl_crystal_colour_modifier with
+              _exptl_crystal_colour_primary, as in 'dark-green' or
+              'bluish-violet', if necessary combined with
+              _exptl_crystal_colour_lustre, as in 'metallic-green'.
+              Note that 'dull' and 'clear' should no longer be used.
+;
+
+data_exptl_crystal_colour_modifier
+    _name                      '_exptl_crystal_colour_modifier'
+    _category                    exptl_crystal
+    _type                        char
+    _list                        both
+    _list_reference            '_exptl_crystal_id'
+    loop_ _enumeration           light
+                                 dark
+                                 pale
+                                 intense
+                                 whitish
+                                 blackish
+                                 grayish
+                                 brownish
+                                 reddish
+                                 pinkish
+                                 orangish
+                                 yellowish
+                                 greenish
+                                 bluish
+                                 .
+    loop_ _related_item
+          _related_function    '_exptl_crystal_colour'  alternate
+    _definition
+;             The enumeration list of standardized names developed for the
+              International Centre for Diffraction Data.
+              The colour of a crystal is given by the combination of
+              _exptl_crystal_colour_modifier with
+              _exptl_crystal_colour_primary, as in 'dark-green' or
+              'bluish-violet', if necessary combined with
+              _exptl_crystal_colour_lustre, as in 'metallic-green'.
+;
+
+data_exptl_crystal_colour_primary
+    _name                      '_exptl_crystal_colour_primary'
+    _category                    exptl_crystal
+    _type                        char
+    _list                        both
+    _list_reference            '_exptl_crystal_id'
+    loop_ _enumeration           colourless
+                                 white
+                                 black
+                                 gray
+                                 brown
+                                 red
+                                 pink
+                                 orange
+                                 yellow
+                                 green
+                                 blue
+                                 violet
+    loop_ _related_item
+          _related_function    '_exptl_crystal_colour'  alternate
+    _definition
+;             The enumeration list of standardized names developed for the
+              International Centre for Diffraction Data.
+              The colour of a crystal is given by the combination of
+              _exptl_crystal_colour_modifier with
+              _exptl_crystal_colour_primary, as in 'dark-green' or
+              'bluish-violet', if necessary combined with
+              _exptl_crystal_colour_lustre, as in 'metallic-green'.
+;
+
+data_exptl_crystal_density_diffrn
+    _name                      '_exptl_crystal_density_diffrn'
+    _category                    exptl_crystal
+    _type                        numb
+    _list                        both
+    _list_reference            '_exptl_crystal_id'
+    _enumeration_range           0.0:
+    _units                       Mg/m^3^
+    _units_detail              'megagram per metre cubed'
+    _definition
+;              Density values calculated from the crystal cell and contents. The
+               units are megagrams per cubic metre (grams per cubic centimetre).
+;
+
+data_exptl_crystal_density_meas
+    _name                      '_exptl_crystal_density_meas'
+    _category                    exptl_crystal
+    _type                        numb
+    _type_conditions             esd
+    _list                        both
+    _list_reference            '_exptl_crystal_id'
+    _enumeration_range           0.0:
+    _units                       Mg/m^3^
+    _units_detail              'megagram per metre cubed'
+    _definition
+;              Density values measured using standard chemical and physical
+               methods. The units are megagrams per cubic metre (grams per
+               cubic centimetre).
+;
+
+data_exptl_crystal_density_meas_gt
+    _name                      '_exptl_crystal_density_meas_gt'
+    _category                    exptl_crystal
+    _type                        numb
+    _list                        both
+    _list_reference            '_exptl_crystal_id'
+    _enumeration_range           0.0:
+    _units                       Mg/m^3^
+    _units_detail              'megagram per metre cubed'
+    loop_ _related_item
+          _related_function    '_exptl_crystal_density_meas'  alternate
+    loop_ _example
+          _example_detail
+                                 2.5
+;                              lower limit for the density (only the range
+                               within which the density lies was given in the
+                               original paper)
+;
+    _definition
+;              The value above which the density measured using standard
+               chemical and physical methods lies. The units are megagrams
+               per cubic metre (grams per cubic centimetre).
+               _exptl_crystal_density_meas_gt and
+               _exptl_crystal_density_meas_lt should not be used to
+               report new experimental work, for which
+               _exptl_crystal_density_meas should be used. These items
+               are intended for use in reporting information in
+               existing databases and archives which would be misleading if
+               reported under _exptl_crystal_density_meas.
+;
+
+data_exptl_crystal_density_meas_lt
+    _name                      '_exptl_crystal_density_meas_lt'
+    _category                    exptl_crystal
+    _type                        numb
+    _list                        both
+    _list_reference            '_exptl_crystal_id'
+    _enumeration_range           0.0:
+    _units                       Mg/m^3^
+    _units_detail              'megagram per metre cubed'
+    loop_ _related_item
+          _related_function    '_exptl_crystal_density_meas'  alternate
+    loop_ _example
+          _example_detail
+                                 1.0
+                               'specimen floats in water'
+                                 5.0
+;                              upper limit for the density (only the range
+                               within which the density lies was given in the
+                               original paper)
+;
+    _definition
+;              The value below which the density measured using standard
+               chemical and physical methods lies. The units are megagrams
+               per cubic metre (grams per cubic centimetre).
+               _exptl_crystal_density_meas_gt and
+               _exptl_crystal_density_meas_lt should not be used to
+               report new experimental work, for which
+               _exptl_crystal_density_meas should be used. These items
+               are intended for use in reporting information in
+               existing databases and archives which would be misleading if
+               reported under _exptl_crystal_density_meas.
+;
+
+
+data_exptl_crystal_density_meas_temp
+    _name                      '_exptl_crystal_density_meas_temp'
+    _category                    exptl_crystal
+    _type                        numb
+    _type_conditions             esd
+    _list                        both
+    _list_reference            '_exptl_crystal_id'
+    _enumeration_range           0.0:
+    _units                       K
+    _units_detail                kelvin
+    _definition
+;              Temperature in kelvins at which _exptl_crystal_density_meas
+               was determined.
+;
+
+data_exptl_crystal_density_meas_temp_gt
+    _name                      '_exptl_crystal_density_meas_temp_gt'
+    _category                    exptl_crystal
+    _type                        numb
+    _list                        both
+    _list_reference            '_exptl_crystal_id'
+    _enumeration_range           0.0:
+    _units                       K
+    _units_detail                kelvin
+    loop_ _related_item
+          _related_function    '_exptl_crystal_density_meas_temp'  alternate
+    _definition
+;              Temperature in kelvins above which _exptl_crystal_density_meas
+               was determined. _exptl_crystal_density_meas_temp_gt and
+               _exptl_crystal_density_meas_temp_lt should not be used for
+               reporting new work, for which the correct temperature of
+               measurement should be given. These items are intended for
+               use in reporting information stored in databases
+               or archives which would be misleading if reported under
+               _exptl_crystal_density_meas_temp.
+;
+
+data_exptl_crystal_density_meas_temp_lt
+    _name                      '_exptl_crystal_density_meas_temp_lt'
+    _category                    exptl_crystal
+    _type                        numb
+    _list                        both
+    _list_reference            '_exptl_crystal_id'
+    _enumeration_range           0.0:
+    _units                       K
+    _units_detail                kelvin
+    loop_ _related_item
+          _related_function    '_exptl_crystal_density_meas_temp'  alternate
+    loop_ _example
+          _example_detail
+                                 300
+;                               The density was measured at some unspecified
+                                temperature below room temperature.
+;
+    _definition
+;              Temperature in kelvins below which _exptl_crystal_density_meas
+               was determined. _exptl_crystal_density_meas_temp_gt and
+               _exptl_crystal_density_meas_temp_lt should not be used for
+               reporting new work, for which the correct temperature of
+               measurement should be given. These items are intended for
+               use in reporting information stored in databases
+               or archives which would be misleading if reported under
+               _exptl_crystal_density_meas_temp.
+;
+
+data_exptl_crystal_density_method
+    _name                      '_exptl_crystal_density_method'
+    _category                    exptl_crystal
+    _type                        char
+    _list                        both
+    _list_reference            '_exptl_crystal_id'
+    loop_ _example             'flotation in aqueous KI'
+                               'not measured'
+                               'Berman density torsion balance'
+
+    _definition
+;              The method used to measure _exptl_crystal_density_meas.
+;
+
+data_exptl_crystal_description
+    _name                      '_exptl_crystal_description'
+    _category                    exptl_crystal
+    _type                        char
+    _list                        both
+    _list_reference            '_exptl_crystal_id'
+    _definition
+;              A description of the quality and habit of the crystal.
+               The crystal dimensions should not normally be reported here;
+               use instead _exptl_crystal_size_ for the gross dimensions of
+               the crystal and _exptl_crystal_face_ to describe the
+               relationship between individual faces.
+;
+
+data_exptl_crystal_F_000
+    _name                      '_exptl_crystal_F_000'
+    _category                    exptl_crystal
+    _type                        numb
+    _list                        both
+    _list_reference            '_exptl_crystal_id'
+    _definition
+;              The expression for a structure factor evaluated in the
+               zeroth-order case h = k = l = 0, F(000). This may contain
+               dispersion contributions and is calculated as
+
+               F(000) = [ (sum f~r~)^2^ + (sum f~i~)^2^ ]^1/2^
+
+               f~r~   = real part of the scattering factors at theta = 0
+               f~i~   = imaginary part of the scattering factors at theta = 0
+
+                        the sum is taken over each atom in the unit cell
+
+               For X-rays, non-dispersive F(000) is a positive number
+               and counts the effective number of electrons in the unit cell;
+               for neutrons, non-dispersive F(000) (which may be negative)
+               counts the total nuclear scattering power in the unit cell. See
+                  http://reference.iucr.org/dictionary/F(000)
+;
+
+data_exptl_crystal_id
+    _name                      '_exptl_crystal_id'
+    _category                    exptl_crystal
+    _type                        char
+    _list                        both
+    _list_mandatory              yes
+    loop_ _list_link_child     '_diffrn_refln_crystal_id'
+                               '_refln_crystal_id'
+    _definition
+;              Code identifying each crystal if multiple crystals are used. It
+               is used to link with _diffrn_refln_crystal_id in the intensity
+               measurements and with _refln_crystal_id in the _refln_ list.
+;
+
+data_exptl_crystal_preparation
+    _name                      '_exptl_crystal_preparation'
+    _category                    exptl_crystal
+    _type                        char
+    _list                        both
+    _list_reference            '_exptl_crystal_id'
+    _example                   'mounted in an argon-filled quartz capillary'
+    _definition
+;              Details of crystal growth and preparation of the crystal (e.g.
+               mounting) prior to the intensity measurements.
+;
+
+data_exptl_crystal_pressure_history
+    _name                      '_exptl_crystal_pressure_history'
+    _category                    exptl_crystal
+    _type                        char
+    _list                        both
+    _list_reference            '_exptl_crystal_id'
+    _definition
+;              Relevant details concerning the pressure history of the
+               sample.
+;
+
+data_exptl_crystal_recrystallization_method
+    _name                      '_exptl_crystal_recrystallization_method'
+    _category                    exptl_crystal
+    _type                        char
+    _list                        both
+    _definition
+;              Describes the method used to recrystallize the sample.
+               Sufficient details should be given for the procedure to be
+               repeated.  The temperature or temperatures should be given as
+               well as details of the solvent, flux or carrier gas with
+               concentrations or pressures and ambient atmosphere.
+;
+
+data_exptl_crystal_size_
+    loop_ _name                '_exptl_crystal_size_length'
+                               '_exptl_crystal_size_max'
+                               '_exptl_crystal_size_mid'
+                               '_exptl_crystal_size_min'
+                               '_exptl_crystal_size_rad'
+    _category                    exptl_crystal
+    _type                        numb
+    _list                        both
+    _list_reference            '_exptl_crystal_id'
+    _enumeration_range           0.0:
+    _units                       mm
+    _units_detail                millimetre
+    _definition
+;              The maximum, medial and minimum dimensions in millimetres of
+               the crystal. If the crystal is a sphere, then the *_rad item is
+               its radius. If the crystal is a cylinder, then the *_rad item
+               is its radius and the *_length item is its length. These may
+               appear in a list with _exptl_crystal_id if multiple crystals
+               are used in the experiment.
+;
+
+data_exptl_crystal_thermal_history
+    _name                      '_exptl_crystal_thermal_history'
+    _category                    exptl_crystal
+    _type                        char
+    _list                        both
+    _list_reference            '_exptl_crystal_id'
+    _definition
+;              Relevant details concerning the thermal history of the
+               sample.
+;
+
+########################
+## EXPTL_CRYSTAL_FACE ##
+########################
+
+data_exptl_crystal_face_[]
+    _name                      '_exptl_crystal_face_[]'
+    _category                    category_overview
+    _type                        null
+    loop_ _example
+          _example_detail
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+;
+    loop_
+    _exptl_crystal_face_index_h
+    _exptl_crystal_face_index_k
+    _exptl_crystal_face_index_l
+    _exptl_crystal_face_perp_dist
+         0   -1   -2    .18274
+         1    0   -2    .17571
+        -1    1   -2    .17845
+        -2    1    0    .21010
+        -1    0    2    .18849
+         1   -1    2    .20605
+         2   -1    0    .24680
+        -1    2    0    .19688
+         0    1    2    .15206
+;
+;
+    Example 1 - based on structure PAWD2 of Vittal & Dean [Acta
+                Cryst. (1996), C52, 1180-1182].
+;
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+    _definition
+;              Data items in the EXPTL_CRYSTAL_FACE category record details
+               of the crystal faces.
+;
+
+data_exptl_crystal_face_diffr_
+    loop_ _name                '_exptl_crystal_face_diffr_chi'
+                               '_exptl_crystal_face_diffr_kappa'
+                               '_exptl_crystal_face_diffr_phi'
+                               '_exptl_crystal_face_diffr_psi'
+    _category                    exptl_crystal_face
+    _type                        numb
+    _list                        yes
+    _list_reference            '_exptl_crystal_face_index_'
+    _units                       deg
+    _units_detail              'degree of arc'
+    _definition
+;              The goniometer angle settings in degrees when the perpendicular
+               to the specified crystal face is aligned along a specified
+               direction (e.g. the bisector of the incident and reflected beams
+               in an optical goniometer).
+
+;
+
+data_exptl_crystal_face_index_
+    loop_ _name                '_exptl_crystal_face_index_h'
+                               '_exptl_crystal_face_index_k'
+                               '_exptl_crystal_face_index_l'
+    _category                    exptl_crystal_face
+    _type                        numb
+    _list                        yes
+    _list_mandatory              yes
+    _definition
+;              Miller indices of the crystal face associated with the value
+               _exptl_crystal_face_perp_dist.
+;
+
+data_exptl_crystal_face_perp_dist
+    _name                      '_exptl_crystal_face_perp_dist'
+    _category                    exptl_crystal_face
+    _type                        numb
+    _list                        yes
+    _list_reference            '_exptl_crystal_face_index_'
+    _enumeration_range           0.0:
+    _units                       mm
+    _units_detail                millimetre
+    _definition
+;              The perpendicular distance in millimetres from the face to the
+               centre of rotation of the crystal.
+;
+
+##########
+## GEOM ##
+##########
+
+data_geom_[]
+    _name                      '_geom_[]'
+    _category                    category_overview
+    _type                        null
+    loop_ _example
+          _example_detail
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+;
+        _geom_special_details
+    ;  All esds (except the esd in the dihedral angle between
+       two l.s. planes) are estimated using the full covariance
+       matrix. The cell esds are taken into account individually
+       in the estimation of esds in distances, angles and
+       torsion angles; correlations between esds in cell
+       parameters are only used when they are defined by crystal
+       symmetry. An approximate (isotropic) treatment of cell
+       esds is used for estimating esds involving l.s. planes.
+    ;
+;
+;
+    Example 1 - based on data set bagan of Yamane & DiSalvo [Acta
+                Cryst. (1996), C52, 760-761].
+;
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+    _definition
+;              Data items in the GEOM and related (GEOM_ANGLE,
+               GEOM_BOND, GEOM_CONTACT, GEOM_HBOND and GEOM_TORSION)
+               categories record details about the molecular and crystal
+               geometry as calculated from the ATOM,
+               CELL and SYMMETRY data.
+
+               Geometry data are usually redundant, in that they can be
+               calculated from other more fundamental quantities in the data
+               block. However, they serve the dual purposes of providing a
+               check on the correctness of both sets of data and of enabling
+               the most important geometric data to be identified for
+               publication by setting the appropriate publication flag.
+;
+
+data_geom_special_details
+    _name                      '_geom_special_details'
+    _category                    geom
+    _type                        char
+    _definition
+;              The description of geometrical information not covered by the
+               existing data names in the geometry categories, such as
+               least-squares planes.
+;
+
+################
+## GEOM_ANGLE ##
+################
+
+data_geom_angle_[]
+    _name                      '_geom_angle_[]'
+    _category                    category_overview
+    _type                        null
+    loop_ _example
+          _example_detail
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+;
+    loop_
+    _geom_angle_atom_site_label_1
+    _geom_angle_atom_site_label_2
+    _geom_angle_atom_site_label_3
+    _geom_angle
+    _geom_angle_site_symmetry_1
+    _geom_angle_site_symmetry_2
+    _geom_angle_site_symmetry_3
+    _geom_angle_publ_flag
+     C2  O1  C5   111.6(2)  1_555  1_555  1_555  yes
+     O1  C2  C3   110.9(2)  1_555  1_555  1_555  yes
+     O1  C2  O21  122.2(3)  1_555  1_555  1_555  yes
+     C3  C2  O21  127.0(3)  1_555  1_555  1_555  yes
+     C2  C3  N4   101.3(2)  1_555  1_555  1_555  yes
+     C2  C3  C31  111.3(2)  1_555  1_555  1_555  yes
+     C2  C3  H3   107(1)    1_555  1_555  1_555  no
+     N4  C3  C31  116.7(2)  1_555  1_555  1_555  yes
+    # - - - - data truncated for brevity - - - -
+;
+;
+    Example 1 - based on data set TOZ of Willis, Beckwith & Tozer
+                [Acta Cryst. (1991), C47, 2276-2277].
+;
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+    _definition
+;              Data items in the GEOM_ANGLE category record details about the
+               bond angles as calculated from the ATOM,
+               CELL and SYMMETRY data.
+;
+
+data_geom_angle
+    _name                      '_geom_angle'
+    _category                    geom_angle
+    _type                        numb
+    _type_conditions             esd
+    _list                        yes
+    _list_reference            '_geom_angle_atom_site_label_'
+    _units                       deg
+    _units_detail              'degree of arc'
+    _definition
+;              Angle in degrees defined by the three sites
+               _geom_angle_atom_site_label_1, *_2 and *_3. The site at *_2
+               is at the apex of the angle.
+;
+
+data_geom_angle_atom_site_label_
+    loop_ _name                '_geom_angle_atom_site_label_1'
+                               '_geom_angle_atom_site_label_2'
+                               '_geom_angle_atom_site_label_3'
+    _category                    geom_angle
+    _type                        char
+    _list                        yes
+    _list_mandatory              yes
+    _list_link_parent          '_atom_site_label'
+    _definition
+;              The labels of the three atom sites which define the angle
+               given by _geom_angle. These must match labels specified as
+               _atom_site_label in the atom list. Label 2 identifies the site at
+               the apex of the angle.
+;
+
+data_geom_angle_publ_flag
+    _name                      '_geom_angle_publ_flag'
+    _category                    geom_angle
+    _type                        char
+    _list                        yes
+    _list_reference            '_geom_angle_atom_site_label_'
+    loop_ _enumeration
+          _enumeration_detail    no  'do not include angle in special list'
+                                 n   'abbreviation for "no"'
+                                 yes 'do include angle in special list'
+                                 y   'abbreviation for "yes"'
+    _definition
+;              This code signals whether the angle is referred to in a
+               publication or should be placed in a table of significant
+               angles.
+;
+
+data_geom_angle_site_symmetry_
+    loop_ _name                '_geom_angle_site_symmetry_1'
+                               '_geom_angle_site_symmetry_2'
+                               '_geom_angle_site_symmetry_3'
+    _category                    geom_angle
+    _type                        char
+    _list                        yes
+    _list_reference            '_geom_angle_atom_site_label_'
+    loop_ _example
+          _example_detail        .     'no symmetry or translation to site'
+                                 4     '4th symmetry operation applied'
+                                 7_645 '7th symm. posn.; +a on x; -b on y'
+    _definition
+;              The symmetry code of each atom site as the symmetry-equivalent
+               position number 'n' and the cell translation number 'klm'.
+               These numbers are combined to form the code 'n klm' or n_klm.
+               The character string n_klm is composed as follows:
+
+               n refers to the symmetry operation that is applied to the
+               coordinates stored in _atom_site_fract_x, _atom_site_fract_y
+               and _atom_site_fract_z. It must match a number given in
+               _space_group_symop_id.
+
+               k, l and m refer to the translations that are subsequently
+               applied to the symmetry-transformed coordinates to generate
+               the atom used in calculating the angle. These translations
+               (x,y,z) are related to (k,l,m) by the relations
+                    k = 5 + x
+                    l = 5 + y
+                    m = 5 + z
+               By adding 5 to the translations, the use of negative numbers
+               is avoided.
+;
+
+###############
+## GEOM_BOND ##
+###############
+
+data_geom_bond_[]
+    _name                      '_geom_bond_[]'
+    _category                    category_overview
+    _type                        null
+    loop_ _example
+          _example_detail
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+;
+    loop_
+    _geom_bond_atom_site_label_1
+    _geom_bond_atom_site_label_2
+    _geom_bond_distance
+    _geom_bond_site_symmetry_1
+    _geom_bond_site_symmetry_2
+    _geom_bond_publ_flag
+      O1  C2   1.342(4)  1_555  1_555  yes
+      O1  C5   1.439(3)  1_555  1_555  yes
+      C2  C3   1.512(4)  1_555  1_555  yes
+      C2  O21  1.199(4)  1_555  1_555  yes
+      C3  N4   1.465(3)  1_555  1_555  yes
+      C3  C31  1.537(4)  1_555  1_555  yes
+      C3  H3   1.00(3)   1_555  1_555  no
+      N4  C5   1.472(3)  1_555  1_555  yes
+    # - - - - data truncated for brevity - - - -
+;
+;
+    Example 1 - based on data set TOZ of Willis, Beckwith & Tozer
+                [Acta Cryst. (1991), C47, 2276-2277].
+;
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+;
+    loop_
+    _geom_bond_atom_site_label_1
+    _geom_bond_atom_site_label_2
+    _geom_bond_distance
+    _geom_bond_multiplicity
+    Ca1   F1   2.495(9)    1
+    Ca1   F2   2.291(10)   2
+    Ca1   F2   2.391(11)   2
+    Ca1   F3   2.214(11)   2
+    Cr1   F1   1.940(11)   2
+    Cr1   F2   1.918(9)    2
+    Cr1   F3   1.848(10)   2
+;
+;
+    Example 2 - An example showing a listing of only symmetry-unique bonds.
+                In high-symmetry structures when many bonds are related by
+                symmetry, it may not be necessary or desirable to list all
+                the bonds in the environment of the first named atom. Some
+                users may wish to give only the symmetry-independent
+                distances and supply a multiplicity to indicate how many
+                such bonds are found in the atomic environment.
+;
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+;
+    loop_
+    _geom_bond_atom_site_label_1
+    _geom_bond_atom_site_label_2
+    _geom_bond_site_symmetry_2
+    _geom_bond_distance
+    _geom_bond_multiplicity
+    Ca1   F1   1_555  2.495(9)    1
+    Ca1   F2   1_555  2.291(10)   2
+    Ca1   F2   2_555  2.291(10)   0
+    Ca1   F2   3_565  2.391(11)   2
+    Ca1   F2   4_555  2.391(11)   0
+    Ca1   F3   2_545  2.214(11)   2
+    Ca1   F3   5_555  2.214(11)   0
+    Cr1   F1   1_555  1.940(11)   2
+    Cr1   F1   2_555  1.940(11)   0
+    Cr1   F2   1_555  1.918(9)    2
+    Cr1   F2   2_555  1.918(9)    0
+    Cr1   F3   1_555  1.848(10)   2
+    Cr1   F3   2_555  1.848(10)   0
+;
+;
+    Example 3 - The same structure as in Example 2, but where the
+                multiplicity is given with a full bond list. Note the
+                use of a value of 0 for _geom_bond_multiplicity in
+                such a case.
+;
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+    _definition
+;              Data items in the GEOM_BOND category record details about
+               bonds as calculated from the ATOM, CELL
+               and SYMMETRY data.
+;
+
+data_geom_bond_atom_site_label_
+    loop_ _name                '_geom_bond_atom_site_label_1'
+                               '_geom_bond_atom_site_label_2'
+    _category                    geom_bond
+    _type                        char
+    _list                        yes
+    _list_mandatory              yes
+    _list_link_parent          '_atom_site_label'
+    _definition
+;              The labels of two atom sites that form a bond. These must match
+               labels specified as _atom_site_label in the atom list.
+;
+
+data_geom_bond_distance
+    _name                      '_geom_bond_distance'
+    _category                    geom_bond
+    _type                        numb
+    _type_conditions             esd
+    _list                        yes
+    _list_reference            '_geom_bond_atom_site_label_'
+    _enumeration_range           0.0:
+    _units                       A
+    _units_detail                angstrom
+    _definition
+;              The intramolecular bond distance in angstroms.
+;
+
+data_geom_bond_multiplicity
+    _name                      '_geom_bond_multiplicity'
+    _category                    geom_bond
+    _type                        numb
+    _list                        yes
+    _list_reference            '_geom_bond_atom_site_label_'
+    _enumeration_range           0:
+    _definition
+;              The number of times the given bond appears in the environment
+               of the atoms labelled _geom_bond_atom_site_label_1. In cases
+               where the full list of bonds is given, one of the series of
+               equivalent bonds may be assigned the appropriate multiplicity
+               while the others are assigned a value of 0.
+;
+
+data_geom_bond_publ_flag
+    _name                      '_geom_bond_publ_flag'
+    _category                    geom_bond
+    _type                        char
+    _list                        yes
+    _list_reference            '_geom_bond_atom_site_label_'
+    loop_ _enumeration
+          _enumeration_detail    no  'do not include bond in special list'
+                                 n   'abbreviation for "no"'
+                                 yes 'do include bond in special list'
+                                 y   'abbreviation for "yes"'
+    _definition
+;              This code signals whether the bond distance is referred to in a
+               publication or should be placed in a list of significant bond
+               distances.
+;
+
+data_geom_bond_site_symmetry_
+    loop_ _name                '_geom_bond_site_symmetry_1'
+                               '_geom_bond_site_symmetry_2'
+    _category                    geom_bond
+    _type                        char
+    _list                        yes
+    _list_reference            '_geom_bond_atom_site_label_'
+    loop_ _example
+          _example_detail        .     'no symmetry or translation to site'
+                                 4     '4th symmetry operation applied'
+                                 7_645 '7th symm. posn.; +a on x; -b on y'
+    _definition
+;              The symmetry code of each atom site as the symmetry-equivalent
+               position number 'n' and the cell translation number 'klm'.
+               These numbers are combined to form the code 'n klm' or n_klm.
+               The character string n_klm is composed as follows:
+
+               n refers to the symmetry operation that is applied to the
+               coordinates stored in _atom_site_fract_x, _atom_site_fract_y
+               and _atom_site_fract_z. It must match a number given in
+               _space_group_symop_id.
+
+               k, l and m refer to the translations that are subsequently
+               applied to the symmetry-transformed coordinates to generate
+               the atom used in calculating the bond. These translations
+               (x,y,z) are related to (k,l,m) by the relations
+                    k = 5 + x
+                    l = 5 + y
+                    m = 5 + z
+               By adding 5 to the translations, the use of negative numbers
+               is avoided.
+;
+
+data_geom_bond_valence
+    _name                      '_geom_bond_valence'
+    _category                    geom_bond
+    _type                        numb
+    _list                        yes
+    _list_reference            '_geom_bond_atom_site_label_'
+    _definition
+;              The bond valence calculated from _geom_bond_distance.
+;
+
+
+##################
+## GEOM_CONTACT ##
+##################
+
+data_geom_contact_[]
+    _name                      '_geom_contact_[]'
+    _category                    category_overview
+    _type                        null
+    loop_ _example
+          _example_detail
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+;
+    loop_
+     _geom_contact_atom_site_label_1
+     _geom_contact_atom_site_label_2
+     _geom_contact_distance
+     _geom_contact_site_symmetry_1
+     _geom_contact_site_symmetry_2
+     _geom_contact_publ_flag
+     O(1)  O(2)     2.735(3)  .  .  yes
+     H(O1) O(2)     1.82      .  .  no
+;
+;
+    Example 1 - based on data set CLPHO6 of Ferguson, Ruhl, McKervey & Browne
+                [Acta Cryst. (1992), C48, 2262-2264].
+;
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+    _definition
+;              Data items in the GEOM_CONTACT category record details about
+               interatomic contacts as calculated from the
+               ATOM, CELL and SYMMETRY data.
+;
+
+data_geom_contact_atom_site_label_
+    loop_ _name                '_geom_contact_atom_site_label_1'
+                               '_geom_contact_atom_site_label_2'
+    _category                    geom_contact
+    _type                        char
+    _list                        yes
+    _list_mandatory              yes
+    _list_link_parent          '_atom_site_label'
+    _definition
+;              The labels of two atom sites that are within contact distance.
+               The labels must match _atom_site_label codes in the atom list.
+;
+
+data_geom_contact_distance
+    _name                      '_geom_contact_distance'
+    _category                    geom_contact
+    _type                        numb
+    _type_conditions             esd
+    _list                        yes
+    _list_reference            '_geom_contact_atom_site_label_'
+    _enumeration_range           0.0:
+    _units                       A
+    _units_detail                angstrom
+    _definition
+;              The interatomic contact distance in angstroms.
+;
+
+data_geom_contact_publ_flag
+    _name                      '_geom_contact_publ_flag'
+    _category                    geom_contact
+    _type                        char
+    _list                        yes
+    _list_reference            '_geom_contact_atom_site_label_'
+    loop_ _enumeration
+          _enumeration_detail    no  'do not include distance in special list'
+                                 n   'abbreviation for "no"'
+                                 yes 'do include distance in special list'
+                                 y   'abbreviation for "yes"'
+    _definition
+;              This code signals whether the contact distance is referred to
+               in a publication or should be placed in a list of significant
+               contact distances.
+;
+
+data_geom_contact_site_symmetry_
+    loop_ _name                '_geom_contact_site_symmetry_1'
+                               '_geom_contact_site_symmetry_2'
+    _category                    geom_contact
+    _type                        char
+    _list                        yes
+    _list_reference            '_geom_contact_atom_site_label_'
+    loop_ _example
+          _example_detail        .     'no symmetry or translation to site'
+                                 4     '4th symmetry operation applied'
+                                 7_645 '7th symm. posn.; +a on x; -b on y'
+    _definition
+;              The symmetry code of each atom site as the symmetry-equivalent
+               position number 'n' and the cell translation number 'klm'.
+               These numbers are combined to form the code 'n klm' or n_klm.
+               The character string n_klm is composed as follows:
+
+               n refers to the symmetry operation that is applied to the
+               coordinates stored in _atom_site_fract_x, _atom_site_fract_y
+               and _atom_site_fract_z. It must match a number given in
+               _space_group_symop_id.
+
+               k, l and m refer to the translations that are subsequently
+               applied to the symmetry-transformed coordinates to generate
+               the atom used in calculating the contact. These translations
+               (x,y,z) are related to (k,l,m) by the relations
+                    k = 5 + x
+                    l = 5 + y
+                    m = 5 + z
+               By adding 5 to the translations, the use of negative numbers
+               is avoided.
+;
+
+################
+## GEOM_HBOND ##
+################
+
+data_geom_hbond_[]
+    _name                      '_geom_hbond_[]'
+    _category                    category_overview
+    _type                        null
+    loop_ _example
+          _example_detail
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+;
+    loop_
+    _geom_hbond_atom_site_label_D
+    _geom_hbond_atom_site_label_H
+    _geom_hbond_atom_site_label_A
+    _geom_hbond_distance_DH
+    _geom_hbond_distance_HA
+    _geom_hbond_distance_DA
+    _geom_hbond_angle_DHA
+    _geom_hbond_publ_flag
+
+    N6   HN6  OW   0.888(8)  1.921(12)  2.801(8)  169.6(8)  yes
+    OW   HO2  O7   0.917(6)  1.923(12)  2.793(8)  153.5(8)  yes
+    OW   HO1  N10  0.894(8)  1.886(11)  2.842(8)  179.7(9)  yes
+;
+;
+    Example 1 - based on C~14~H~13~ClN~2~O.H~2~O, reported by Palmer,
+                Puddle & Lisgarten [Acta Cryst. (1993), C49, 1777-1779].
+;
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+    _definition
+;              Data items in the GEOM_HBOND category record details about
+               hydrogen bonds as calculated from the ATOM,
+               CELL and SYMMETRY data.
+;
+
+data_geom_hbond_angle_DHA
+    _name                      '_geom_hbond_angle_DHA'
+    _category                    geom_hbond
+    _type                        numb
+    _type_conditions             esd
+    _list                        yes
+    _list_reference            '_geom_hbond_atom_site_label_'
+    _units                       deg
+    _units_detail              'degree of arc'
+    _definition
+;              Angle in degrees defined by the three sites
+               _geom_hbond_atom_site_label_D, *_H and *_A. The site at *_H
+               (the hydrogen atom participating in the interaction) is at
+               the apex of the angle.
+;
+
+data_geom_hbond_atom_site_label_
+    loop_ _name                '_geom_hbond_atom_site_label_D'
+                               '_geom_hbond_atom_site_label_H'
+                               '_geom_hbond_atom_site_label_A'
+    _category                    geom_hbond
+    _type                        char
+    _list                        yes
+    _list_mandatory              yes
+    _list_link_parent          '_atom_site_label'
+    _definition
+;              The labels of three atom sites (respectively, the donor atom,
+               hydrogen atom and acceptor atom) participating in a hydrogen
+               bond. These must match labels specified as _atom_site_label
+               in the atom list.
+;
+
+data_geom_hbond_distance_
+    loop_ _name                '_geom_hbond_distance_DH'
+                               '_geom_hbond_distance_HA'
+                               '_geom_hbond_distance_DA'
+    _category                    geom_hbond
+    _type                        numb
+    _type_conditions             esd
+    _list                        yes
+    _list_reference            '_geom_hbond_atom_site_label_'
+    _enumeration_range           0.0:
+    _units                       A
+    _units_detail                angstrom
+    _definition
+;              Distances in angstroms between the donor and hydrogen (*_DH),
+               hydrogen and acceptor (*_HA) and donor and acceptor (*_DA)
+               sites in a hydrogen bond.
+;
+
+data_geom_hbond_publ_flag
+    _name                      '_geom_hbond_publ_flag'
+    _category                    geom_hbond
+    _type                        char
+    _list                        yes
+    _list_reference            '_geom_hbond_atom_site_label_'
+    loop_ _enumeration
+          _enumeration_detail    no  'do not include bond in special list'
+                                 n   'abbreviation for "no"'
+                                 yes 'do include bond in special list'
+                                 y   'abbreviation for "yes"'
+    _definition
+;              This code signals whether the hydrogen-bond information
+               is referred to in a publication or should be placed in a
+               table of significant hydrogen-bond geometry.
+;
+
+data_geom_hbond_site_symmetry_
+    loop_ _name                '_geom_hbond_site_symmetry_D'
+                               '_geom_hbond_site_symmetry_H'
+                               '_geom_hbond_site_symmetry_A'
+    _category                    geom_hbond
+    _type                        char
+    _list                        yes
+    _list_reference            '_geom_hbond_atom_site_label_'
+    loop_ _example
+          _example_detail        .     'no symmetry or translation to site'
+                                 4     '4th symmetry operation applied'
+                                 7_645 '7th symm. posn.; +a on x; -b on y'
+    _definition
+;              The symmetry code of each atom site as the symmetry-equivalent
+               position number 'n' and the cell translation number 'klm'.
+               These numbers are combined to form the code 'n klm' or n_klm.
+               The character string n_klm is composed as follows:
+
+               n refers to the symmetry operation that is applied to the
+               coordinates stored in _atom_site_fract_x, _atom_site_fract_y
+               and _atom_site_fract_z. It must match a number given in
+               _space_group_symop_id.
+
+               k, l and m refer to the translations that are subsequently
+               applied to the symmetry-transformed coordinates to generate
+               the atom used in calculating the hydrogen bond. These
+               translations (x,y,z) are related to (k,l,m) by the relations
+                    k = 5 + x
+                    l = 5 + y
+                    m = 5 + z
+               By adding 5 to the translations, the use of negative numbers
+               is avoided.
+;
+
+##################
+## GEOM_TORSION ##
+##################
+
+data_geom_torsion_[]
+    _name                      '_geom_torsion_[]'
+    _category                    category_overview
+    _type                        null
+    loop_ _example
+          _example_detail
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+;
+    loop_
+     _geom_torsion_atom_site_label_1
+     _geom_torsion_atom_site_label_2
+     _geom_torsion_atom_site_label_3
+     _geom_torsion_atom_site_label_4
+     _geom_torsion
+     _geom_torsion_site_symmetry_1
+     _geom_torsion_site_symmetry_2
+     _geom_torsion_site_symmetry_3
+     _geom_torsion_site_symmetry_4
+     _geom_torsion_publ_flag
+     C(9)  O(2)  C(7)   C(2)    71.8(2)  .  .  .  .      yes
+     C(7)  O(2)  C(9)   C(10) -168.0(3)  .  .  .  2_666  yes
+     C(10) O(3)  C(8)   C(6)  -167.7(3)  .  .  .  .      yes
+     C(8)  O(3)  C(10)  C(9)   -69.7(2)  .  .  .  2_666  yes
+     O(1)  C(1)  C(2)   C(3)  -179.5(4)  .  .  .  .      no
+     O(1)  C(1)  C(2)   C(7)    -0.6(1)  .  .  .  .      no
+;
+;
+     Example 1 - based on data set CLPHO6 of Ferguson, Ruhl, McKervey & Browne
+                [Acta Cryst. (1992), C48, 2262-2264].
+;
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+    _definition
+;              Data items in the GEOM_TORSION category record details about
+               interatomic torsion angles as calculated from
+               the ATOM, CELL and SYMMETRY data.
+;
+
+data_geom_torsion
+    _name                      '_geom_torsion'
+    _category                    geom_torsion
+    _type                        numb
+    _type_conditions             esd
+    _list                        yes
+    _list_reference            '_geom_torsion_atom_site_label_'
+    _units                       deg
+    _units_detail              'degree of arc'
+    _definition
+;              The torsion angle in degrees bounded by the four atom sites
+               identified by the _geom_torsion_atom_site_label_ codes. These
+               must match labels specified as _atom_site_label in the atom list.
+               The torsion-angle definition should be that of Klyne and Prelog.
+
+               Ref: Klyne, W. & Prelog, V. (1960). Experientia, 16, 521-523.
+;
+
+data_geom_torsion_atom_site_label_
+    loop_ _name                '_geom_torsion_atom_site_label_1'
+                               '_geom_torsion_atom_site_label_2'
+                               '_geom_torsion_atom_site_label_3'
+                               '_geom_torsion_atom_site_label_4'
+    _category                    geom_torsion
+    _type                        char
+    _list                        yes
+    _list_mandatory              yes
+    _list_link_parent          '_atom_site_label'
+    _definition
+;              The labels of the four atom sites which define the torsion angle
+               specified by _geom_torsion. These must match codes specified as
+               _atom_site_label in the atom list. The torsion-angle definition
+               should be that of Klyne and Prelog. The vector direction
+               *_label_2 to *_label_3 is the viewing direction, and the torsion
+               angle is the angle of twist required to superimpose the
+               projection of the vector between site 2 and site 1 onto the
+               projection of the vector between site 3 and site 4. Clockwise
+               torsions are positive, anticlockwise torsions are negative.
+
+               Ref: Klyne, W. & Prelog, V. (1960). Experientia, 16, 521-523.
+;
+
+data_geom_torsion_publ_flag
+    _name                      '_geom_torsion_publ_flag'
+    _category                    geom_torsion
+    _type                        char
+    _list                        yes
+    _list_reference            '_geom_torsion_atom_site_label_'
+    loop_ _enumeration
+          _enumeration_detail    no  'do not include angle in special list'
+                                 n   'abbreviation for "no"'
+                                 yes 'do include angle in special list'
+                                 y   'abbreviation for "yes"'
+    _definition
+;              This code signals whether the torsion angle is referred to in a
+               publication or should be placed in a table of significant
+               torsion angles.
+;
+
+data_geom_torsion_site_symmetry_
+    loop_ _name                '_geom_torsion_site_symmetry_1'
+                               '_geom_torsion_site_symmetry_2'
+                               '_geom_torsion_site_symmetry_3'
+                               '_geom_torsion_site_symmetry_4'
+    _category                    geom_torsion
+    _type                        char
+    _list                        yes
+    _list_reference            '_geom_torsion_atom_site_label_'
+    loop_ _example
+          _example_detail        .     'no symmetry or translation to site'
+                                 4     '4th symmetry operation applied'
+                                 7_645 '7th symm. posn.; +a on x; -b on y'
+    _definition
+;              The symmetry code of each atom site as the symmetry-equivalent
+               position number 'n' and the cell translation number 'klm'.
+               These numbers are combined to form the code 'n klm' or n_klm.
+               The character string n_klm is composed as follows:
+
+               n refers to the symmetry operation that is applied to the
+               coordinates stored in _atom_site_fract_x, _atom_site_fract_y
+               and _atom_site_fract_z. It must match a number given in
+               _space_group_symop_id.
+
+               k, l and m refer to the translations that are subsequently
+               applied to the symmetry-transformed coordinates to generate
+               the atom used in calculating the angle. These translations
+               (x,y,z) are related to (k,l,m) by the relations
+                    k = 5 + x
+                    l = 5 + y
+                    m = 5 + z
+               By adding 5 to the translations, the use of negative numbers
+               is avoided.
+;
+
+#############
+## JOURNAL ##
+#############
+
+data_journal_[]
+    _name                      '_journal_[]'
+    _category                    category_overview
+    _type                        null
+    loop_ _example
+          _example_detail
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+;
+    _journal_date_recd_electronic     91-04-15
+    _journal_date_from_coeditor       91-04-18
+    _journal_date_accepted            91-04-18
+    _journal_date_printers_first      91-08-07
+    _journal_date_proofs_out          91-08-07
+    _journal_coeditor_code            HL0007
+    _journal_techeditor_code          C910963
+    _journal_coden_ASTM               ACSCEE
+    _journal_name_full        'Acta Crystallographica Section C'
+    _journal_year                     1991
+    _journal_volume                   47
+    _journal_issue                    NOV91
+    _journal_page_first               2276
+    _journal_page_last                2277
+;
+;
+    Example 1 - based on Acta Cryst. file for entry HL0007 [Willis, Beckwith
+                & Tozer (1991). Acta Cryst. C47, 2276-2277].
+;
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+    _definition
+;              Data items in the JOURNAL category record details about the
+               book-keeping by the journal staff when processing
+               a CIF submitted for publication.
+
+               The creator of a CIF will not normally specify these data items.
+               The data names are not defined in the dictionary because they are
+               for journal use only.
+;
+
+data_journal_
+    loop_ _name                '_journal_coden_ASTM'
+                               '_journal_coden_Cambridge'
+                               '_journal_coeditor_address'
+                               '_journal_coeditor_code'
+                               '_journal_coeditor_email'
+                               '_journal_coeditor_fax'
+                               '_journal_coeditor_name'
+                               '_journal_coeditor_notes'
+                               '_journal_coeditor_phone'
+                               '_journal_data_validation_number'
+                               '_journal_date_accepted'
+                               '_journal_date_from_coeditor'
+                               '_journal_date_to_coeditor'
+                               '_journal_date_printers_final'
+                               '_journal_date_printers_first'
+                               '_journal_date_proofs_in'
+                               '_journal_date_proofs_out'
+                               '_journal_date_recd_copyright'
+                               '_journal_date_recd_electronic'
+                               '_journal_date_recd_hard_copy'
+                               '_journal_issue'
+                               '_journal_language'
+                               '_journal_name_full'
+                               '_journal_page_first'
+                               '_journal_page_last'
+                               '_journal_paper_category'
+                               '_journal_paper_doi'
+                               '_journal_suppl_publ_number'
+                               '_journal_suppl_publ_pages'
+                               '_journal_techeditor_address'
+                               '_journal_techeditor_code'
+                               '_journal_techeditor_email'
+                               '_journal_techeditor_fax'
+                               '_journal_techeditor_name'
+                               '_journal_techeditor_notes'
+                               '_journal_techeditor_phone'
+                               '_journal_volume'
+                               '_journal_year'
+    _category                    journal
+    _type                        char
+    _definition
+;              Data items specified by the journal staff.
+;
+
+###################
+## JOURNAL_INDEX ##
+###################
+
+data_journal_index_[]
+    _name                      '_journal_index_[]'
+    _category                    category_overview
+    _type                        null
+    loop_ _example
+          _example_detail
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+;
+    loop_
+    _journal_index_type
+    _journal_index_term
+    _journal_index_subterm
+      O   C16H19NO4            .
+      S   alkaloids           (-)-norcocaine
+      S   (-)-norcocaine       .
+      S
+    ;  [2R,3S-(2\b,3\b)]-methyl
+       3-(benzoyloxy)-8-azabicyclo[3.2.1]octane-2-carboxylate
+    ;                          .
+;
+;
+    Example 1 - based on a paper by Zhu, Reynolds, Klein & Trudell
+                [Acta Cryst. (1994), C50, 2067-2069].
+;
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+    _definition
+;              Data items in the JOURNAL_INDEX category are used to list
+               terms used to generate the journal indexes.
+
+               The creator of a CIF will not normally specify these data items.
+;
+
+data_journal_index_
+    loop_ _name                '_journal_index_subterm'
+                               '_journal_index_term'
+                               '_journal_index_type'
+    _category                    journal_index
+    _type                        char
+    _definition
+;             Indexing terms supplied by the journal staff.
+;
+
+##########
+## PUBL ##
+##########
+
+data_publ_[]
+    _name                      '_publ_[]'
+    _category                    category_overview
+    _type                        null
+    loop_ _example
+          _example_detail
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+;    _publ_section_title
+    ;  trans-3-Benzoyl-2-(tert-butyl)-4-(iso-butyl)-
+       1,3-oxazolidin-5-one
+    ;
+
+    _publ_section_abstract
+    ;  The oxazolidinone ring is a shallow envelope
+       conformation with the tert-butyl and iso-butyl groups
+       occupying trans-positions with respect to the ring. The
+       angles at the N atom sum to 356.2\%, indicating a very
+       small degree of pyramidalization at this atom. This is
+       consistent with electron delocalization between the N
+       atom and the carbonyl centre [N-C=O = 1.374(3)\%A].
+    ;
+;
+;
+    Example 1 - based on Willis, Beckwith & Tozer
+                [Acta Cryst. (1991), C47, 2276-2277].
+;
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+;    _publ_section_title
+    ;  Hemiasterlin methyl ester
+    ;
+
+    _publ_section_title_footnote
+    ;  IUPAC name: methyl 2,5-dimethyl-4-{2-[3-methyl-
+       2-methylamino-3-(N-methylbenzo[b]pyrrol-
+       3-yl)butanamido]-3,3-dimethyl-N-methyl-
+       butanamido}-2-hexenoate.
+    ;
+;
+;
+    Example 2 - based on C~31~H~48~N~4~O~4~, reported by Coleman, Patrick,
+                Andersen & Rettig [Acta Cryst. (1996), C52, 1525-1527].
+;
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+    _definition
+;              Data items in the PUBL category are used when submitting a
+               manuscript for publication. They refer either to the paper as
+               a whole, or to specific named elements within a paper (such as
+               the title and abstract, or the Comment and Experimental
+               sections of Acta Crystallographica Section C). The data items
+               in the PUBL_BODY category should be used for the text
+               of other submissions. Typically, each journal will
+               supply a list of the specific items it requires in its Notes
+               for Authors.
+;
+
+data_publ_contact_author
+    _name                      '_publ_contact_author'
+    _category                    publ
+    _type                        char
+     loop_
+    _example
+;                       Professor George Ferguson
+                        Department of Chemistry and Biochemistry
+                        University of Guelph
+                        Ontario
+                        Canada
+                        N1G 2W1
+;
+    _definition
+;              The name and address of the author submitting the manuscript and
+               data block. This is the person contacted by the journal
+               editorial staff. It is preferable to use the separate data items
+               _publ_contact_author_name and _publ_contact_author_address.
+;
+
+data_publ_contact_author_address
+    _name                      '_publ_contact_author_address'
+    _category                    publ
+    _type                        char
+    _example
+;                       Department of Chemistry and Biochemistry
+                        University of Guelph
+                        Ontario
+                        Canada
+                        N1G 2W1
+;
+    _definition
+;              The address of the author submitting the manuscript and
+               data block. This is the person contacted by the journal
+               editorial staff.
+;
+
+data_publ_contact_author_email
+    _name                      '_publ_contact_author_email'
+    _category                    publ
+    _type                        char
+    loop_ _example               name@host.domain.country
+                                 bm@iucr.org
+    _definition
+;              E-mail address in a form recognizable to international networks.
+               The format of e-mail addresses is given in Section 3.4, Address
+               Specification, of  Internet Message Format, RFC 2822, P. Resnick
+               (Editor), Network Standards Group, April 2001.
+;
+
+data_publ_contact_author_fax
+    _name                      '_publ_contact_author_fax'
+    _category                    publ
+    _type                        char
+     loop_
+    _example                    '12(34)9477334'
+                                '12()349477334'
+    _definition
+;              Facsimile telephone number of the author submitting the
+               manuscript and data block.
+
+               The recommended style is the international dialing
+               prefix, followed  by the area code in parentheses, followed by
+               the local number with no spaces. The earlier convention of
+               including the international dialing prefix in parentheses is
+               no longer recommended.
+;
+
+data_publ_contact_author_id_iucr
+    _name                      '_publ_contact_author_id_iucr'
+    _category                    publ
+    _type                        char
+    _example                     2985
+    _definition
+;              Identifier in the IUCr contact database of the author
+               submitting the manuscript and data block. This identifier may
+               be available from the World Directory of Crystallographers
+               (http://wdc.iucr.org).
+;
+
+data_publ_contact_author_id_orcid
+    _name                      '_publ_contact_author_id_orcid'
+    _category                    publ
+    _type                        char
+    _example                     0000-0003-0391-0002
+    _definition
+;              Identifier in the ORCID Registry of the author submitting
+               the manuscript and data block. ORCID is an open, non-profit,
+               community-driven service to provide a registry of unique
+               researcher identifiers (http://orcid.org).
+;
+
+data_publ_contact_author_name
+    _name                      '_publ_contact_author_name'
+    _category                    publ
+    _type                        char
+    _example                    'Professor George Ferguson'
+    _definition
+;              The name of the author submitting the manuscript and
+               data block. This is the person contacted by the journal
+               editorial staff.
+;
+
+data_publ_contact_author_phone
+    _name                      '_publ_contact_author_phone'
+    _category                    publ
+    _type                        char
+     loop_
+    _example                    '12(34)9477330'
+                                '12()349477330'
+                                '12(34)9477330x5543'
+    _definition
+;              Telephone number of the author submitting the manuscript and
+               data block.
+
+               The recommended style is the international dialing
+               prefix, followed by the area code in parentheses, followed by the
+               local number and any extension number prefixed by 'x',
+               with no spaces. The earlier convention of including
+               the international dialing prefix in parentheses is no longer
+               recommended.
+;
+
+data_publ_contact_letter
+    _name                      '_publ_contact_letter'
+    _category                    publ
+    _type                        char
+    _definition
+;              A letter submitted to the journal editor by the contact author.
+;
+
+data_publ_manuscript_creation
+    _name                      '_publ_manuscript_creation'
+    _category                    publ
+    _type                        char
+    _example                    'Tex file created by FrameMaker on a Sun 3/280'
+    _definition
+;              A description of the word-processor package and computer used to
+               create the word-processed manuscript stored as
+               _publ_manuscript_processed.
+;
+
+data_publ_manuscript_processed
+    _name                      '_publ_manuscript_processed'
+    _category                    publ
+    _type                        char
+    _definition
+;              The full manuscript of a paper (excluding possibly the figures
+               and the tables) output in ASCII characters from a word processor.
+               Information about the generation of this data item must be
+               specified in the data item _publ_manuscript_creation.
+;
+
+data_publ_manuscript_text
+    _name                      '_publ_manuscript_text'
+    _category                    publ
+    _type                        char
+    _definition
+;              The full manuscript of a paper (excluding figures and possibly
+               the tables) output as standard ASCII text.
+;
+
+data_publ_requested_category
+    _name                      '_publ_requested_category'
+    _category                    publ
+    _type                        char
+    loop_ _enumeration
+          _enumeration_detail
+            AD  'Addenda and Errata (Acta C, Acta E)'
+            CI  'CIF-access paper - inorganic (Acta C) (no longer in use)'
+            CM  'CIF-access paper - metal-organic (Acta C) (no longer in use)'
+            CO  'CIF-access paper - organic (Acta C)  (no longer in use)'
+            EI  'Electronic submission - inorganic (Acta E)'
+            EM  'Electronic submission - metal-organic (Acta E)'
+            EO  'Electronic submission - organic (Acta E)'
+            FA  'Full article'
+            FI  'Full submission - inorganic (Acta C)'
+            FM  'Full submission - metal-organic (Acta C)'
+            FO  'Full submission - organic (Acta C)'
+            GI  'Research communications - inorganic compounds (Acta E)'
+            GM  'Research communications - metal-organic compounds (Acta E)'
+            GO  'Research communications - organic compounds (Acta E)'
+            HI  'Data reports - inorganic compounds (Acta E)'
+            HM  'Data reports - metal-organic compounds (Acta E)'
+            HO  'Data reports - organic compounds (Acta E)'
+            QI  'Inorganic compounds (Acta E)'
+            QM  'Metal-organic compounds (Acta E)'
+            QO  'Organic compounds (Acta E)'
+            SC  'Short communication'
+    _enumeration_default         FA
+    _definition
+;              The category of paper submitted. For submission to Acta
+               Crystallographica Section C or Acta Crystallographica
+               Section E, ONLY those codes indicated for use with those
+               journals should be used.
+;
+
+data_publ_requested_coeditor_name
+    _name                      '_publ_requested_coeditor_name'
+    _category                    publ
+    _type                        char
+    _definition
+;              The name of the co-editor whom the authors would like to
+               handle the submitted manuscript.
+;
+
+data_publ_requested_journal
+    _name                      '_publ_requested_journal'
+    _category                    publ
+    _type                        char
+    _definition
+;              The name of the journal to which the manuscript is being
+               submitted.
+;
+
+data_publ_section_
+    loop_ _name                '_publ_section_title'
+                               '_publ_section_title_footnote'
+                               '_publ_section_synopsis'
+                               '_publ_section_abstract'
+                               '_publ_section_comment'
+                               '_publ_section_introduction'
+                               '_publ_section_experimental'
+                               '_publ_section_exptl_prep'
+                               '_publ_section_exptl_refinement'
+                               '_publ_section_exptl_solution'
+                               '_publ_section_discussion'
+                               '_publ_section_acknowledgements'
+                               '_publ_section_references'
+                               '_publ_section_related_literature'
+                               '_publ_section_figure_captions'
+                               '_publ_section_table_legends'
+                               '_publ_section_keywords'
+    _category                    publ
+    _type                        char
+    _definition
+;              The sections of a manuscript if submitted in parts. As
+               an alternative, see _publ_manuscript_text and
+               _publ_manuscript_processed.
+
+               The _publ_section_exptl_prep, _publ_section_exptl_refinement
+               and _publ_section_exptl_solution items are preferred for
+               separating the chemical preparation, refinement and structure
+               solution aspects of the experimental description.
+;
+
+#################
+## PUBL_AUTHOR ##
+#################
+
+data_publ_author_[]
+    _name                      '_publ_author_[]'
+    _category                    category_overview
+    _type                        null
+    loop_ _example
+          _example_detail
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+;
+    loop_
+    _publ_author_name
+    _publ_author_address
+
+         'Willis, Anthony C.'
+    ;    Research School of Chemistry
+         Australian National University
+         GPO Box 4
+         Canberra, ACT
+         Australia    2601
+    ;
+;
+;
+    Example 1 - based on Willis, Beckwith & Tozer
+                [Acta Cryst. (1991), C47, 2276-2277].
+;
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+    _definition
+;              Data items in the PUBL_AUTHOR category record details of
+               the authors of a manuscript submitted for publication.
+;
+
+data_publ_author_address
+    _name                      '_publ_author_address'
+    _category                    publ_author
+    _type                        char
+    _list                        both
+    _list_reference            '_publ_author_name'
+    _example
+;                       Department
+                        Institute
+                        Street
+                        City and postcode
+                        COUNTRY
+;
+    _definition
+;              The address of a publication author. If there is more than one
+               author, this will be looped with _publ_author_name.
+;
+data_publ_author_email
+    _name                      '_publ_author_email'
+    _category                    publ_author
+    _type                        char
+    _list                        both
+    _list_reference            '_publ_author_name'
+    loop_ _example               name@host.domain.country
+                                 bm@iucr.org
+    _definition
+;              The e-mail address of a publication author. If there is more
+               than one author, this will be looped with _publ_author_name.
+               The format of e-mail addresses is given in Section 3.4, Address
+               Specification, of  Internet Message Format, RFC 2822, P. Resnick
+               (Editor), Network Standards Group, April 2001.
+;
+
+data_publ_author_footnote
+    _name                      '_publ_author_footnote'
+    _category                    publ_author
+    _type                        char
+    _list                        both
+    _list_reference            '_publ_author_name'
+    loop_ _example              'On leave from U. Western Australia'
+                                'Also at Department of Biophysics'
+    _definition
+;              A footnote accompanying an author's name in the list of authors
+               of a paper. Typically indicates sabbatical address, additional
+               affiliations or date of decease.
+;
+
+data_publ_author_id_iucr
+    _name                      '_publ_author_id_iucr'
+    _category                    publ_author
+    _type                        char
+    _list                        both
+    _example                     2985
+    _definition
+;              Identifier in the IUCr contact database of a publication
+               author.  This identifier may be available from the World
+               Directory of Crystallographers (http://wdc.iucr.org).
+;
+
+data_publ_author_id_orcid
+    _name                      '_publ_author_id_orcid'
+    _category                    publ_author
+    _type                        char
+    _list                        both
+    _example                     0000-0003-0391-0002
+    _definition
+;              Identifier in the ORCID Registry of a publication
+               author. ORCID is an open, non-profit, community-driven
+               service to provide a registry of unique researcher
+               identifiers (http://orcid.org).
+;
+
+data_publ_author_name
+    _name                      '_publ_author_name'
+    _category                    publ_author
+    _type                        char
+    _list                        both
+    _list_mandatory              yes
+    loop_ _example             'Bleary, Percival R.'
+                               "O'Neil, F.K."
+                               'Van den Bossche, G.'
+                               'Yang, D.-L.'
+                               'Simonov, Yu.A.'
+                               'M\"uller, H.A.'
+                               'Ross II, C.R.'
+    _definition
+;              The name of a publication author. If there are multiple authors,
+               this will be looped with _publ_author_address. The family
+               name(s), followed by a comma and including any dynastic
+               components, precedes the first names or initials.
+;
+
+###############
+## PUBL_BODY ##
+###############
+
+data_publ_body_[]
+    _name                      '_publ_body_[]'
+    _category                    category_overview
+    _type                        null
+    loop_ _example
+          _example_detail
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+;
+    loop_
+    _publ_body_element
+    _publ_body_label
+    _publ_body_title
+    _publ_body_format
+    _publ_body_contents
+
+         section   1         Introduction                    cif
+    ; X-ray diffraction from a crystalline material provides
+      information on the thermally and spatially averaged
+      electron density in the crystal...
+    ;
+         section   2         Theory                           tex
+    ; In the rigid-atom approximation, the dynamic electron
+      density of an atom is described by the convolution
+      product of the static atomic density and a probability
+      density function,
+      $\rho_{dyn}(\bf r) = \rho_{stat}(\bf r) * P(\bf r). \eqno(1)$
+    ;
+;
+;
+    Example 1 - based on a paper by R. Restori & D. Schwarzenbach
+                [Acta Cryst. (1996), A52, 369-378].
+;
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+;
+    loop_
+    _publ_body_element
+    _publ_body_label
+    _publ_body_title
+    _publ_body_contents
+
+         section     3
+    ; The two-channel method for retrieval of the deformation
+      electron density
+    ;
+         .
+         subsection  3.1  'The two-channel entropy S[\D\r(r)]'
+    ; As the wide dynamic range involved in the total electron
+      density...
+    ;
+         subsection  3.2
+    'Uniform vs informative prior model densities'        .
+         subsubsection  3.2.1  'Use of uniform models'
+    ; Straightforward algebra leads to expressions analogous
+      to...
+    ;
+;
+;
+    Example 2 - based on a paper by R. J. Papoular, Y. Vekhter & P. Coppens
+                [Acta Cryst. (1996), A52, 397-407].
+;
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+    _definition
+;              Data items in the PUBL_BODY category permit the labelling of
+               different text sections within the body of a paper.
+               Note that these should not be used in a paper which has
+               a standard format with sections tagged by specific data names
+               (such as in Acta Crystallographica Section C). Typically,
+               each journal will supply a list of the specific items it
+               requires in its Notes for Authors.
+;
+
+data_publ_body_contents
+    _name                      '_publ_body_contents'
+    _category                    publ_body
+    _type                        char
+    _list                        yes
+    _list_reference            '_publ_body_label'
+    _definition
+;              A text section of a paper.
+;
+
+data_publ_body_element
+    _name                      '_publ_body_element'
+    _category                    publ_body
+    _type                        char
+    _list                        yes
+    _list_reference            '_publ_body_label'
+    loop_ _enumeration
+                                 section
+                                 subsection
+                                 subsubsection
+                                 appendix
+                                 footnote
+    _definition
+;              The functional role of the associated text section.
+;
+
+data_publ_body_format
+    _name                      '_publ_body_format'
+    _category                    publ_body
+    _type                        char
+    _list                        yes
+    _list_reference            '_publ_body_label'
+    loop_ _enumeration
+          _enumeration_detail
+                                 ascii   'no coding for special symbols'
+                                 cif     'CIF convention'
+                                 latex   'LaTeX'
+                                 rtf     'Rich Text Format'
+                                 sgml    'SGML (ISO 8879)'
+                                 tex     'TeX'
+                                 troff   'troff or nroff'
+    _enumeration_default         cif
+    _definition
+;              Code indicating the appropriate typesetting conventions
+               for accented characters and special symbols in the text
+               section.
+;
+
+data_publ_body_label
+    _name                      '_publ_body_label'
+    _category                    publ_body
+    _type                        char
+    _list                        yes
+    _list_mandatory              yes
+    _list_uniqueness           '_publ_body_element'
+    loop_ _example               1   1.1   2.1.3
+    _definition
+;              Code identifying the section of text. The combination of this
+               with _publ_body_element must be unique.
+;
+
+data_publ_body_title
+    _name                      '_publ_body_title'
+    _category                    publ_body
+    _type                        char
+    _list                        yes
+    _list_reference            '_publ_body_label'
+    _definition
+;              Title of the associated section of text.
+;
+
+##########################
+## PUBL_MANUSCRIPT_INCL ##
+##########################
+
+data_publ_manuscript_incl_[]
+    _name                      '_publ_manuscript_incl_[]'
+    _category                    category_overview
+    _type                        null
+    loop_ _example
+          _example_detail
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+;
+    loop_
+    _publ_manuscript_incl_extra_item
+    _publ_manuscript_incl_extra_info
+    _publ_manuscript_incl_extra_defn
+    #
+    # Include Hydrogen Bonding Geometry Description
+    # =============================================
+    # Name                             explanation    standard?
+    # ----                             -----------    ---------
+      '_geom_hbond_atom_site_label_D'  'H-bond donor'     yes
+      '_geom_hbond_atom_site_label_H'  'H-bond hydrogen'  yes
+      '_geom_hbond_atom_site_label_A'  'H-bond acceptor'  yes
+      '_geom_hbond_distance_DH'        'H-bond D-H'       yes
+      '_geom_hbond_distance_HA'        'H-bond H...A'     yes
+      '_geom_hbond_distance_DA'        'H-bond D...A'     yes
+      '_geom_hbond_angle_DHA'          'H-bond D-H...A'   yes
+
+;
+;
+    Example 1 - directive to include a hydrogen-bonding table, including
+                cosmetic headings in comments.
+;
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+;
+    loop_
+    _publ_manuscript_incl_extra_item
+    _publ_manuscript_incl_extra_info
+    _publ_manuscript_incl_extra_defn
+      '_atom_site_site_symmetry_multiplicity'
+                         'to emphasise special sites'      yes
+      '_chemical_compound_source'
+                         'rare material, unusual source'   yes
+      '_reflns_d_resolution_high'
+                         'limited data is a problem here'  yes
+      '_crystal_magnetic_permeability'
+                         'unusual value for this material'  no
+;
+;
+    Example 2 - hypothetical example including both standard CIF data items
+                and a non-CIF quantity which the author wishes to list.
+;
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+    _definition
+;              Data items in the PUBL_MANUSCRIPT_INCL category allow
+               the authors of a manuscript submitted for publication to list
+               data names that should be added to the standard request list
+               used by the journal printing software. Although these fields are
+               primarily intended to identify CIF data items that the author
+               wishes to include in a published paper, they can also be used
+               to identify data names created so that non-CIF items can be
+               included in the publication. Note that *_item names MUST be
+               enclosed in single quotes.
+;
+
+data_publ_manuscript_incl_extra_defn
+    _name                      '_publ_manuscript_incl_extra_defn'
+    _category                    publ_manuscript_incl
+    _type                        char
+    _list                        yes
+    _list_reference            '_publ_manuscript_incl_extra_item'
+    loop_ _enumeration
+          _enumeration_detail
+                                 no  'not a standard CIF data name'
+                                 n   'abbreviation for "no"'
+                                 yes 'a standard CIF data name'
+                                 y   'abbreviation for "yes"'
+    _enumeration_default         yes
+    _definition
+;              Flags whether the corresponding data item marked for inclusion
+               in a journal request list is a standard CIF definition or not.
+;
+
+data_publ_manuscript_incl_extra_info
+    _name                      '_publ_manuscript_incl_extra_info'
+    _category                    publ_manuscript_incl
+    _type                        char
+    _list                        yes
+    _list_reference            '_publ_manuscript_incl_extra_item'
+    _definition
+;              A short note indicating the reason why the author wishes the
+               corresponding data item marked for inclusion in the journal
+               request list to be published.
+;
+
+data_publ_manuscript_incl_extra_item
+    _name                      '_publ_manuscript_incl_extra_item'
+    _category                    publ_manuscript_incl
+    _type                        char
+    _list                        yes
+    _list_mandatory              yes
+    _definition
+;              Specifies the inclusion of specific data into a manuscript
+               which are not normally requested by the journal. The values
+               of this item are the extra data names (which MUST be enclosed
+               in single quotes) that will be added to the journal request list.
+;
+
+############
+## REFINE ##
+############
+
+data_refine_[]
+    _name                      '_refine_[]'
+    _category                    category_overview
+    _type                        null
+    loop_ _example
+          _example_detail
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+;
+    _refine_special_details     sfls:_F_calc_weight_full_matrix
+
+    _refine_ls_structure_factor_coef   F
+    _refine_ls_matrix_type             full
+    _refine_ls_weighting_scheme        calc
+    _refine_ls_weighting_details      'w=1/(u^2^(F)+0.0004F^2^)'
+    _refine_ls_hydrogen_treatment      refxyz
+    _refine_ls_extinction_method       Zachariasen
+    _refine_ls_extinction_coef         3514(42)
+    _refine_ls_extinction_expression
+    ; Larson, A. C. (1970). "Crystallographic Computing", edited
+      by F. R. Ahmed. Eq. (22) p. 292. Copenhagen: Munksgaard.
+    ;
+    _refine_ls_abs_structure_details
+    ; The absolute configuration was assigned to agree with that
+      of its precursor l-leucine at the chiral centre C3.
+    ;
+    _refine_ls_number_reflns           1408
+    _refine_ls_number_parameters       272
+    _refine_ls_number_restraints       0
+    _refine_ls_number_constraints      0
+    _refine_ls_R_factor_all            .038
+    _refine_ls_R_factor_gt             .034
+    _refine_ls_wR_factor_all           .044
+    _refine_ls_wR_factor_gt            .042
+    _refine_ls_goodness_of_fit_all    1.462
+    _refine_ls_goodness_of_fit_gt     1.515
+    _refine_ls_shift/su_max            .535
+    _refine_ls_shift/su_mean           .044
+    _refine_diff_density_min          -.108
+    _refine_diff_density_max           .131
+;
+;
+    Example 1 - based on data set TOZ of Willis, Beckwith & Tozer
+                [Acta Cryst. (1991), C47, 2276-2277].
+;
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+    _definition
+;              Data items in the REFINE category record details about the
+               structure-refinement parameters.
+;
+
+data_refine_diff_density_
+    loop_ _name                '_refine_diff_density_max'
+                               '_refine_diff_density_min'
+                               '_refine_diff_density_rms'
+    _category                    refine
+    _type                        numb
+    _type_conditions             esd
+    _units                       e/A^3^
+    _units_detail              'electron per angstrom cubed'
+    _definition
+;              The largest and smallest values and the root-mean-square
+               deviation, in electrons per angstrom cubed, of the final
+               difference electron density. The *_rms value is measured with
+               respect to the arithmetic mean density and is derived from
+               summations over each grid point in the asymmetric unit of
+               the cell. This quantity is useful for assessing the
+               significance of *_min and *_max values, and also for
+               defining suitable contour levels.
+;
+
+data_refine_ls_abs_structure_details
+    _name                      '_refine_ls_abs_structure_details'
+    _category                    refine
+    _type                        char
+    _definition
+;              The nature of the absolute structure and how it was determined.
+;
+
+data_refine_ls_abs_structure_Flack
+    _name                      '_refine_ls_abs_structure_Flack'
+    _category                    refine
+    _type                        numb
+    _type_conditions             esd
+    _enumeration_range           0.0:1.0
+    _definition
+;              The measure of absolute structure as defined by Flack (1983).
+
+               For centrosymmetric structures, the only permitted value, if the
+               data name is present, is 'inapplicable', represented by '.' .
+
+               For noncentrosymmetric structures, the value must lie in the
+               99.97% Gaussian confidence interval  -3u =< x =< 1 + 3u and a
+               standard uncertainty (e.s.d.) u must be supplied. The
+               _enumeration_range of 0.0:1.0 is correctly interpreted as
+               meaning (0.0 - 3u) =< x =< (1.0 + 3u).
+
+               Ref: Flack, H. D. (1983). Acta Cryst. A39, 876-881.
+;
+
+data_refine_ls_abs_structure_Rogers
+    _name                      '_refine_ls_abs_structure_Rogers'
+    _category                    refine
+    _type                        numb
+    _type_conditions             esd
+    _enumeration_range           -1.0:1.0
+    _definition
+;              The measure of absolute structure as defined by Rogers (1981).
+
+               The value must lie in the 99.97% Gaussian confidence interval
+               -1 -3u =< \h =< 1 + 3u and a standard uncertainty (e.s.d.) u must
+               be supplied. The _enumeration_range of -1.0:1.0 is correctly
+               interpreted as meaning (-1.0 - 3u) =< \h =< (1.0 + 3u).
+
+               Ref: Rogers, D. (1981). Acta Cryst. A37, 734-741.
+;
+
+data_refine_ls_d_res_high
+    _name                      '_refine_ls_d_res_high'
+    _category                    refine
+    _type                        numb
+    _enumeration_range           0.0:
+    _units                       A
+    _units_detail                angstrom
+    _definition
+;              The smallest value in angstroms of the interplanar spacings
+               of the reflections used in the refinement. This is called
+               the highest resolution.
+;
+
+data_refine_ls_d_res_low
+    _name                      '_refine_ls_d_res_low'
+    _category                    refine
+    _type                        numb
+    _enumeration_range           0.0:
+    _units                       A
+    _units_detail                angstrom
+    _definition
+;              The largest value in angstroms of the interplanar spacings
+               of the reflections used in the refinement. This is called
+               the lowest resolution.
+;
+
+data_refine_ls_extinction_coef
+    _name                      '_refine_ls_extinction_coef'
+    _category                    refine
+    _type                        numb
+    _type_conditions             esd
+    _example                     3472(52)
+    _example_detail             'Zachariasen coefficient r* = 0.347(5) E04'
+    _definition
+;              The extinction coefficient used to calculate the correction
+               factor applied to the structure-factor data. The nature of the
+               extinction coefficient is given in the definitions of
+               _refine_ls_extinction_expression and
+               _refine_ls_extinction_method.
+
+               For the 'Zachariasen' method it is the r* value; for the
+               'Becker-Coppens type 1 isotropic' method it is the 'g' value
+               and for 'Becker-Coppens type 2 isotropic' corrections it is
+               the 'rho' value. Note that the magnitude of these values is
+               usually of the order of 10000.
+
+               Ref:  Becker, P. J. & Coppens, P. (1974). Acta Cryst. A30,
+                     129-147, 148-153.
+                     Zachariasen, W. H. (1967). Acta Cryst. 23, 558-564.
+                     Larson, A. C. (1967). Acta Cryst. 23, 664-665.
+;
+
+data_refine_ls_extinction_expression
+    _name                      '_refine_ls_extinction_expression'
+    _category                    refine
+    _type                        char
+    _example
+;                            Larson, A. C. (1970). "Crystallographic Computing",
+                             edited by F. R. Ahmed. Eq. (22), p. 292.
+                             Copenhagen: Munksgaard.
+;
+    _definition
+;              A description of or reference to the extinction-correction
+               equation used to apply the data item _refine_ls_extinction_coef.
+               This information must be sufficient to reproduce the
+               extinction-correction factors applied to the structure factors.
+;
+
+data_refine_ls_extinction_method
+    _name                      '_refine_ls_extinction_method'
+    _category                    refine
+    _type                        char
+    loop_ _example              'B-C type 2 Gaussian isotropic'
+                                'none'
+    _definition
+;              A description of the extinction-correction method applied.
+               This description should
+               include information about the correction method, either
+               'Becker-Coppens' or 'Zachariasen'. The latter is sometimes
+               referred to as the 'Larson' method even though it employs
+               Zachariasen's formula.
+
+               The Becker-Coppens procedure is referred to as 'type 1' when
+               correcting secondary extinction dominated by the mosaic spread;
+               as 'type 2' when secondary extinction is dominated by particle
+               size and includes a primary extinction component; and as 'mixed'
+               when there is a mixture of types 1 and 2.
+
+               For the Becker-Coppens method, it is also necessary to set the
+               mosaic distribution as either 'Gaussian' or 'Lorentzian' and
+               the nature of the extinction as 'isotropic' or 'anisotropic'.
+               Note that if either the 'mixed' or 'anisotropic' corrections
+               are applied, the multiple coefficients cannot be contained in
+               *_extinction_coef and must be listed in _refine_special_details.
+
+               Ref:  Becker, P. J. & Coppens, P. (1974). Acta Cryst. A30,
+                     129-147, 148-153.
+                     Zachariasen, W. H. (1967). Acta Cryst. 23, 558-564.
+                     Larson, A. C. (1967). Acta Cryst. 23, 664-665.
+;
+
+data_refine_ls_F_calc_details
+    _name                      '_refine_ls_F_calc_details'
+    _category                    refine
+    _type                        char
+    loop_ _example               'Gaussian integration using 16 points'
+;                                Bessel functions expansion up to 5th order.
+                                 Bessel functions estimated accuracy: better
+                                 than 0.001 electrons.
+;
+    _definition
+;              Details concerning the evaluation of the structure
+               factors using the expression given in
+               _refine_ls_F_calc_formula.
+;
+
+data_refine_ls_F_calc_formula
+    _name                      '_refine_ls_F_calc_formula'
+    _category                    refine
+    _type                        char
+    _definition
+;              Analytical expression used to calculate the structure factors.
+;
+
+data_refine_ls_F_calc_precision
+    _name                      '_refine_ls_F_calc_precision'
+    _category                    refine
+    _type                        numb
+    _enumeration_range           0.0:
+    _definition
+;              This item gives an estimate of the precision resulting
+               from the numerical approximations made during the evaluation
+               of the structure factors using the expression given in
+               _refine_ls_F_calc_formula following the method outlined
+               in _refine_ls_F_calc_details.  For X-ray diffraction the
+               result is given in electrons.
+;
+
+data_refine_ls_goodness_of_fit_all
+    _name                      '_refine_ls_goodness_of_fit_all'
+    _category                    refine
+    _type                        numb
+    _type_conditions             esd
+    _enumeration_range           0.0:
+    _definition
+;              The least-squares goodness-of-fit parameter S for all
+               reflections after the final cycle of refinement.
+               Ideally, account should be taken of parameters restrained
+               in the least-squares refinement. See also
+               _refine_ls_restrained_S_ definitions.
+
+                   {  sum { w [ Y(obs) - Y(calc) ]^2^ }  }^1/2^
+               S = { ----------------------------------- }
+                   {            Nref - Nparam            }
+
+               Y(obs)  = the observed coefficients
+                         (see _refine_ls_structure_factor_coef)
+               Y(calc) = the calculated coefficients
+                         (see _refine_ls_structure_factor_coef)
+               w       = the least-squares reflection weight
+                         [1/(u^2^)]
+               u       = the standard uncertainty
+
+               Nref   = the number of reflections used in the refinement
+               Nparam = the number of refined parameters
+
+               and the sum is taken over the specified reflections
+;
+
+data_refine_ls_goodness_of_fit_gt
+    _name                      '_refine_ls_goodness_of_fit_gt'
+    _category                    refine
+    _type                        numb
+    _type_conditions             esd
+    loop_ _related_item
+          _related_function    '_refine_ls_goodness_of_fit_obs'  alternate
+    _enumeration_range           0.0:
+    _definition
+;              The least-squares goodness-of-fit parameter S for
+               significantly intense reflections (see
+               _reflns_threshold_expression) after the final cycle of
+               refinement. Ideally, account should be taken of parameters
+               restrained in the least-squares refinement. See also
+               _refine_ls_restrained_S_ definitions.
+
+                   {  sum { w [ Y(obs) - Y(calc) ]^2^ }  }^1/2^
+               S = { ----------------------------------- }
+                   {            Nref - Nparam            }
+
+               Y(obs)  = the observed coefficients
+                         (see _refine_ls_structure_factor_coef)
+               Y(calc) = the calculated coefficients
+                         (see _refine_ls_structure_factor_coef)
+               w       = the least-squares reflection weight
+                         [1/(u^2^)]
+               u       = standard uncertainty
+
+               Nref   = the number of reflections used in the refinement
+               Nparam = the number of refined parameters
+
+               and the sum is taken over the specified reflections
+;
+
+data_refine_ls_goodness_of_fit_obs
+    _name                      '_refine_ls_goodness_of_fit_obs'
+    _category                    refine
+    _type                        numb
+    _type_conditions             esd
+    loop_ _related_item
+          _related_function    '_refine_ls_goodness_of_fit_gt'  replace
+    _enumeration_range           0.0:
+    _definition
+;              The least-squares goodness-of-fit parameter S for observed
+               reflections (see _reflns_observed_criterion) after the final
+               cycle of refinement. Ideally, account should be taken of
+               parameters restrained in the least-squares refinement. See also
+               _refine_ls_restrained_S_ definitions.
+
+                   {  sum { w [ Y(obs) - Y(calc) ]^2^ }  }^1/2^
+               S = { ----------------------------------- }
+                   {            Nref - Nparam            }
+
+               Y(obs)  = the observed coefficients
+                         (see _refine_ls_structure_factor_coef)
+               Y(calc) = the calculated coefficients
+                         (see _refine_ls_structure_factor_coef)
+               w       = the least-squares reflection weight
+                         [1/(u^2^)]
+               u       = standard uncertainty (e.s.d.)
+
+               Nref   = the number of reflections used in the refinement
+               Nparam = the number of refined parameters
+
+               and the sum is taken over the specified reflections
+;
+
+data_refine_ls_goodness_of_fit_ref
+    _name                      '_refine_ls_goodness_of_fit_ref'
+    _category                    refine
+    _type                        numb
+    _type_conditions             esd
+    _enumeration_range           0.0:
+    _definition
+;              The least-squares goodness-of-fit parameter S for all
+               reflections included in the refinement after the final cycle
+               of refinement. Ideally, account should be taken of parameters
+               restrained in the least-squares refinement. See also
+               _refine_ls_restrained_S_ definitions.
+
+                   {  sum | w | Y(obs) - Y(calc) |^2^ |  }^1/2^
+               S = { ----------------------------------- }
+                   {            Nref - Nparam            }
+
+               Y(obs)  = the observed coefficients
+                         (see _refine_ls_structure_factor_coef)
+               Y(calc) = the calculated coefficients
+                         (see _refine_ls_structure_factor_coef)
+               w       = the least-squares reflection weight
+                         [1/(u^2^)]
+               u       = standard uncertainty
+
+               Nref   = the number of reflections used in the refinement
+               Nparam = the number of refined parameters
+
+               and the sum is taken over the specified reflections
+;
+
+data_refine_ls_hydrogen_treatment
+    _name                      '_refine_ls_hydrogen_treatment'
+    _category                    refine
+    _type                        char
+    loop_ _enumeration
+          _enumeration_detail    refall  'refined all H-atom parameters'
+                                 refxyz  'refined H-atom coordinates only'
+                                 refU    'refined H-atom U's only'
+                                 noref   'no refinement of H-atom parameters'
+                                 constr  'H-atom parameters constrained'
+                                 hetero
+;                                         H-atom parameters constrained for
+                                          H on C, all H-atom parameters refined
+                                          for H on heteroatoms
+;
+                                 heteroxyz
+;                                         H-atom parameters constrained for
+                                          H on C, refined H-atom coordinates
+                                          only for H on heteroatoms
+;
+                                 heteroU
+;                                         H-atom parameters constrained for
+                                          H on C, refined H-atom U's only
+                                          for H on heteroatoms
+;
+                                 heteronoref
+;                                         H-atom parameters constrained for
+                                          H on C, no refinement of H-atom
+                                          parameters for H on heteroatoms
+;
+                                 hetero-mixed
+;                                         H-atom parameters constrained for
+                                          H on C and some heteroatoms, all
+                                          H-atom parameters refined
+                                          for H on remaining heteroatoms
+;
+                                 heteroxyz-mixed
+;                                         H-atom parameters constrained for
+                                          H on C and some heteroatoms, refined
+                                          H-atom coordinates only
+                                          for H on remaining heteroatoms
+;
+                                 heteroU-mixed
+;                                         H-atom parameters constrained for
+                                          H on C and some heteroatoms, refined
+                                          H-atom U's only for H on remaining
+                                          heteroatoms
+;
+                                 heteronoref-mixed
+;                                         H-atom parameters constrained for H
+                                          on C and some heteroatoms, no
+                                          refinement of H-atom parameters
+                                          for H on remaining heteroatoms
+;
+                                 mixed   'some constrained, some independent'
+                                 undef   'H-atom parameters not defined'
+    _definition
+;              Treatment of hydrogen atoms in the least-squares refinement.
+;
+
+data_refine_ls_matrix_type
+    _name                      '_refine_ls_matrix_type'
+    _category                    refine
+    _type                        char
+    loop_ _enumeration
+          _enumeration_detail    full       'full'
+                                 fullcycle  'full with fixed elements per cycle'
+                                 atomblock  'block diagonal per atom'
+                                 userblock  'user-defined blocks'
+                                 diagonal   'diagonal elements only'
+                                 sparse     'selected elements only'
+    _definition
+;              Type of matrix used to accumulate the least-squares derivatives.
+;
+
+data_refine_ls_number_constraints
+    _name                      '_refine_ls_number_constraints'
+    _category                    refine
+    _type                        numb
+    _enumeration_range           0:
+    _definition
+;              The number of constrained (non-refined or dependent) parameters
+               in the least-squares process. These may be due to symmetry or any
+               other constraint process (e.g. rigid-body refinement). See also
+               _atom_site_constraints and _atom_site_refinement_flags. A general
+               description of constraints may appear in _refine_special_details.
+;
+
+data_refine_ls_number_parameters
+    _name                      '_refine_ls_number_parameters'
+    _category                    refine
+    _type                        numb
+    _enumeration_range           0:
+    _definition
+;              The number of parameters refined in the least-squares process.
+               If possible, this number should include some contribution from
+               the restrained parameters. The restrained parameters are
+               distinct from the constrained parameters (where one or more
+               parameters are linearly dependent on the refined value of
+               another). Least-squares restraints often depend on geometry or
+               energy considerations and this makes their direct contribution
+               to this number, and to the goodness-of-fit calculation,
+               difficult to assess.
+;
+
+data_refine_ls_number_reflns
+    _name                      '_refine_ls_number_reflns'
+    _category                    refine
+    _type                        numb
+    _enumeration_range           0:
+    _definition
+;              The number of unique reflections contributing to the
+               least-squares refinement calculation.
+;
+
+data_refine_ls_number_restraints
+    _name                      '_refine_ls_number_restraints'
+    _category                    refine
+    _type                        numb
+    _enumeration_range           0:
+    _definition
+;              The number of restrained parameters. These are parameters which
+               are not directly dependent on another refined parameter.
+               Restrained parameters often involve geometry or energy
+               dependencies.
+               See also _atom_site_constraints and _atom_site_refinement_flags.
+               A general description of refinement constraints may appear in
+               _refine_special_details.
+;
+
+data_refine_ls_R_factor_all
+    _name                      '_refine_ls_R_factor_all'
+    _category                    refine
+    _type                        numb
+    _enumeration_range           0.0:
+    _definition
+;              Residual factor for all reflections satisfying the
+               resolution limits established by _refine_ls_d_res_high and
+               _refine_ls_d_res_low. This is the conventional R
+               factor. See also _refine_ls_wR_factor_ definitions.
+
+                   sum | F(obs) - F(calc) |
+               R = ------------------------
+                         sum | F(obs) |
+
+               F(obs)  = the observed structure-factor amplitudes
+               F(calc) = the calculated structure-factor amplitudes
+
+               and the sum is taken over the specified reflections
+;
+
+data_refine_ls_R_factor_gt
+    _name                      '_refine_ls_R_factor_gt'
+    _category                    refine
+    _type                        numb
+    loop_ _related_item
+          _related_function    '_refine_ls_R_factor_obs'  alternate
+    _enumeration_range           0.0:
+    _definition
+;              Residual factor for the reflections (with number given by
+               _reflns_number_gt) judged significantly intense (i.e. satisfying
+               the threshold specified by _reflns_threshold_expression)
+               and included in the refinement. The reflections also satisfy
+               the resolution limits established by _refine_ls_d_res_high and
+               _refine_ls_d_res_low. This is the conventional R
+               factor. See also _refine_ls_wR_factor_ definitions.
+
+                   sum | F(obs) - F(calc) |
+               R = ------------------------
+                         sum | F(obs) |
+
+               F(obs)  = the observed structure-factor amplitudes
+               F(calc) = the calculated structure-factor amplitudes
+
+               and the sum is taken over the specified reflections
+;
+
+data_refine_ls_R_factor_obs
+    _name                      '_refine_ls_R_factor_obs'
+    _category                    refine
+    _type                        numb
+    loop_ _related_item
+          _related_function    '_refine_ls_R_factor_gt'  replace
+    _enumeration_range           0.0:
+    _definition
+;              Residual factor for the reflections classified as 'observed'
+               (see _reflns_observed_criterion) and included in the
+               refinement. The reflections also satisfy the resolution limits
+               established by _refine_ls_d_res_high and
+               _refine_ls_d_res_low. This is the conventional R
+               factor. See also _refine_ls_wR_factor_ definitions.
+
+                   sum | F(obs) - F(calc) |
+               R = ------------------------
+                         sum | F(obs) |
+
+               F(obs)  = the observed structure-factor amplitudes
+               F(calc) = the calculated structure-factor amplitudes
+
+               and the sum is taken over the specified reflections
+;
+
+data_refine_ls_R_Fsqd_factor
+    _name                       '_refine_ls_R_Fsqd_factor'
+    _category                    refine
+    _type                        numb
+    _enumeration_range           0.0:
+    _definition
+;              Residual factor R(Fsqd), calculated on the squared amplitudes
+               of the observed and calculated structure factors, for
+               significantly intense reflections (satisfying
+               _reflns_threshold_expression) and included in the refinement.
+
+               The reflections also satisfy the resolution limits established
+               by _refine_ls_d_res_high and _refine_ls_d_res_low.
+
+                          sum | F(obs)^2^ - F(calc)^2^ |
+               R(Fsqd) = -------------------------------
+                                  sum F(obs)^2^
+
+               F(obs)^2^  = squares of the observed structure-factor amplitudes
+               F(calc)^2^ = squares of the calculated structure-factor
+                            amplitudes
+
+               and the sum is taken over the specified reflections
+;
+
+data_refine_ls_R_I_factor
+    _name                       '_refine_ls_R_I_factor'
+    _category                    refine
+    _type                        numb
+    _enumeration_range           0.0:
+    _definition
+;              Residual factor R(I) for significantly intense reflections
+               (satisfying _reflns_threshold_expression) and included in
+               the refinement.
+
+               This is most often calculated in Rietveld refinements against
+               powder data, where it is referred to as R~B~ or R~Bragg~.
+
+                       sum | I(obs) - I(calc) |
+               R(I) =  ------------------------
+                              sum | I(obs) |
+
+               I(obs)  = the net observed intensities
+               I(calc) = the net calculated intensities
+
+               and the sum is taken over the specified reflections
+;
+
+data_refine_ls_restrained_S_all
+    _name                      '_refine_ls_restrained_S_all'
+    _category                    refine
+    _type                        numb
+    _enumeration_range           0.0:
+    _definition
+;              The least-squares goodness-of-fit parameter S' for all
+               reflections after the final cycle of least-squares refinement.
+               This parameter explicitly includes the restraints applied in the
+               least-squares process. See also _refine_ls_goodness_of_fit_
+               definitions.
+
+                    {sum { w [ Y(obs) - Y(calc) ]^2^ }                   }^1/2^
+                    {         + sum~r~ { w~r~ [ P(calc) - P(targ) ]^2^ } }
+               S' = { -------------------------------------------------- }
+                    {            N~ref~ + N~restr~ - N~param~            }
+
+               Y(obs)   = the observed coefficients
+                          (see _refine_ls_structure_factor_coef)
+               Y(calc)  = the calculated coefficients
+                          (see _refine_ls_structure_factor_coef)
+               w        = the least-squares reflection weight
+                          [1/square of standard uncertainty (e.s.d.)]
+
+               P(calc)  = the calculated restraint values
+               P(targ)  = the target restraint values
+               w~r~     = the restraint weight
+
+               N~ref~   = the number of reflections used in the refinement
+                        (see _refine_ls_number_reflns)
+               N~restr~ = the number of restraints
+                        (see _refine_ls_number_restraints)
+               N~param~ = the number of refined parameters
+                        (see _refine_ls_number_parameters)
+
+               sum     is taken over the specified reflections
+               sum~r~  is taken over the restraints
+;
+
+data_refine_ls_restrained_S_gt
+    _name                      '_refine_ls_restrained_S_gt'
+    _category                    refine
+    _type                        numb
+    loop_ _related_item
+          _related_function    '_refine_ls_restrained_S_obs'  alternate
+    _enumeration_range           0.0:
+    _definition
+;              The least-squares goodness-of-fit parameter S' for
+               significantly intense reflections (satisfying
+               _reflns_threshold_expression) after the final cycle
+               of least-squares refinement. This parameter explicitly includes
+               the restraints applied in the least-squares process.
+               See also _refine_ls_goodness_of_fit_ definitions.
+
+                    {sum { w [ Y(obs) - Y(calc) ]^2^ }                   }^1/2^
+                    {         + sum~r~ { w~r~ [ P(calc) - P(targ) ]^2^ } }
+               S' = { -------------------------------------------------- }
+                    {            N~ref~ + N~restr~ - N~param~            }
+
+               Y(obs)   = the observed coefficients
+                          (see _refine_ls_structure_factor_coef)
+               Y(calc)  = the calculated coefficients
+                          (see _refine_ls_structure_factor_coef)
+               w        = the least-squares reflection weight
+                          [1/square of standard uncertainty (e.s.d.)]
+
+               P(calc)  = the calculated restraint values
+               P(targ)  = the target restraint values
+               w~r~     = the restraint weight
+
+               N~ref~   = the number of reflections used in the refinement
+                        (see _refine_ls_number_reflns)
+               N~restr~ = the number of restraints
+                        (see _refine_ls_number_restraints)
+               N~param~ = the number of refined parameters
+                        (see _refine_ls_number_parameters)
+
+               sum     is taken over the specified reflections
+               sum~r~  is taken over the restraints
+;
+
+data_refine_ls_restrained_S_obs
+    _name                      '_refine_ls_restrained_S_obs'
+    _category                    refine
+    _type                        numb
+    loop_ _related_item
+          _related_function    '_refine_ls_restrained_S_gt'  replace
+    _enumeration_range           0.0:
+    _definition
+;              The least-squares goodness-of-fit parameter S' for observed
+               reflections after the final cycle of least-squares refinement.
+               This parameter explicitly includes the restraints applied in the
+               least-squares process.  See also _refine_ls_goodness_of_fit_
+               definitions.
+
+                    {sum { w [ Y(obs) - Y(calc) ]^2^ }                   }^1/2^
+                    {         + sum~r~ { w~r~ [ P(calc) - P(targ) ]^2^ } }
+               S' = { -------------------------------------------------- }
+                    {            N~ref~ + N~restr~ - N~param~            }
+
+               Y(obs)   = the observed coefficients
+                          (see _refine_ls_structure_factor_coef)
+               Y(calc)  = the calculated coefficients
+                          (see _refine_ls_structure_factor_coef)
+               w        = the least-squares reflection weight
+                          [1/square of standard uncertainty (e.s.d.)]
+
+               P(calc)  = the calculated restraint values
+               P(targ)  = the target restraint values
+               w~r~     = the restraint weight
+
+               N~ref~   = the number of reflections used in the refinement
+                        (see _refine_ls_number_reflns)
+               N~restr~ = the number of restraints
+                        (see _refine_ls_number_restraints)
+               N~param~ = the number of refined parameters
+                        (see _refine_ls_number_parameters)
+
+               sum     is taken over the specified reflections
+               sum~r~  is taken over the restraints
+;
+
+data_refine_ls_shift/esd_max
+    _name                      '_refine_ls_shift/esd_max'
+    _category                    refine
+    _type                        numb
+    loop_ _related_item
+          _related_function    '_refine_ls_shift/su_max'  replace
+    _enumeration_range           0.0:
+    _definition
+;              The largest ratio of the final least-squares parameter
+               shift to the final standard uncertainty (s.u.,
+               formerly described as estimated standard deviation, e.s.d.).
+;
+
+data_refine_ls_shift/esd_mean
+    _name                      '_refine_ls_shift/esd_mean'
+    _category                    refine
+    _type                        numb
+    loop_ _related_item
+          _related_function    '_refine_ls_shift/su_mean'  replace
+    _enumeration_range           0.0:
+    _definition
+;              The average ratio of the final least-squares parameter
+               shift to the final standard uncertainty (s.u.,
+               formerly described as estimated standard deviation, e.s.d.).
+;
+
+data_refine_ls_shift/su_max
+    _name                      '_refine_ls_shift/su_max'
+    _category                    refine
+    _type                        numb
+    loop_ _related_item
+          _related_function    '_refine_ls_shift/esd_max'  alternate
+    _enumeration_range           0.0:
+    _definition
+;              The largest ratio of the final least-squares parameter
+               shift to the final standard uncertainty.
+;
+
+data_refine_ls_shift/su_max_lt
+    _name                      '_refine_ls_shift/su_max_lt'
+    _category                    refine
+    _type                        numb
+    loop_ _related_item
+          _related_function    '_refine_ls_shift/su_max'  alternate
+    _enumeration_range           0.0:
+    _definition
+;              An upper limit for the largest ratio of the final
+               least-squares parameter shift to the final
+               standard uncertainty.  This item is used when the largest
+               value of the shift divided by the final standard uncertainty
+               is too small to measure.
+;
+
+data_refine_ls_shift/su_mean
+    _name                      '_refine_ls_shift/su_mean'
+    _category                    refine
+    _type                        numb
+    loop_ _related_item
+          _related_function    '_refine_ls_shift/esd_mean'  alternate
+    _enumeration_range           0.0:
+    _definition
+;              The average ratio of the final least-squares parameter
+               shift to the final standard uncertainty.
+;
+
+data_refine_ls_shift/su_mean_lt
+    _name                      '_refine_ls_shift/su_mean_lt'
+    _category                    refine
+    _type                        numb
+    loop_ _related_item
+          _related_function    '_refine_ls_shift/su_mean'  alternate
+    _enumeration_range           0.0:
+    _definition
+;              An upper limit for the average ratio of the final
+               least-squares parameter shift to the
+               final standard uncertainty.  This
+               item is used when the average value of the shift divided by
+               the final standard uncertainty is too small to measure.
+;
+
+data_refine_ls_structure_factor_coef
+    _name                      '_refine_ls_structure_factor_coef'
+    _category                    refine
+    _type                        char
+    loop_ _enumeration
+          _enumeration_detail    F      'structure-factor magnitude'
+                                 Fsqd   'structure factor squared'
+                                 Inet   'net intensity'
+    _definition
+;              Structure-factor coefficient |F|, F^2^ or I used in the
+               least-squares refinement process.
+;
+
+data_refine_ls_weighting_details
+
+    _name                      '_refine_ls_weighting_details'
+    _category                    refine
+    _type                        char
+    _example
+;                  Sigdel model of Konnert-Hendrickson:
+                   Sigdel = Afsig +  Bfsig*(sin(\q)/\l - 1/6)
+                   Afsig = 22.0, Bfsig = 150.0 at the beginning of refinement.
+                   Afsig = 16.0, Bfsig =  60.0 at the end of refinement.
+;
+    _definition
+;              A description of special aspects of the weighting scheme used
+               in the least-squares refinement. Used to describe the weighting
+               when the value of _refine_ls_weighting_scheme is specified
+               as 'calc'.
+;
+
+data_refine_ls_weighting_scheme
+    _name                      '_refine_ls_weighting_scheme'
+    _category                    refine
+    _type                        char
+    loop_ _enumeration
+          _enumeration_detail    sigma    "based on measured s.u.'s"
+                                 unit     'unit or no weights applied'
+                                 calc     'calculated weights applied'
+    _definition
+;              The weighting scheme applied in the least-squares process. The
+               standard code may be followed by a description of the weight
+               (but see _refine_ls_weighting_details for a preferred approach).
+;
+
+data_refine_ls_wR_factor_all
+    _name                      '_refine_ls_wR_factor_all'
+    _category                    refine
+    _type                        numb
+    _enumeration_range           0.0:
+    _definition
+;              Weighted residual factors for all reflections.
+               The reflections also satisfy the resolution limits established
+               by _refine_ls_d_res_high and _refine_ls_d_res_low.
+               See also the _refine_ls_R_factor_ definitions.
+
+                    ( sum w [ Y(obs) - Y(calc) ]^2^  )^1/2^
+               wR = ( ------------------------------ )
+                    (         sum w Y(obs)^2^       )
+
+               Y(obs)  = the observed amplitude specified by
+                         _refine_ls_structure_factor_coef
+               Y(calc) = the calculated amplitude specified by
+                         _refine_ls_structure_factor_coef
+               w       = the least-squares weight
+
+               and the sum is taken over the specified reflections
+;
+
+data_refine_ls_wR_factor_gt
+    _name                      '_refine_ls_wR_factor_gt'
+    _category                    refine
+    _type                        numb
+    loop_ _related_item
+          _related_function    '_refine_ls_wR_factor_obs'  alternate
+    _enumeration_range           0.0:
+    _definition
+;              Weighted residual factors for significantly intense reflections
+               (satisfying _reflns_threshold_expression) included in the
+               refinement.  The reflections also satisfy the resolution
+               limits established by _refine_ls_d_res_high and
+               _refine_ls_d_res_low.  See also the _refine_ls_R_factor_
+               definitions.
+
+                    ( sum w [ Y(obs) - Y(calc) ]^2^  )^1/2^
+               wR = ( ------------------------------ )
+                    (         sum w Y(obs)^2^       )
+
+               Y(obs)  = the observed amplitude specified by
+                         _refine_ls_structure_factor_coef
+               Y(calc) = the calculated amplitude specified by
+                         _refine_ls_structure_factor_coef
+               w       = the least-squares weight
+
+               and the sum is taken over the specified reflections
+;
+
+data_refine_ls_wR_factor_obs
+    _name                      '_refine_ls_wR_factor_obs'
+    _category                    refine
+    _type                        numb
+    loop_ _related_item
+          _related_function    '_refine_ls_wR_factor_gt'  replace
+    _enumeration_range           0.0:
+    _definition
+;              Weighted residual factors for the reflections classified as
+               'observed' (see _reflns_observed_criterion) and included
+               in the refinement.  The reflections also satisfy the resolution
+               limits established by _refine_ls_d_res_high and
+               _refine_ls_d_res_low. See also the _refine_ls_R_factor_
+               definitions.
+
+                    ( sum w [ Y(obs) - Y(calc) ]^2^  )^1/2^
+               wR = ( ------------------------------ )
+                    (         sum w Y(obs)^2^       )
+
+               Y(obs)  = the observed amplitude specified by
+                         _refine_ls_structure_factor_coef
+               Y(calc) = the calculated amplitude specified by
+                         _refine_ls_structure_factor_coef
+               w       = the least-squares weight
+
+               and the sum is taken over the specified reflections
+;
+
+data_refine_ls_wR_factor_ref
+    _name                      '_refine_ls_wR_factor_ref'
+    _category                    refine
+    _type                        numb
+    _enumeration_range           0.0:
+    _definition
+;              Weighted residual factors for all reflections included in the
+               refinement.  The reflections also satisfy the resolution
+               limits established by _refine_ls_d_res_high and
+               _refine_ls_d_res_low.  See also the _refine_ls_R_factor_
+               definitions.
+
+                    ( sum w [ Y(obs) - Y(calc) ]^2^  )^1/2^
+               wR = ( ------------------------------ )
+                    (         sum w Y(obs)^2^       )
+
+               Y(obs)  = the observed amplitude specified by
+                         _refine_ls_structure_factor_coef
+               Y(calc) = the calculated amplitude specified by
+                         _refine_ls_structure_factor_coef
+               w       = the least-squares weight
+
+               and the sum is taken over the specified reflections
+;
+
+data_refine_special_details
+    _name                      '_refine_special_details'
+    _category                    refine
+    _type                        char
+    _definition
+;              Description of special aspects of the refinement process.
+;
+
+#####################
+## REFINE_LS_CLASS ##
+#####################
+
+data_refine_ls_class_[]
+    _name                      '_refine_ls_class_[]'
+    _category                    category_overview
+    _type                        null
+    loop_ _example
+          _example_detail
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+;
+    loop_
+        _refine_ls_class_R_factor_gt
+        _refine_ls_class_code
+                0.057    'Main'
+                0.074    'Com'
+                0.064    'NbRefls'
+                0.046    'LaRefls'
+                0.112    'Sat1'
+                0.177    'Sat2'
+;
+;
+    Example 1 - example for a modulated structure extracted from van Smaalen
+                [J. Phys. Condens. Matter (1991), 3, 1247-1263.]
+;
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+      _definition
+;              Data items in the REFINE_LS_CLASS category record details
+               (for each reflection class separately) about the reflections
+               used for the structure refinement.
+;
+
+data_refine_ls_class_code
+    _name                      '_refine_ls_class_code'
+    _category                    refine_ls_class
+    _type                        char
+    _list                        yes
+    _list_link_parent          '_reflns_class_code'
+    loop_ _example               '1'
+                                 'm1'
+                                 's2'
+    _definition
+;              The code identifying a certain reflection class. This code must
+               match a _reflns_class_code.
+;
+
+data_refine_ls_class_d_res_high
+    _name                      '_refine_ls_class_d_res_high'
+    _category                    refine_ls_class
+    _type                        numb
+    _list                        yes
+    _list_reference            '_refine_ls_class_code'
+    _enumeration_range           0.0:
+    _units                       A
+    _units_detail                angstrom
+    _definition
+;              For each reflection class, the highest resolution in angstroms
+               for the reflections used in the refinement. This is
+               the lowest d value in a reflection class.
+;
+
+data_refine_ls_class_d_res_low
+    _name                      '_refine_ls_class_d_res_low'
+    _category                    refine_ls_class
+    _type                        numb
+    _list                        yes
+    _list_reference            '_refine_ls_class_code'
+    _enumeration_range           0.0:
+    _units                       A
+    _units_detail                angstrom
+    _definition
+;              For each reflection class, the lowest resolution in angstroms
+               for the reflections used in the refinement. This is
+               the highest d value in a reflection class.
+;
+
+data_refine_ls_class_R_factor_
+    loop_ _name                '_refine_ls_class_R_factor_all'
+                               '_refine_ls_class_R_factor_gt'
+    _category                    refine_ls_class
+    _type                        numb
+    _list                        yes
+    _list_reference            '_refine_ls_class_code'
+    _enumeration_range           0.0:
+    _definition
+;              For each reflection class, the residual factors for all
+               reflections, and for significantly intense reflections (see
+               _reflns_threshold_expression), included in the refinement.
+               The reflections also satisfy the resolution limits established by
+               _refine_ls_class_d_res_high and _refine_ls_class_d_res_low.
+               This is the conventional R factor.
+
+                   sum | F(obs) - F(calc) |
+               R = ------------------------
+                         sum | F(obs) |
+
+               F(obs)  = the observed structure-factor amplitudes
+               F(calc) = the calculated structure-factor amplitudes
+
+               and the sum is taken over the reflections of this class. See also
+               _refine_ls_class_wR_factor_all definitions.
+;
+
+data_refine_ls_class_R_Fsqd_factor
+    _name                      '_refine_ls_class_R_Fsqd_factor'
+    _category                    refine_ls_class
+    _type                        numb
+    _list                        yes
+    _list_reference            '_refine_ls_class_code'
+    _enumeration_range           0.0:
+    _definition
+;              For each reflection class, the residual factor R(F^2^) calculated
+               on the squared amplitudes of the observed and calculated
+               structure factors for the reflections judged significantly
+               intense (i.e. satisfying the threshold specified by
+               _reflns_threshold_expression) and included in the refinement.
+
+               The reflections also satisfy the resolution limits established
+               by _refine_ls_class_d_res_high and _refine_ls_class_d_res_low.
+
+                          sum | F(obs)^2^ - F(calc)^2^ |
+               R(Fsqd) = -------------------------------
+                                  sum F(obs)^2^
+
+               F(obs)^2^  = squares of the observed structure-factor amplitudes
+               F(calc)^2^ = squares of the calculated structure-factor
+                            amplitudes
+
+               and the sum is taken over the reflections of this class.
+;
+
+data_refine_ls_class_R_I_factor
+    _name                      '_refine_ls_class_R_I_factor'
+    _category                    refine_ls_class
+    _type                        numb
+    _list                        yes
+    _list_reference            '_refine_ls_class_code'
+    _enumeration_range           0.0:
+    _definition
+;              For each reflection class, the residual factor R(I) for the
+               reflections judged significantly intense (i.e. satisfying the
+               threshold specified by _reflns_threshold_expression) and
+               included in the refinement.
+
+               This is most often calculated in Rietveld refinements
+               against powder data, where it is referred to as R~B~ or R~Bragg~.
+
+                       sum | I(obs) - I(calc) |
+               R(I) =  ------------------------
+                              sum | I(obs) |
+
+               I(obs)  = the net observed intensities
+               I(calc) = the net calculated intensities
+
+               and the sum is taken over the reflections of this class.
+;
+
+data_refine_ls_class_wR_factor_all
+    _name                      '_refine_ls_class_wR_factor_all'
+    _category                    refine_ls_class
+    _type                        numb
+    _list                        yes
+    _list_reference            '_refine_ls_class_code'
+    _enumeration_range           0.0:
+    _definition
+;              For each reflection class, the weighted residual factors for all
+               reflections included in the refinement. The reflections also
+               satisfy the resolution limits established by
+               _refine_ls_class_d_res_high and _refine_ls_class_d_res_low.
+
+                    ( sum w [ Y(obs) - Y(calc) ]^2^  )^1/2^
+               wR = ( ------------------------------ )
+                    (         sum w Y(obs)^2^       )
+
+               Y(obs)  = the observed amplitudes specified by
+                         _refine_ls_structure_factor_coef
+               Y(calc) = the calculated amplitudes specified by
+                         _refine_ls_structure_factor_coef
+               w       = the least-squares weights
+
+               and the sum is taken over the reflections of this class. See
+               also _refine_ls_class_R_factor_ definitions.
+;
+
+###########
+## REFLN ##
+###########
+
+data_refln_[]
+    _name                      '_refln_[]'
+    _category                    category_overview
+    _type                        null
+    loop_ _example
+          _example_detail
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+;
+    loop_
+     _refln_index_h
+     _refln_index_k
+     _refln_index_l
+     _refln_F_squared_calc
+     _refln_F_squared_meas
+     _refln_F_squared_sigma
+     _refln_include_status
+       2   0   0       85.57       58.90      1.45 o
+       3   0   0    15718.18    15631.06     30.40 o
+       4   0   0    55613.11    49840.09     61.86 o
+       5   0   0      246.85      241.86     10.02 o
+       6   0   0       82.16       69.97      1.93 o
+       7   0   0     1133.62      947.79     11.78 o
+       8   0   0     2558.04     2453.33     20.44 o
+       9   0   0      283.88      393.66      7.79 o
+       10  0   0      283.70      171.98      4.26 o
+;
+;
+    Example 1 - based on data set fetod of Todres, Yanovsky, Ermekov & Struchkov
+                [Acta Cryst. (1993), C49, 1352-1354].
+;
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+;
+    loop_
+    _refln_index_h
+    _refln_index_k
+    _refln_index_l
+    _refln_F_meas
+    _refln_F_calc
+    _refln_F_sigma
+    _refln_include_status
+    _refln_scale_group_code
+        0   0   6  34.935  36.034   3.143  o  1
+        0   0  12  42.599  40.855   2.131  o  1
+        0   1   0  42.500  42.507   4.719  o  1
+        0   1   1  59.172  57.976   4.719  o  1
+        0   1   2  89.694  94.741   4.325  o  1
+        0   1   3  51.743  52.241   3.850  o  1
+        0   1   4   9.294  10.318   2.346  o  1
+        0   1   5  41.160  39.951   3.313  o  1
+        0   1   6   6.755   7.102    .895  <  1
+        0   1   7  30.693  31.171   2.668  o  1
+        0   1   8  12.324  12.085   2.391  o  1
+        0   1   9  15.348  15.122   2.239  o  1
+        0   1  10  17.622  19.605   1.997  o  1
+;
+;
+    Example 2 - based on standard test data set p6122 of the Xtal distribution
+                [Hall, King & Stewart (1995). Xtal3.4 User's Manual. University
+                of Western Australia].
+;
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+    _definition
+;              Data items in the REFLN category record details about the
+               reflections used to determine the ATOM_SITE data items.
+
+               The REFLN data items refer to individual reflections and must
+               be included in looped lists.
+
+               The REFLNS data items specify the parameters that apply to all
+               reflections. The REFLNS data items are not looped.
+;
+
+data_refln_A_
+    loop_ _name                '_refln_A_calc'
+                               '_refln_A_meas'
+    _category                    refln
+    _type                        numb
+    _list                        yes
+    _list_reference            '_refln_index_'
+    _definition
+;              The calculated and measured structure-factor component A
+               (in electrons for X-ray diffraction).
+
+               A =|F|cos(phase)
+;
+
+data_refln_B_
+    loop_ _name                '_refln_B_calc'
+                               '_refln_B_meas'
+    _category                    refln
+    _type                        numb
+    _list                        yes
+    _list_reference            '_refln_index_'
+    _definition
+;              The calculated and measured structure-factor component B
+               (in electrons for X-ray diffraction).
+
+               B =|F|sin(phase)
+;
+
+data_refln_class_code
+    _name                      '_refln_class_code'
+    _category                    refln
+    _type                        char
+    _list                        yes
+    _list_reference            '_refln_index_'
+    _list_link_parent          '_reflns_class_code'
+    _definition
+;              The code identifying the class to which this reflection has been
+               assigned. This code must match a value of _reflns_class_code.
+               Reflections may be grouped into classes for a variety of
+               purposes. For example, for modulated structures each reflection
+               class may be defined by the number m=sum|m~i~|, where the m~i~
+               are the integer coefficients that, in addition to h,k,l, index
+               the corresponding diffraction vector in the basis defined
+               for the reciprocal lattice.
+;
+
+data_refln_crystal_id
+    _name                      '_refln_crystal_id'
+    _category                    refln
+    _type                        char
+    _list                        yes
+    _list_link_parent          '_exptl_crystal_id'
+    _list_reference            '_refln_index_'
+    _definition
+;              Code identifying each crystal if multiple crystals are used. Is
+               used to link with _exptl_crystal_id in the _exptl_crystal_ list.
+;
+
+data_refln_d_spacing
+    _name                      '_refln_d_spacing'
+    _category                    refln
+    _type                        numb
+    _list                        yes
+    _list_reference            '_refln_index_'
+    _enumeration_range           0.0:
+    _units                       A
+    _units_detail                angstrom
+    _definition
+;              The d spacing in angstroms for this reflection. This is related
+               to the (sin theta)/lambda value by the expression
+                    _refln_d_spacing = 2/(_refln_sint/lambda)
+;
+
+data_refln_F_
+    loop_ _name                '_refln_F_calc'
+                               '_refln_F_meas'
+                               '_refln_F_sigma'
+    _category                    refln
+    _type                        numb
+    _list                        yes
+    _list_reference            '_refln_index_'
+    _definition
+;              The calculated, measured and standard uncertainty (derived from
+               measurement) of the structure factors (in electrons for
+               X-ray diffraction).
+;
+
+data_refln_F_squared_
+    loop_ _name                '_refln_F_squared_calc'
+                               '_refln_F_squared_meas'
+                               '_refln_F_squared_sigma'
+    _category                    refln
+    _type                        numb
+    _list                        yes
+    _list_reference            '_refln_index_'
+    _definition
+;              Calculated, measured and estimated standard uncertainty (derived
+               from measurement) of the squared structure factors (in electrons
+               squared for X-ray diffraction).
+;
+
+data_refln_include_status
+    _name                      '_refln_include_status'
+    _category                    refln
+    _type                        char
+    loop_ _related_item
+          _related_function    '_refln_observed_status'  alternate
+    _list                        yes
+    _list_reference            '_refln_index_'
+    loop_ _enumeration
+          _enumeration_detail    o
+;                                     (lower-case letter o for 'observed')
+                                      satisfies _refine_ls_d_res_high
+                                      satisfies _refine_ls_d_res_low
+                                      exceeds _reflns_threshold_expression
+;
+                                 <
+;                                     satisfies _refine_ls_d_res_high
+                                      satisfies _refine_ls_d_res_low
+                                      does not exceed
+                                        _reflns_threshold_expression
+;
+                                 -  'systematically absent reflection'
+                                 x  'unreliable measurement -- not used'
+                                 h  'does not satisfy _refine_ls_d_res_high'
+                                 l  'does not satisfy _refine_ls_d_res_low'
+    _definition
+;              Classification of a reflection indicating its status with
+               respect to inclusion in the refinement and the calculation
+               of R factors.
+;
+
+data_refln_index_
+    loop_ _name                '_refln_index_h'
+                               '_refln_index_k'
+                               '_refln_index_l'
+    _category                    refln
+    _type                        numb
+    _list                        yes
+    _list_mandatory              yes
+    _definition
+;              Miller indices of the reflection. The values of the Miller
+               indices in the REFLN category must correspond to the cell
+               defined by the cell lengths and cell angles in the CELL category.
+;
+
+data_refln_intensity_
+    loop_ _name                '_refln_intensity_calc'
+                               '_refln_intensity_meas'
+                               '_refln_intensity_sigma'
+    _category                    refln
+    _type                        numb
+    _list                        yes
+    _list_reference            '_refln_index_'
+    _definition
+;              The calculated, measured and standard uncertainty (derived from
+               measurement) of the intensity, all in the same arbitrary units
+               as _refln_intensity_meas.
+;
+
+data_refln_mean_path_length_tbar
+    _name                      '_refln_mean_path_length_tbar'
+    _category                    refln
+    _type                        numb
+    _list                        yes
+    _list_reference            '_refln_index_'
+    _enumeration_range           0.0:
+    _units                       mm
+    _units_detail                millimetre
+    _definition
+;              Mean path length in millimetres through the crystal for this
+               reflection.
+;
+
+data_refln_observed_status
+    _name                      '_refln_observed_status'
+    _category                    refln
+    _type                        char
+    loop_ _related_item
+          _related_function    '_refln_include_status'  replace
+    _list                        yes
+    _list_reference            '_refln_index_'
+    loop_ _enumeration
+          _enumeration_detail    o
+;                                     satisfies _refine_ls_d_res_high
+                                      satisfies _refine_ls_d_res_low
+                                      observed by _reflns_observed_criterion
+;
+                                 <
+;                                     satisfies _refine_ls_d_res_high
+                                      satisfies _refine_ls_d_res_low
+                                      unobserved by _reflns_observed_criterion
+;
+                                 -  'systematically absent reflection'
+                                 x  'unreliable measurement -- not used'
+                                 h  'does not satisfy _refine_ls_d_res_high'
+                                 l  'does not satisfy _refine_ls_d_res_low'
+    _definition
+;              Classification of a reflection indicating its status with
+               respect to inclusion in the refinement and the calculation
+               of R factors.
+;
+
+data_refln_phase_calc
+    _name                      '_refln_phase_calc'
+    _category                    refln
+    _type                        numb
+    _list                        yes
+    _list_reference            '_refln_index_'
+    _units                       deg
+    _units_detail              'degree of arc'
+    _definition
+;              The calculated structure-factor phase in degrees.
+;
+
+data_refln_phase_meas
+    _name                      '_refln_phase_meas'
+    _category                    refln
+    _type                        numb
+    _type_conditions             esd
+    _list                        yes
+    _list_reference            '_refln_index_'
+    _units                       deg
+    _units_detail              'degree of arc'
+    _definition
+;              The measured structure-factor phase in degrees.
+;
+
+data_refln_refinement_status
+    _name                      '_refln_refinement_status'
+    _category                    refln
+    _type                        char
+    _list                        yes
+    _list_reference            '_refln_index_'
+    loop_ _enumeration
+          _enumeration_detail    incl    'included in ls process'
+                                 excl    'excluded from ls process'
+                                 extn    'excluded due to extinction'
+    _definition
+;              Status of a reflection in the structure-refinement process.
+;
+
+data_refln_scale_group_code
+    _name                      '_refln_scale_group_code'
+    _category                    refln
+    _type                        char
+    _list                        yes
+    _list_link_parent          '_reflns_scale_group_code'
+    _list_reference            '_refln_index_'
+    loop_ _example               1 2 3 s1 A B c1 c2 c3
+    _definition
+;              Code identifying the structure-factor scale. This code must
+               correspond to one of the _reflns_scale_group_code values.
+;
+
+data_refln_sint/lambda
+    _name                      '_refln_sint/lambda'
+    _category                    refln
+    _type                        numb
+    _list                        yes
+    _list_reference            '_refln_index_'
+    _enumeration_range           0.0:
+    _units                       A^-1^
+    _units_detail              'reciprocal angstrom'
+    _definition
+;              The (sin theta)/lambda value in reciprocal angstroms for this
+               reflection.
+;
+
+data_refln_symmetry_epsilon
+    _name                      '_refln_symmetry_epsilon'
+    _category                    refln
+    _type                        numb
+    _list                        yes
+    _list_reference            '_refln_index_'
+    _enumeration_range           1:48
+    _definition
+;              The symmetry reinforcement factor corresponding to the number of
+               times the reflection indices are generated identically from the
+               space-group symmetry operations.
+;
+
+data_refln_symmetry_multiplicity
+    _name                      '_refln_symmetry_multiplicity'
+    _category                    refln
+    _type                        numb
+    _list                        yes
+    _list_reference            '_refln_index_'
+    _enumeration_range           1:48
+    _definition
+;              The number of reflections symmetry-equivalent under the Laue
+               symmetry to the present reflection. In the Laue symmetry, Friedel
+               opposites (h k l and -h -k -l) are equivalent. Tables of
+               symmetry-equivalent reflections are available in International
+               Tables for Crystallography Volume A (2002), Chapter 10.1.
+;
+
+data_refln_wavelength
+    _name                      '_refln_wavelength'
+    _category                    refln
+    _type                        numb
+    _list                        yes
+    _list_reference            '_refln_index_'
+    _enumeration_range           0.0:
+    _units                       A
+    _units_detail                angstrom
+    _definition
+;              The mean wavelength in angstroms of the radiation used to measure
+               this reflection. This is an important parameter for data
+               collected using energy-dispersive detectors or the Laue method.
+;
+
+data_refln_wavelength_id
+    _name                      '_refln_wavelength_id'
+    _category                    refln
+    _type                        char
+    _list                        yes
+    _list_link_parent          '_diffrn_radiation_wavelength_id'
+    _list_reference            '_refln_index_'
+    _definition
+;              Code identifying the wavelength in the _diffrn_radiation_ list.
+               See _diffrn_radiation_wavelength_id.
+;
+
+############
+## REFLNS ##
+############
+
+data_reflns_[]
+    _name                      '_reflns_[]'
+    _category                    category_overview
+    _type                        null
+    loop_ _example
+          _example_detail
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+;
+    _reflns_limit_h_min                0
+    _reflns_limit_h_max                6
+    _reflns_limit_k_min                0
+    _reflns_limit_k_max                17
+    _reflns_limit_l_min                0
+    _reflns_limit_l_max                22
+    _reflns_number_total               1592
+    _reflns_number_gt                  1408
+    _reflns_threshold_expression       'F > 6.0u(F)'
+    _reflns_d_resolution_high          0.8733
+    _reflns_d_resolution_low           11.9202
+;
+;
+    Example 1 - based on data set TOZ of Willis, Beckwith & Tozer
+                [Acta Cryst. (1991), C47, 2276-2277].
+;
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+    _definition
+;              Data items in the REFLNS category record details about the
+               reflections used to determine the ATOM_SITE data items.
+
+               The REFLN data items refer to individual reflections and must
+               be included in looped lists.
+
+               The REFLNS data items specify the parameters that apply to all
+               reflections. The REFLNS data items are not looped.
+;
+
+data_reflns_d_resolution_
+    loop_ _name                '_reflns_d_resolution_high'
+                               '_reflns_d_resolution_low'
+    _category                    reflns
+    _type                        numb
+    _enumeration_range           0.0:
+    _units                       A
+    _units_detail                angstrom
+    _definition
+;              The highest and lowest resolution in angstroms for the
+               reflections. These are the smallest and largest d values.
+;
+
+data_reflns_Friedel_coverage
+    _name                      '_reflns_Friedel_coverage'
+    _category                    reflns
+    _type                        numb
+    _enumeration_range           0.0:1.0
+    _definition
+;              The proportion of Friedel-related reflections present in
+               the number of 'independent' reflections specified by
+               the item _reflns_number_total.
+
+               This proportion is calculated as the ratio:
+
+                 [N(crystal class) - N(Laue symmetry)] / N(Laue symmetry)
+
+               where, working from the _diffrn_refln_ list,
+
+               N(crystal class) is the number of reflections obtained on
+                  averaging under the symmetry of the crystal class
+               N(Laue symmetry) is the number of reflections obtained on
+                  averaging under the Laue symmetry.
+
+               Examples:
+                 (a) For centrosymmetric structures, _reflns_Friedel_coverage
+                     is necessarily equal to 0.0 as the crystal class
+                     is identical to the Laue symmetry.
+                 (b) For whole-sphere data for a crystal in the space
+                     group P1, _reflns_Friedel_coverage is equal to 1.0,
+                     as no reflection h k l is equivalent to -h -k -l
+                     in the crystal class and all Friedel pairs
+                     {h k l; -h -k -l} have been measured.
+                 (c) For whole-sphere data in space group Pmm2,
+                     _reflns_Friedel_coverage will be < 1.0 because
+                     although reflections h k l and
+                     -h -k -l are not equivalent when h k l indices are
+                     nonzero, they are when l=0.
+                 (d) For a crystal in the space group Pmm2, measurements of the
+                     two inequivalent octants h >= 0, k >=0, l lead to the
+                     same value as in (c), whereas measurements of the
+                     two equivalent octants h >= 0, k, l >= 0 will lead to
+                     a value of zero for _reflns_Friedel_coverage.
+;
+
+data_reflns_Friedel_fraction_full
+    _name                      '_reflns_Friedel_fraction_full'
+    _category                    reflns
+    _type                        numb
+    _enumeration_range           0.0:1.0
+    _definition
+;              The number of Friedel pairs measured out to
+               _diffrn_reflns_theta_full. divided by the
+               number theoretically possible (ignoring reflections in
+               centric projections and systematic absences
+               throughout). In contrast to _reflns_Friedel_coverage
+               this can take values in the full range 0 to 1 for any
+               non-centrosymmetric space group, and so one can see at
+               a glance how completely the Friedel pairs have been
+               measured. For centrosymmetric space groups the value
+               would be 0/0 and so would be given as '.'.
+;
+
+data_reflns_Friedel_fraction_max
+    _name                      '_reflns_Friedel_fraction_max'
+    _category                    reflns
+    _type                        numb
+    _enumeration_range           0.0:1.0
+    _definition
+;              The number of Friedel pairs measured out to
+               _diffrn_reflns_theta_max. divided by the
+               number theoretically possible (ignoring reflections in
+               centric projections and systematic absences
+               throughout). In contrast to _reflns_Friedel_coverage
+               this can take values in the full range 0 to 1 for any
+               non-centrosymmetric space group, and so one can see at
+               a glance how completely the Friedel pairs have been
+               measured. For centrosymmetric space groups the value
+               would be 0/0 and so would be given as '.'.
+;
+
+data_reflns_limit_
+    loop_ _name                '_reflns_limit_h_max'
+                               '_reflns_limit_h_min'
+                               '_reflns_limit_k_max'
+                               '_reflns_limit_k_min'
+                               '_reflns_limit_l_max'
+                               '_reflns_limit_l_min'
+    _category                    reflns
+    _type                        numb
+    _definition
+;              Miller indices limits for the reported reflections. These need
+               not be the same as the _diffrn_reflns_limit_ values.
+;
+
+data_reflns_number_gt
+    _name                      '_reflns_number_gt'
+    _category                    reflns
+    _type                        numb
+    loop_ _related_item
+          _related_function    '_reflns_number_observed'  alternate
+    _enumeration_range           0:
+    _definition
+;              The number of reflections in the _refln_ list (not the
+               _diffrn_refln_ list) that are significantly intense, satisfying
+               the criterion specified by _reflns_threshold_expression. This may
+               include Friedel-equivalent reflections (i.e. those which are
+               symmetry-equivalent under the Laue symmetry but inequivalent
+               under the crystal class) according to the nature of the
+               structure and the procedures used. Special characteristics
+               of the reflections included in the _refln_ list should be given
+               in the item _reflns_special_details.
+;
+
+data_reflns_number_observed
+    _name                      '_reflns_number_observed'
+    _category                    reflns
+    _type                        numb
+    loop_ _related_item
+          _related_function    '_reflns_number_gt'  replace
+    _enumeration_range           0:
+    _definition
+;              The number of 'observed' reflections in the _refln_ list (not
+               the _diffrn_refln_ list). The observed reflections satisfy the
+               threshold criterion specified by _reflns_threshold_expression
+               (or the deprecated item _reflns_observed_criterion). They may
+               include Friedel-equivalent reflections according to the nature
+               of the structure and the procedures used. Special characteristics
+               of the reflections included in the _refln_ list should be given
+               in the item _reflns_special_details.
+;
+
+data_reflns_number_total
+    _name                      '_reflns_number_total'
+    _category                    reflns
+    _type                        numb
+    _enumeration_range           0:
+    _definition
+;              The total number of reflections in the _refln_ list (not the
+                _diffrn_refln_ list). This may include Friedel-equivalent
+               reflections (i.e. those which are symmetry-equivalent under the
+               Laue symmetry but inequivalent under the crystal class)
+               according to the nature of the structure and the procedures
+               used. Special characteristics of the reflections included
+               in the _refln_ list should be given in the item
+               _reflns_special_details.
+;
+
+data_reflns_observed_criterion
+    _name                      '_reflns_observed_criterion'
+    _category                    reflns
+    _type                        char
+    loop_ _related_item
+          _related_function    '_reflns_threshold_expression'  replace
+    _example                    'I>2u(I)'
+    _definition
+;              The criterion used to classify a reflection as 'observed'. This
+               criterion is usually expressed in terms of a sigma(I) or sigma(F)
+               threshold.
+;
+
+data_reflns_special_details
+    _name                      '_reflns_special_details'
+    _category                    reflns
+    _type                        char
+    _definition
+;              Description of the properties of the reported reflection list
+               that are not given in other data items.  In particular, this
+               should include information about the averaging (or not) of
+               symmetry-equivalent reflections including Friedel pairs.
+;
+
+data_reflns_threshold_expression
+    _name                      '_reflns_threshold_expression'
+    _category                    reflns
+    _type                        char
+    loop_ _related_item
+          _related_function    '_reflns_observed_criterion'  alternate
+    _example                    'I>2u(I)'
+    _definition
+;              The threshold, usually based on multiples of u(I), u(F^2^)
+               or u(F), that serves to identify significantly intense
+               reflections, the number of which is given by _reflns_number_gt.
+               These reflections are used in the calculation of
+               _refine_ls_R_factor_gt.
+;
+
+##################
+## REFLNS_CLASS ##
+##################
+
+data_reflns_class_[]
+    _name                        '_reflns_class_[]'
+    _category                    category_overview
+    _type                        null
+    loop_ _example
+          _example_detail
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+;
+    loop_
+        _reflns_class_number_gt
+        _reflns_class_code
+               584     'Main'
+               226     'Sat1'
+               50      'Sat2'
+;
+;
+    Example 1 - corresponding to the one-dimensional incommensurately
+                modulated structure of K~2~SeO~4~.
+;
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+      _definition
+;              Data items in the REFLNS_CLASS category record details, for
+               each reflection class, about the reflections used to determine
+               the structural parameters.
+;
+
+data_reflns_class_code
+    _name                      '_reflns_class_code'
+    _category                    reflns_class
+    _type                        char
+    _list                        yes
+    loop_ _list_link_child     '_refln_class_code'
+                               '_refine_ls_class_code'
+    loop_ _example               '1'
+                                 'm1'
+                                 's2'
+    _definition
+;              The code identifying a certain reflection class.
+;
+
+
+data_reflns_class_d_res_high
+    _name                      '_reflns_class_d_res_high'
+    _category                    reflns_class
+    _type                        numb
+    _list                        yes
+    _list_reference            '_reflns_class_code'
+    _enumeration_range           0.0:
+    _units                       A
+    _units_detail                angstrom
+    _definition
+;              For each reflection class, the highest resolution in angstroms
+               for the reflections used in the refinement. This is the smallest
+               d value.
+;
+
+data_reflns_class_d_res_low
+    _name                      '_reflns_class_d_res_low'
+    _category                    reflns_class
+    _type                        numb
+    _list                        yes
+    _list_reference            '_reflns_class_code'
+    _enumeration_range           0.0:
+    _units                       A
+    _units_detail                angstrom
+    _definition
+;              For each reflection class, the lowest resolution in angstroms
+               for the reflections used in the refinement. This is the largest
+               d value.
+;
+
+data_reflns_class_description
+    _name                      '_reflns_class_description'
+    _category                    reflns_class
+    _type                        char
+    _list                        yes
+    _list_reference            '_reflns_class_code'
+    loop_ _example               'm=1 first order satellites'
+                                 'H0L0 common projection reflections'
+    _definition
+;              Description of each reflection class.
+;
+
+data_reflns_class_number_gt
+    _name                      '_reflns_class_number_gt'
+    _category                    reflns_class
+    _type                        numb
+    _list                        yes
+    _list_reference            '_reflns_class_code'
+    _enumeration_range           0.0:
+    _definition
+;              For each reflection class, the number of significantly intense
+               reflections (see _reflns_threshold_expression) in the _refln_
+               list (not the _diffrn_refln_ list). This may include Friedel-
+               equivalent reflections (i.e. those which are symmetry-equivalent
+               under the Laue symmetry but inequivalent under the crystal
+               class)  according to the nature of the structure and the
+               procedures used. Special characteristics of the reflections
+               included in the _refln_ list should be given in the item
+               _reflns_special_details.
+;
+
+data_reflns_class_number_total
+    _name                      '_reflns_class_number_total'
+    _category                    reflns_class
+    _type                        numb
+    _list                        yes
+    _list_reference            '_reflns_class_code'
+    _enumeration_range           0.0:
+    _definition
+;              For each reflection class, the total number of reflections
+               in the _refln_ list (not the _diffrn_refln_ list). This may
+               include Friedel-equivalent reflections (i.e. those which are
+               symmetry-equivalent under the Laue symmetry but inequivalent
+               under the crystal class) according to the nature of the
+               structure and the procedures used. Special characteristics
+               of the reflections included in the _refln_ list should be given
+               in the item _reflns_special_details.
+;
+
+data_reflns_class_R_factor_
+    loop_ _name                '_reflns_class_R_factor_all'
+                               '_reflns_class_R_factor_gt'
+    _category                    reflns_class
+    _type                        numb
+    _list                        yes
+    _list_reference            '_reflns_class_code'
+    _enumeration_range           0.0:
+    _definition
+;              For each reflection class, the residual factors for all
+               reflections, and for significantly intense reflections (see
+               _reflns_threshold_expression), included in the refinement.
+               The reflections also satisfy the resolution limits established by
+               _reflns_class_d_res_high and _reflns_class_d_res_low.
+               This is the conventional R factor.
+
+                   sum | F(obs) - F(calc) |
+               R = ------------------------
+                         sum | F(obs) |
+
+               F(obs)  = the observed structure-factor amplitudes
+               F(calc) = the calculated structure-factor amplitudes
+
+               and the sum is taken over the reflections of this class. See also
+               _reflns_class_wR_factor_all definitions.
+;
+
+data_reflns_class_R_Fsqd_factor
+    _name                      '_reflns_class_R_Fsqd_factor'
+    _category                    reflns_class
+    _type                        numb
+    _list                        yes
+    _list_reference            '_reflns_class_code'
+    _enumeration_range           0.0:
+    _definition
+;              For each reflection class, the residual factor R(F^2^) calculated
+               on the squared amplitudes of the observed and calculated
+               structure factors, for the reflections judged significantly
+               intense (i.e. satisfying the threshold specified by
+               _reflns_threshold_expression) and included in the refinement.
+
+               The reflections also satisfy the resolution limits established
+               by _reflns_class_d_res_high and _reflns_class_d_res_low.
+
+                          sum | F(obs)^2^ - F(calc)^2^ |
+               R(Fsqd) = -------------------------------
+                                  sum F(obs)^2^
+
+               F(obs)^2^  = squares of the observed structure-factor amplitudes
+               F(calc)^2^ = squares of the calculated structure-factor
+                            amplitudes
+
+               and the sum is taken over the reflections of this class.
+;
+
+data_reflns_class_R_I_factor
+    _name                      '_reflns_class_R_I_factor'
+    _category                    reflns_class
+    _type                        numb
+    _list                        yes
+    _list_reference            '_reflns_class_code'
+    _enumeration_range           0.0:
+    _definition
+;              For each reflection class, the residual factor R(I) for the
+               reflections judged significantly intense (i.e. satisfying the
+               threshold specified by _reflns_threshold_expression) and
+               included in the refinement.
+
+               This is most often calculated in Rietveld refinements
+               against powder data, where it is referred to as R~B~ or R~Bragg~.
+
+                       sum | I(obs) - I(calc) |
+               R(I) =  ------------------------
+                              sum | I(obs) |
+
+               I(obs)  = the net observed intensities
+               I(calc) = the net calculated intensities
+
+               and the sum is taken over the reflections of this class.
+;
+
+data_reflns_class_wR_factor_all
+    _name                      '_reflns_class_wR_factor_all'
+    _category                    reflns_class
+    _type                        numb
+    _list                        yes
+    _list_reference            '_reflns_class_code'
+    _enumeration_range           0.0:
+    _definition
+;              For each reflection class, the weighted residual factors for all
+               reflections included in the refinement. The reflections also
+               satisfy the resolution limits established by
+               _reflns_class_d_res_high and _reflns_class_d_res_low.
+
+                    ( sum w [ Y(obs) - Y(calc) ]^2^  )^1/2^
+               wR = ( ------------------------------ )
+                    (         sum w Y(obs)^2^       )
+
+               Y(obs)  = the observed amplitudes specified by
+                         _refine_ls_structure_factor_coef
+               Y(calc) = the calculated amplitudes specified by
+                         _refine_ls_structure_factor_coef
+               w       = the least-squares weights
+
+               and the sum is taken over the reflections of this class. See
+               also _reflns_class_R_factor_ definitions.
+;
+
+##################
+## REFLNS_SCALE ##
+##################
+
+data_reflns_scale_[]
+    _name                      '_reflns_scale_[]'
+    _category                    category_overview
+    _type                        null
+    loop_ _example
+          _example_detail
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+;
+    loop_
+    _reflns_scale_group_code
+    _reflns_scale_meas_F
+      1  .895447
+      2  .912743
+
+;
+;
+    Example 1 - based on standard test data set p6122 of the Xtal distribution
+                [Hall, King & Stewart (1995). Xtal3.4 User's Manual. University
+                of Western Australia].
+;
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+    _definition
+;              Data items in the REFLNS_SCALE category record details about
+               the structure-factor scales. They are referenced from within
+               the REFLN list through _refln_scale_group_code.
+;
+
+data_reflns_scale_group_code
+    _name                      '_reflns_scale_group_code'
+    _category                    reflns_scale
+    _type                        char
+    _list                        yes
+    _list_mandatory              yes
+    _list_link_child           '_refln_scale_group_code'
+    _definition
+;              The code identifying a scale _reflns_scale_meas_. These are
+               linked to the _refln_ list by the _refln_scale_group_code. These
+               codes need not correspond to those in the _diffrn_scale_ list.
+;
+
+data_reflns_scale_meas_
+    loop_ _name                '_reflns_scale_meas_F'
+                               '_reflns_scale_meas_F_squared'
+                               '_reflns_scale_meas_intensity'
+    _category                    reflns_scale
+    _type                        numb
+    _type_conditions             esd
+    _enumeration_range           0.0:
+    _list                        yes
+    _list_reference            '_reflns_scale_group_code'
+    _definition
+;              Scales associated with _reflns_scale_group_code.
+;
+
+##################
+## REFLNS_SHELL ##
+##################
+
+data_reflns_shell_[]
+    _name                      '_reflns_shell_[]'
+    _category                    category_overview
+    _type                        null
+    loop_ _example
+          _example_detail
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+;
+    loop_
+    _reflns_shell_d_res_high
+    _reflns_shell_d_res_low
+    _reflns_shell_meanI_over_uI_gt
+    _reflns_shell_number_measured_gt
+    _reflns_shell_number_unique_gt
+    _reflns_shell_percent_possible_gt
+    _reflns_shell_Rmerge_F_gt
+      31.38  3.82  69.8  9024  2540  96.8   1.98
+       3.82  3.03  26.1  7413  2364  95.1   3.85
+       3.03  2.65  10.5  5640  2123  86.2   6.37
+       2.65  2.41   6.4  4322  1882  76.8   8.01
+       2.41  2.23   4.3  3247  1714  70.4   9.86
+       2.23  2.10   3.1  1140   812  33.3  13.99
+;
+;
+    Example 1 - based on PDB entry 5HVP and laboratory records for the
+                structure corresponding to PDB entry 5HVP.
+;
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+    _definition
+;              Data items in the REFLNS_SHELL category record details about
+               the reflections used to determine the ATOM_SITE data items,
+               as broken down by shells of resolution.
+;
+
+data_reflns_shell_d_res_high
+    _name                      '_reflns_shell_d_res_high'
+    _category                    reflns_shell
+    _type                        numb
+    _list                        yes
+    _enumeration_range           0.0:
+    _units                       A
+    _units_detail                angstrom
+    _definition
+;              The highest resolution in angstroms for the reflections in
+               this shell. This is the smallest d value.
+;
+
+data_reflns_shell_d_res_low
+    _name                      '_reflns_shell_d_res_low'
+    _category                    reflns_shell
+    _type                        numb
+    _list                        yes
+    _enumeration_range           0.0:
+    _units                       A
+    _units_detail                angstrom
+    _definition
+;              The lowest resolution in angstroms for the
+               reflections in this shell. This is the largest d value.
+;
+
+data_reflns_shell_meanI_over_sigI_all
+    _name                      '_reflns_shell_meanI_over_sigI_all'
+    _category                    reflns_shell
+    _type                        numb
+    loop_ _related_item
+          _related_function    '_reflns_shell_meanI_over_uI_all'  replace
+    _list                        yes
+    _definition
+;              The ratio of the mean of the intensities of all reflections
+               in this shell to the mean of the standard uncertainties of the
+               intensities of all reflections in the resolution shell.
+;
+
+data_reflns_shell_meanI_over_sigI_gt
+    _name                      '_reflns_shell_meanI_over_sigI_gt'
+    _category                    reflns_shell
+    _type                        numb
+    loop_ _related_item
+          _related_function    '_reflns_shell_meanI_over_uI_gt'  replace
+    _list                        yes
+    _definition
+;              The ratio of the mean of the intensities of the significantly
+               intense reflections (see _reflns_threshold_expression) in
+               this shell to the mean of the standard uncertainties of the
+               intensities of the significantly intense reflections in the
+               resolution shell.
+;
+
+data_reflns_shell_meanI_over_sigI_obs
+    _name                      '_reflns_shell_meanI_over_sigI_obs'
+    _category                    reflns_shell
+    _type                        numb
+    loop_ _related_item
+          _related_function    '_reflns_shell_meanI_over_sigI_gt'  replace
+    _list                        yes
+    _definition
+;              The ratio of the mean of the intensities of the reflections
+               classified as 'observed' (see _reflns_observed_criterion) in
+               this shell to the mean of the standard uncertainties of the
+               intensities of the 'observed' reflections in the resolution
+               shell.
+;
+
+data_reflns_shell_meanI_over_uI_all
+    _name                      '_reflns_shell_meanI_over_uI_all'
+    _category                    reflns_shell
+    _type                        numb
+    loop_ _related_item
+          _related_function    '_reflns_shell_meanI_over_sigI_all'  alternate
+    _list                        yes
+    _definition
+;              The ratio of the mean of the intensities of all reflections
+               in this shell to the mean of the standard uncertainties of the
+               intensities of all reflections in the resolution shell.
+;
+
+data_reflns_shell_meanI_over_uI_gt
+    _name                      '_reflns_shell_meanI_over_uI_gt'
+    _category                    reflns_shell
+    _type                        numb
+    loop_ _related_item
+          _related_function    '_reflns_shell_meanI_over_sigI_gt'   alternate
+                               '_reflns_shell_meanI_over_sigI_obs'  alternate
+    _list                        yes
+    _definition
+;              The ratio of the mean of the intensities of the significantly
+               intense reflections (see _reflns_threshold_expression) in
+               this shell to the mean of the standard uncertainties of the
+               intensities of the significantly intense reflections in the
+               resolution shell.
+;
+
+
+data_reflns_shell_number_measured_all
+    _name                      '_reflns_shell_number_measured_all'
+    _category                    reflns_shell
+    _type                        numb
+    _list                        yes
+    _enumeration_range           0.0:
+    _definition
+;              The total number of reflections measured for this
+               resolution shell.
+;
+
+data_reflns_shell_number_measured_gt
+    _name                      '_reflns_shell_number_measured_gt'
+    _category                    reflns_shell
+    _type                        numb
+    loop_ _related_item
+          _related_function    '_reflns_shell_number_measured_obs'  alternate
+    _list                        yes
+    _enumeration_range           0.0:
+    _definition
+;              The number of significantly intense reflections
+               (see _reflns_threshold_expression) measured for this
+               resolution shell.
+;
+
+data_reflns_shell_number_measured_obs
+    _name                      '_reflns_shell_number_measured_obs'
+    _category                    reflns_shell
+    _type                        numb
+    loop_ _related_item
+          _related_function    '_reflns_shell_number_measured_gt'  replace
+    _list                        yes
+    _enumeration_range           0.0:
+    _definition
+;              The number of reflections classified as 'observed'
+               (see _reflns_observed_criterion) measured for this
+               resolution shell.
+;
+
+data_reflns_shell_number_possible
+    _name                      '_reflns_shell_number_possible'
+    _category                    reflns_shell
+    _type                        numb
+    _list                        yes
+    _enumeration_range           0:
+    _definition
+;              The number of unique reflections it is possible to measure in
+               this reflection shell.
+;
+
+data_reflns_shell_number_unique_all
+    _name                      '_reflns_shell_number_unique_all'
+    _category                    reflns_shell
+    _type                        numb
+    _list                        yes
+    _enumeration_range           0:
+    _definition
+;              The total number of measured reflections resulting from
+               merging measured symmetry-equivalent reflections for this
+               resolution shell.
+;
+
+data_reflns_shell_number_unique_gt
+    _name                      '_reflns_shell_number_unique_gt'
+    _category                    reflns_shell
+    _type                        numb
+    loop_ _related_item
+          _related_function    '_reflns_shell_number_unique_obs'  alternate
+    _list                        yes
+    _enumeration_range           0:
+    _definition
+;              The total number of significantly intense reflections
+               (see _reflns_threshold_expression) resulting from merging
+               measured symmetry-equivalent reflections for this resolution
+               shell.
+;
+
+data_reflns_shell_number_unique_obs
+    _name                      '_reflns_shell_number_unique_obs'
+    _category                    reflns_shell
+    _type                        numb
+    loop_ _related_item
+          _related_function    '_reflns_shell_number_unique_gt'  replace
+    _list                        yes
+    _enumeration_range           0:
+    _definition
+;              The total number of reflections classified as
+               'observed' (see _reflns_observed_criterion) resulting from
+               merging measured symmetry-equivalent reflections for this
+               resolution shell.
+;
+
+data_reflns_shell_percent_possible_all
+    _name                      '_reflns_shell_percent_possible_all'
+    _category                    reflns_shell
+    _type                        numb
+    _list                        yes
+    _enumeration_range           0.0:100.0
+    _definition
+;              The percentage of geometrically possible reflections
+               represented by all reflections measured for this
+               resolution shell.
+;
+
+data_reflns_shell_percent_possible_gt
+    _name                      '_reflns_shell_percent_possible_gt'
+    _category                    reflns_shell
+    _type                        numb
+    loop_ _related_item
+          _related_function    '_reflns_shell_percent_possible_obs'  alternate
+    _list                        yes
+    _enumeration_range           0.0:100.0
+    _definition
+;              The percentage of geometrically possible reflections
+               represented by significantly intense reflections
+               (see _reflns_threshold_expression) measured for this
+               resolution shell.
+;
+
+data_reflns_shell_percent_possible_obs
+    _name                      '_reflns_shell_percent_possible_obs'
+    _category                    reflns_shell
+    _type                        numb
+    loop_ _related_item
+          _related_function    '_reflns_shell_percent_possible_gt'  replace
+    _list                        yes
+    _enumeration_range           0.0:100.0
+    _definition
+;              The percentage of geometrically possible reflections
+               represented by reflections classified as 'observed'
+               (see _reflns_observed_criterion) measured for this
+               resolution shell.
+;
+
+data_reflns_shell_Rmerge_F_all
+    _name                      '_reflns_shell_Rmerge_F_all'
+    _category                    reflns_shell
+    _type                        numb
+    _list                        yes
+    _enumeration_range           0.0:
+    _definition
+;              The value of Rmerge(F) for all reflections in a given shell.
+
+                           sum~i~ ( sum~j~ | F~j~ - <F> | )
+               Rmerge(F) = --------------------------------
+                               sum~i~ ( sum~j~ <F> )
+
+               F~j~  = the amplitude of the jth observation of reflection i
+               <F> = the mean of the amplitudes of all observations of
+                      reflection i
+
+               sum~i~ is taken over all reflections
+               sum~j~ is taken over all observations of each reflection.
+;
+
+data_reflns_shell_Rmerge_F_gt
+    _name                      '_reflns_shell_Rmerge_F_gt'
+    _category                    reflns_shell
+    _type                        numb
+    loop_ _related_item
+          _related_function    '_reflns_shell_Rmerge_F_obs'  alternate
+    _list                        yes
+    _enumeration_range           0.0:
+    _definition
+;              The value of Rmerge(F) for significantly intense reflections
+               (see _reflns_threshold_expression) in a given shell.
+
+                           sum~i~ ( sum~j~ | F~j~ - <F> | )
+               Rmerge(F) = --------------------------------
+                               sum~i~ ( sum~j~ <F> )
+
+               F~j~  = the amplitude of the jth observation of reflection i
+               <F> = the mean of the amplitudes of all observations of
+                      reflection i
+
+               sum~i~ is taken over all reflections
+               sum~j~ is taken over all observations of each reflection.
+;
+
+data_reflns_shell_Rmerge_F_obs
+    _name                      '_reflns_shell_Rmerge_F_obs'
+    _category                    reflns_shell
+    _type                        numb
+    loop_ _related_item
+          _related_function    '_reflns_shell_Rmerge_F_gt' replace
+    _list                        yes
+    _enumeration_range           0.0:
+    _definition
+;              The value of Rmerge(F) for reflections classified as 'observed'
+               (see _reflns_observed_criterion) in a given shell.
+
+                           sum~i~ ( sum~j~ | F~j~ - <F> | )
+               Rmerge(F) = --------------------------------
+                               sum~i~ ( sum~j~ <F> )
+
+               F~j~  = the amplitude of the jth observation of reflection i
+               <F> = the mean of the amplitudes of all observations of
+                      reflection i
+
+               sum~i~ is taken over all reflections
+               sum~j~ is taken over all observations of each reflection.
+;
+
+data_reflns_shell_Rmerge_I_all
+    _name                      '_reflns_shell_Rmerge_I_all'
+    _category                    reflns_shell
+    _type                        numb
+    _list                        yes
+    _enumeration_range           0.0:
+    _definition
+;              The value of Rmerge(I) for all reflections in a given shell.
+
+                           sum~i~ ( sum~j~ | I~j~ - <I> | )
+               Rmerge(I) = --------------------------------
+                               sum~i~ ( sum~j~ <I> )
+
+               I~j~  = the intensity of the jth observation of reflection i
+               <I> = the mean of the intensities of all observations of
+                      reflection i
+
+               sum~i~ is taken over all reflections
+               sum~j~ is taken over all observations of each reflection.
+;
+
+data_reflns_shell_Rmerge_I_gt
+    _name                      '_reflns_shell_Rmerge_I_gt'
+    _category                    reflns_shell
+    _type                        numb
+    loop_ _related_item
+          _related_function    '_reflns_shell_Rmerge_I_obs'  alternate
+    _list                        yes
+    _enumeration_range           0.0:
+    _definition
+;              The value of Rmerge(I) for significantly intense reflections
+               (see _reflns_threshold_expression) in a given shell.
+
+                           sum~i~ ( sum~j~ | I~j~ - <I> | )
+               Rmerge(I) = --------------------------------
+                               sum~i~ ( sum~j~ <I> )
+
+               I~j~  = the intensity of the jth observation of reflection i
+               <I> = the mean of the intensities of all observations of
+                      reflection i
+
+               sum~i~ is taken over all reflections
+               sum~j~ is taken over all observations of each reflection.
+;
+
+data_reflns_shell_Rmerge_I_obs
+    _name                      '_reflns_shell_Rmerge_I_obs'
+    _category                    reflns_shell
+    _type                        numb
+    loop_ _related_item
+          _related_function    '_reflns_shell_Rmerge_I_gt'  replace
+    _list                        yes
+    _enumeration_range           0.0:
+    _definition
+;              The value of Rmerge(I) for reflections classified as 'observed'
+               (see _reflns_observed_criterion) in a given shell.
+
+                           sum~i~ ( sum~j~ | I~j~ - <I> | )
+               Rmerge(I) = --------------------------------
+                               sum~i~ ( sum~j~ <I> )
+
+               I~j~  = the intensity of the jth observation of reflection i
+               <I> = the mean of the intensities of all observations of
+                      reflection i
+
+               sum~i~ is taken over all reflections
+               sum~j~ is taken over all observations of each reflection.
+;
+
+#################
+## SPACE_GROUP ##
+#################
+
+data_space_group_[]
+    _name                      '_space_group_[]'
+    _category                    category_overview
+    _type                        null
+    loop_ _example
+    _example_detail
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+;
+    _space_group_name_H-M_alt       'C 2/c'
+    _space_group_IT_number          15
+    _space_group_name_Hall          '-C 2yc'
+    _space_group_crystal_system     monoclinic
+;
+;
+    Example 1 - the monoclinic space group No. 15 with unique axis b.
+;
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+    _definition
+;              Contains all the data items that refer to the space group as a
+               whole, such as its name or crystal system.
+
+               Only a subset of the SPACE_GROUP category items appear in the
+               core dictionary. The remainder are found in the symmetry CIF
+               dictionary.
+
+               Space-group types are identified by their number as given in
+               International Tables for Crystallography Vol. A. Specific
+               settings of the space groups can be identified either by their
+               Hall symbol or by specifying their symmetry operations.
+
+               The commonly used Hermann-Mauguin symbol determines the
+               space-group type uniquely but several different Hermann-Mauguin
+               symbols may refer to the same space-group type. A
+               Hermann-Mauguin symbol contains information on the choice of
+               the basis, but not on the choice of origin.  Different formats
+               for the Hermann-Mauguin symbol are found in the symmetry CIF
+               dictionary.
+;
+
+data_space_group_crystal_system
+    _name                      '_space_group_crystal_system'
+    _category                   space_group
+    _type                       char
+    loop_ _related_item
+          _related_function    '_symmetry_cell_setting'  alternate
+    loop_ _enumeration           triclinic
+                                 monoclinic
+                                 orthorhombic
+                                 tetragonal
+                                 trigonal
+                                 hexagonal
+                                 cubic
+    _definition
+;              The name of the system of geometric crystal classes of space
+               groups (crystal system) to which the space group belongs.
+               Note that rhombohedral space groups belong to the
+               trigonal system.
+;
+
+data_space_group_IT_number
+    _name                      '_space_group_IT_number'
+    _category                    space_group
+    _type                        numb
+    loop_ _related_item
+          _related_function    '_symmetry_Int_Tables_number'  alternate
+    _enumeration_range           1:230
+    _definition
+;              The number as assigned in International Tables for
+               Crystallography Vol. A, specifying the proper affine class (i.e.
+               the orientation-preserving affine class) of space groups
+               (crystallographic space-group type) to which the space group
+               belongs. This number defines the space-group type but not
+               the coordinate system in which it is expressed.
+;
+
+data_space_group_name_H-M_alt
+    _name                      '_space_group_name_H-M_alt'
+    _category                    space_group
+    _type                        char
+    loop_ _related_item
+          _related_function    '_symmetry_space_group_name_H-M'  alternate
+    loop_ _example
+          _example_detail
+;                                loop_
+                                   _space_group_name_H-M_alt
+                                   'C m c m'
+                                   'C 2/c 2/m 21/m'
+                                   'A m a m'
+;
+                               'three examples for space group No. 63'
+    _definition
+;              _space_group_name_H-M_alt allows any Hermann-Mauguin symbol
+               to be given. The way in which this item is used is determined
+               by the user and in general is not intended to be interpreted by
+               computer. It may, for example, be used to give one of the
+               extended Hermann-Mauguin symbols given in Table 4.3.2.1 of
+               International Tables for Crystallography Vol. A (2002) or
+               a Hermann-Mauguin symbol for a conventional or unconventional
+               setting.
+
+               Each component of the space-group name is separated by a
+               space or an underscore. The use of a space is strongly
+               recommended. The underscore is only retained because it
+               was used in older files. It should not be used in new CIFs.
+               Subscripts should appear without special symbols. Bars should
+               be given as negative signs before the numbers to which they apply.
+
+               The commonly used Hermann-Mauguin symbol determines the space-
+               group type uniquely but a given space-group type may be
+               described by more than one Hermann-Mauguin symbol. The space-
+               group type is best described using _space_group_IT_number.
+
+               The Hermann-Mauguin symbol may contain information on the
+               choice of basis, but not on the choice of origin. To
+               define the setting uniquely, use _space_group_name_Hall or
+               list the symmetry operations.
+;
+
+data_space_group_name_Hall
+    _name                      '_space_group_name_Hall'
+    _category                    space_group
+    _type                        char
+    loop_ _related_item
+          _related_function    '_symmetry_space_group_name_Hall'  alternate
+    loop_ _example
+          _example_detail      'P 2c -2ac'            'equivalent to Pca21'
+                               '-I 4bd 2ab 3'         'equivalent to Ia-3d'
+    _definition
+;              Space-group symbol defined by Hall.
+
+               Each component of the space-group name is separated by a
+               space or an underscore.  The use of a space is strongly
+               recommended.  The underscore is only retained because it
+               was used in older files.  It should not be
+               used in new CIFs.
+
+               _space_group_name_Hall uniquely defines the space group and
+               its reference to a particular coordinate system.
+
+               Ref: Hall, S. R. (1981). Acta Cryst. A37, 517-525; erratum
+                    (1981), A37, 921.
+                    [See also International Tables for Crystallography,
+                    Vol. B (2001), Chapter 1.4, Appendix 1.4.2]
+;
+
+#######################
+## SPACE_GROUP_SYMOP ##
+#######################
+
+data_space_group_symop_[]
+    _name                      '_space_group_symop_[]'
+    _category                    category_overview
+    _type                        null
+    loop_ _example
+          _example_detail
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+;   loop_
+    _space_group_symop_id
+    _space_group_symop_operation_xyz
+      1    x,y,z
+      2   -x,-y,-z
+      3   -x,1/2+y,1/2-z
+      4    x,1/2-y,1/2+z
+;
+;
+    Example 1 - the symmetry operations for the space group P21/c.
+;
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+    _definition
+;              Contains information about the symmetry operations of the
+               space group.
+;
+
+data_space_group_symop_id
+    _name                      '_space_group_symop_id'
+    _type                        char
+    _category                    space_group_symop
+    _list                        both
+    _list_mandatory              yes
+    loop_ _related_item
+          _related_function      '_symmetry_equiv_pos_site_id'  alternate
+    _definition
+;              An arbitrary identifier that uniquely labels each symmetry
+               operation in the list.
+
+               In order for the defaults to work correctly, the identity
+               operation should have _space_group_symop_id or
+               _symmetry_equiv_pos_site_id set to 1, and
+               _space_group_symop_operation_xyz or
+               _symmetry_equiv_pos_as_xyz set to x,y,z;
+               i.e. the operation labelled 1 should be the identity
+               operation.
+;
+
+
+data_space_group_symop_operation_xyz
+    _name                      '_space_group_symop_operation_xyz'
+    _category                    space_group_symop
+    _type                        char
+    _list                        both
+    _list_reference            '_space_group_symop_id'
+    loop_ _related_item
+          _related_function    '_symmetry_equiv_pos_as_xyz'  alternate
+    loop_ _example
+    _example_detail            'x,1/2-y,1/2+z'
+;                                glide reflection through the plane (x,1/4,z),
+                                 with glide vector (1/2)c
+;
+    _definition
+;               A parsable string giving one of the symmetry operations of the
+                space group in algebraic form.  If W is a matrix representation
+                of the rotational part of the symmetry operation defined by the
+                positions and signs of x, y and z, and w is a column of
+                translations defined by fractions, an equivalent position
+                X' is generated from a given position X by the equation
+
+                          X' = WX + w
+
+                (Note: X is used to represent bold_italics_x in International
+                Tables for Crystallography Vol. A, Part 5)
+
+                When a list of symmetry operations is given, it must contain
+                a complete set of coordinate representatives which generates
+                all the operations of the space group by the addition of
+                all primitive translations of the space group. Such
+                representatives are to be found as the coordinates of
+                the general-equivalent position in International Tables for
+                Crystallography Vol. A (2002), to which it is necessary to
+                add any centring translations shown above the
+                general-equivalent position.
+
+                That is to say, it is necessary to list explicitly all the
+                symmetry operations required to generate all the atoms in
+                the unit cell defined by the setting used.
+
+               In order for the defaults to work correctly, the identity
+               operation should have _space_group_symop_id or
+               _symmetry_equiv_pos_site_id set to 1, and
+               _space_group_symop_operation_xyz or
+               _symmetry_equiv_pos_as_xyz set to x,y,z;
+               i.e. the operation labelled 1 should be the identity
+               operation.
+;
+
+##############
+## SYMMETRY ##
+##############
+
+data_symmetry_[]
+    _name                      '_symmetry_[]'
+    _category                    category_overview
+    _type                        null
+    loop_ _example
+          _example_detail
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+;
+    _symmetry_cell_setting             orthorhombic
+    _symmetry_space_group_name_H-M     'P 21 21 21'
+    _symmetry_space_group_name_Hall    'P 2ac 2ab'
+;
+;
+    Example 1 - based on data set TOZ of Willis, Beckwith & Tozer
+                [Acta Cryst. (1991), C47, 2276-2277].
+;
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+    _definition
+;              Data items in the SYMMETRY category record details about the
+               space-group symmetry.
+;
+
+data_symmetry_cell_setting
+    _name                      '_symmetry_cell_setting'
+    _category                    symmetry
+    _type                        char
+    loop_ _enumeration           triclinic
+                                 monoclinic
+                                 orthorhombic
+                                 tetragonal
+                                 rhombohedral
+                                 trigonal
+                                 hexagonal
+                                 cubic
+    loop_ _related_item
+          _related_function    '_space_group_crystal_system'  replace
+    _definition
+;              The cell settings for this space-group symmetry.
+;
+
+data_symmetry_Int_Tables_number
+    _name                      '_symmetry_Int_Tables_number'
+    _category                    symmetry
+    _type                        numb
+    _enumeration_range           1:230
+    loop_ _related_item
+          _related_function    '_space_group_IT_number'  replace
+    _definition
+;              Space-group number from International Tables for Crystallography
+               Vol. A (2002).
+;
+
+data_symmetry_space_group_name_H-M
+    _name                      '_symmetry_space_group_name_H-M'
+    _category                    symmetry
+    _type                        char
+    loop_ _related_item
+          _related_function    '_space_group_name_H-M_alt'  replace
+    loop_ _example              'P 1 21/m 1'
+                                'P 2/n 2/n 2/n (origin at -1)'
+                                'R -3 2/m'
+    _definition
+;             Hermann-Mauguin space-group symbol. Note that the Hermann-Mauguin
+              symbol does not necessarily contain complete information
+              about the symmetry and the space-group origin. If used, always
+              supply the FULL symbol from International Tables for
+              Crystallography Vol. A (2002) and indicate the origin and
+              the setting if it is not implicit. If there is any doubt
+              that the equivalent positions can be uniquely deduced from
+              this symbol, specify the _symmetry_equiv_pos_as_xyz
+              or *_Hall data items as well. Leave spaces between
+              symbols referring to different axes.
+
+;
+
+data_symmetry_space_group_name_Hall
+    _name                      '_symmetry_space_group_name_Hall'
+    _category                    symmetry
+    _type                        char
+    loop_ _related_item
+          _related_function    '_space_group_name_Hall'  replace
+    loop_ _example             '-P 2ac 2n'
+                               '-R 3 2"'
+                               'P 61 2 2 (0 0 -1)'
+    _definition
+;              Space-group symbol as described by Hall. This symbol gives the
+               space-group setting explicitly. Leave spaces between the separate
+               components of the symbol.
+
+               Ref: Hall, S. R. (1981). Acta Cryst. A37, 517-525; erratum
+               (1981), A37, 921.
+;
+
+####################
+## SYMMETRY_EQUIV ##
+####################
+
+data_symmetry_equiv_[]
+    _name                      '_symmetry_equiv_[]'
+    _category                    category_overview
+    _type                        null
+    loop_ _example
+          _example_detail
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+;
+    loop_
+    _symmetry_equiv_pos_as_xyz
+        +x,+y,+z  1/2-x,-y,1/2+z  1/2+x,1/2-y,-z  -x,1/2+y,1/2-z
+;
+;
+    Example 1 - based on data set TOZ of Willis, Beckwith & Tozer
+                [Acta Cryst. (1991), C47, 2276-2277].
+;
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+;
+    loop_
+    _symmetry_equiv_pos_site_id
+    _symmetry_equiv_pos_as_xyz
+        1     x,y,z
+        2     1/2-x,-y,1/2+z
+        3     1/2+x,1/2-y,-z
+        4     -x,1/2+y,1/2-z
+
+;
+;
+    Example 2 - based on data set TOZ of Willis, Beckwith & Tozer
+                [Acta Cryst. (1991), C47, 2276-2277]. Formally, the value of
+                _symmetry_equiv_pos_site_id can be any unique character string;
+                it is recommended that it be assigned the sequence number of
+                the list of equivalent positions for compatibility with
+                older files in which it did not appear.
+;
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+    _definition
+;              Data items in the SYMMETRY_EQUIV category list the
+               symmetry-equivalent positions for the space group.
+;
+
+data_symmetry_equiv_pos_as_xyz
+    _name                      '_symmetry_equiv_pos_as_xyz'
+    _category                    symmetry_equiv
+    _type                        char
+    _list                        both
+    _example                     -y+x,-y,1/3+z
+    loop_ _related_item
+          _related_function    '_space_group_symop_operation_xyz'  replace
+    _definition
+;              Symmetry-equivalent position in the 'xyz' representation. Except
+               for the space group P1, these data will be repeated in a loop.
+               The format of the data item is as per International Tables for
+               Crystallography Vol. A. (2002). All equivalent positions should
+               be entered, including those for lattice centring and a centre of
+               symmetry, if present.
+
+               In order for the defaults to work correctly, the identity
+               operation should have _space_group_symop_id or
+               _symmetry_equiv_pos_site_id set to 1, and
+               _space_group_symop_operation_xyz or
+               _symmetry_equiv_pos_as_xyz set to x,y,z;
+               i.e. the operation labelled 1 should be the identity
+               operation.
+;
+
+data_symmetry_equiv_pos_site_id
+    _name                      '_symmetry_equiv_pos_site_id'
+    _category                    symmetry_equiv
+    _type                        numb
+    _list                        both
+    _list_reference            '_symmetry_equiv_pos_as_xyz'
+    loop_ _related_item
+          _related_function    '_space_group_symop_id'  replace
+    _definition
+;              A code identifying each entry in the _symmetry_equiv_pos_as_xyz
+               list. It is normally the sequence number of the entry in that
+               list, and should be identified with the code 'n' in
+               _geom_*_symmetry_ codes of the form 'n_klm'.
+
+               In order for the defaults to work correctly, the identity
+               operation should have _space_group_symop_id or
+               _symmetry_equiv_pos_site_id set to 1, and
+               _space_group_symop_operation_xyz or
+               _symmetry_equiv_pos_as_xyz set to x,y,z;
+               i.e. the operation labelled 1 should be the identity
+               operation.
+;
+
+###################
+## VALENCE_PARAM ##
+###################
+
+data_valence_param_[]
+    _name                      '_valence_param_[]'
+    _category                    category_overview
+    _type                        null
+    loop_ _example
+          _example_detail
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+;
+    loop_
+    _valence_param_id
+    _valence_param_atom_1
+    _valence_param_atom_1_valence
+    _valence_param_atom_2
+    _valence_param_atom_2_valence
+    _valence_param_Ro
+    _valence_param_B
+    _valence_param_ref_id
+    _valence_param_details
+      1   Cu 2 O -2 1.679 0.37 a .
+      2   Cu 2 O -2 1.649 0.37 j .
+      3   Cu 2 N -3 1.64  0.37 m '2-coordinate N'
+      4   Cu 2 N -3 1.76  0.37 m '3-coordinate N'
+    loop_
+    _valence_ref_id
+    _valence_ref_reference
+      a  'Brown & Altermatt (1985), Acta Cryst. B41, 244-247'
+      j  'Liu & Thorp (1993), Inorg. Chem. 32, 4102-4205'
+      m  'See, Krause & Strub (1998), Inorg. Chem. 37, 5369-5375'
+;
+;
+    Example 1 - a bond-valence parameter list with accompanying references.
+;
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+    _definition
+;              Data items in the VALENCE_PARAM category define the
+               parameters used for calculating bond valences from bond
+               lengths.  In addition to the parameters, a pointer
+               is given to the reference (in VALENCE_REF) from which
+               the bond-valence parameters were taken.
+;
+
+data_valence_param_atom_1
+    _name                      '_valence_param_atom_1'
+    _category                    valence_param
+    _type                        char
+    _list                        yes
+    _list_reference            '_valence_param_id'
+    _definition
+;              The element symbol of the first atom forming the bond whose
+               bond-valence parameters are given in this category.
+;
+
+data_valence_param_atom_1_valence
+    _name                      '_valence_param_atom_1_valence'
+    _category                    valence_param
+    _type                        numb
+    _list                        yes
+    _list_reference            '_valence_param_id'
+    _definition
+;              The valence (formal charge) of the first atom whose
+               bond-valence parameters are given in this category.
+;
+
+data_valence_param_atom_2
+    _name                      '_valence_param_atom_2'
+    _category                    valence_param
+    _type                        char
+    _list                        yes
+    _list_reference            '_valence_param_id'
+    _definition
+;              The element symbol of the second atom forming the bond whose
+               bond-valence parameters are given in this category.
+;
+
+data_valence_param_atom_2_valence
+    _name                      '_valence_param_atom_2_valence'
+    _category                    valence_param
+    _type                        numb
+    _list                        yes
+    _list_reference            '_valence_param_id'
+    _definition
+;              The valence (formal charge) of the second atom whose
+               bond-valence parameters are given in this category.
+;
+
+data_valence_param_B
+    _name                      '_valence_param_B'
+    _category                    valence_param
+    _type                        numb
+    _list                        yes
+    _list_reference            '_valence_param_id'
+    _units                       A
+    _units_detail                angstrom
+    _definition
+;              The bond-valence parameter B used in the expression
+
+                     s = exp[(Ro - R)/B]
+
+               where s is the valence of a bond of length R.
+;
+
+data_valence_param_details
+    _name                      '_valence_param_details'
+    _category                    valence_param
+    _type                        char
+    _list                        yes
+    _list_reference            '_valence_param_id'
+    _definition
+;              Details of or comments on the bond-valence parameters.
+;
+
+data_valence_param_id
+    _name                      '_valence_param_id'
+    _category                    valence_param
+    _type                        char
+    _list                        yes
+    _definition
+;              An identifier for the valence parameters of a bond between
+               the given atoms.
+;
+
+data_valence_param_ref_id
+    _name                      '_valence_param_ref_id'
+    _category                     valence_param
+    _type                         char
+    _list                         yes
+    _list_reference             '_valence_param_id'
+    _list_link_parent           '_valence_ref_id'
+    _definition
+;              An identifier which links to the reference to the source
+               from which the bond-valence parameters are taken. A child
+               of _valence_ref_id, which it must match.
+;
+
+data_valence_param_Ro
+    _name                      '_valence_param_Ro'
+    _category                    valence_param
+    _type                        numb
+    _list                        yes
+    _list_reference            '_valence_param_id'
+    _units                       A
+    _units_detail                angstrom
+    _definition
+;              The bond-valence parameter Ro used in the expression
+
+                     s = exp[(Ro - R)/B]
+
+               where s is the valence of a bond of length R.
+;
+
+#################
+## VALENCE_REF ##
+#################
+
+data_valence_ref_[]
+    _name                      '_valence_ref_[]'
+    _category                    category_overview
+    _type                        null
+    _definition
+;              Data items in the VALENCE_REF category list the references
+               from which the bond-valence parameters have been taken.
+;
+
+data_valence_ref_id
+    _name                      '_valence_ref_id'
+    _category                    valence_ref
+    _type                        char
+    _list                        yes
+    _list_link_child           '_valence_param_ref_id'
+    _definition
+;              An identifier for items in this category. Parent of
+               _valence_param_ref_id, which must have the same value.
+;
+
+data_valence_ref_reference
+    _name                      '_valence_ref_reference'
+    _type                        char
+    _category                    valence_ref
+    _list                        yes
+    _list_reference            '_valence_ref_id'
+    _definition
+;              Literature reference from which the valence parameters
+               identified by _valence_param_id were taken.
+;
+
+#-eof-eof-eof-eof-eof-eof-eof-eof-eof-eof-eof-eof-eof-eof-eof-eof-eof-eof-eof

--- a/dictionaries/cif_pd.dic
+++ b/dictionaries/cif_pd.dic
@@ -1,0 +1,2620 @@
+##############################################################################
+#                                                                            #
+#                        Powder CIF Dictionary                               #
+#                        ---------------------                               #
+#                                                                            #
+#  CIF data definitions specifically for powder diffraction applications.    #
+#  These are in addition to those defined in the Core CIF Dictionary 1996.   #
+#                                                                            #
+#  The DDL commands used in this dictionary are defined in "ddl_core.dic".   #
+#                                                                            #
+##############################################################################
+
+data_on_this_dictionary
+
+    _dictionary_name            cif_pd.dic
+    _dictionary_version         1.0.2-dev-1
+    _dictionary_update          2021-03-23
+    _dictionary_history
+;
+  1991-08-28  Initial definitions                                  B.H. Toby
+  1991-09-15  More definitions added                               B.H. Toby
+  1991-09-21  Still More definitions                               B.H. Toby
+  1991-09-24  Some updates from down under  |:-)                   S.R. Hall
+  1991-10-07  Unable to leave well enough alone...                 B.H. Toby
+  1991-10-10  Some additional fine tuning   (-:|                   S.R. Hall
+  1991-10-14  Minor touchups                                       B.H. Toby
+  1991-12-08  Back to Work...                                      B.H. Toby
+  1992-01-07  Add _pd_refln_ to allow for mixtures                 B.H. Toby
+  1992-02-07  Some redefinitions                                   S.R. Hall
+  1992-02-25  Defining standards is a fiddly business              S.R. Hall
+  1992-03-18  And still more...                                    B.H. Toby
+  1992-05-22  Minor cleanup                                        B.H. Toby
+  1992-05-23  Quasar says that all is OK now...                    S.R. Hall
+  1992-05-30  Changes from comments @ APD-II                       B.H. Toby
+  1992-08-18  Add calculated pattern definitions                   B.H. Toby
+  1992-08-28  Change 'powder' to 'pw'                              B.H. Toby
+  1992-08-31  Major overhaul of some definitions                   B.H. Toby
+  1992-09-01  Small adjustments                                    S.R. Hall
+  1992-10-01  Change 'pw' to 'pd'                                  B.H. Toby
+  1993-04-16  Change usage for multiple detectors                  B.H. Toby
+  1993-04-19  Change *_raw_ to *_meas_; *_sample_ to *_samp_
+              Install new DDL commands; new *_phase_ group         S.R. Hall
+  1993-05-22  Fix _pd_calib_ defs; Minor editing                   B.H. Toby
+  1993-05-31  Still more minor editing                             B.H. Toby
+  1993-06-02  Application of new DDL commands                      S.R. Hall
+  1993-08-13  Last stop before Beijing, more descriptive entries &
+              more descriptive text added; support for film data.  B.H. Toby
+  1993-10-27  My two cents worth                                   I.D. Brown
+  1994-01-23  Change two to 2.5; sample to specimen.               B.H. Toby
+  1994-03-13  Change date/time usage
+              Be more careful about pd_proc usage: separate data
+              & processing conditions                              B.H. Toby
+  1994-04-11  Start work on categories: move all diffractogram
+              items (that might ever be in a single loop) into
+              pd_data.                                             B.H. Toby
+  1994-05-11  Start revisions based on I.D. Brown's comments       B.H. Toby
+  1994-06-25  Complete revisions prior to ACA                      B.H. Toby
+  1994-10-27  Working draft                                        B.H. Toby
+  1995-10-23  Implemented _units and _units_detail                 B. McMahon
+  1995-10-24  Transferred _pd_instr_radiation_probe to the core
+              as _diffrn_radiation_probe                           B. McMahon
+  1997-01-30  Final cleanup: removed _nm units; add units to
+              definitions; add _pd_block_diffractogram_id;
+              change _pd_meas_distance_value to _pd_meas_position;
+              remove _pd_proc_wavelength_nm, _pd_proc_d_spacing_nm;
+              _pd_proc_recip_len_Q_nm, and _pd_peak_d_spacing_nm
+                                                                   B.H. Toby
+  1997-01-31  Changed dictionary_definition to category_overview;
+              removed data_include_dependent_dictionaries and global_
+              blocks; some typos fixed                             B. McMahon
+  1997-02-12  Some typos fixed                                     B. McMahon
+  1997-02-18  References to e.s.d. changed to s.u. etc.
+              Notation for Bragg and expected R factors changed to
+              R~B~ and R~exp~
+                                                                   B. McMahon
+  1997-03-10  Category of _pd_refln_ things changed to 'refln'; category of`
+              _pd_proc_number_of_points changed to 'pd_proc_info'; some
+              rewording of descriptions involving s.u.s according to BT;
+              changed 'samp' to 'spec' in many datanames relating distances
+              to specimen; changed style of these and similar to *_src/spec
+              etc; _pd_calc_method no longer has '_list yes'; _list_uniqueness
+              deleted from _pd_refln_peak_id; use of '.' instead of '?'
+              recommended in a couple of places; addition of example to
+              _pd_calib_conversion_eqn; '_pd_proc_intensity_calc_bkg' and
+              '_fix_bkg' changed to '_pd_proc_intensity_bkg_calc' and '_fix'
+                                                                   B. McMahon
+  1997-03-12  Category of _pd_calib_ things changed to 'pd_calib';
+              _pd_calib_conversion_eqn and *_special_details renamed as
+              _pd_calibration_* and assigned to category 'pd_calibration'
+              Alphabetised entries within category.
+                                                                   B. McMahon
+  1997-03-17  Copyediting changes to punctuation and spelling.     B. McMahon
+  1997-10-29  Changed _pd_calib_std_external_id to
+              _pd_calib_std_external_block_id. Moved _pd_proc_2theta_range_ to
+              category pd_proc_info (because not looped with other pd_data
+              items).
+                                                                   B. McMahon
+  1997-10-29  Release version 1.0                                  B. McMahon
+  2005-01-07  NJA: minor corrections to hyphenation, spelling and punctuation
+                   pd_data_[pd]: Example 3, second loop _pd_calc_2theta_scan
+                   changed to _pd_proc_2theta_corrected
+                   _pd_instr_cons_illum_len: definition rephrased
+                   _pd_phase_[pd]: first sentence of definition rephrased
+                   _pd_proc_ls_background_function: second paragraph of
+                   definition rephrased
+  2017-06-30  Maintenance update:
+                Moved all unlooped instances of _related_function to
+                  a loop structure as required by the ddl.dic.     A. Vaitkus
+  2021-03-23  Maintenance update:
+                Homogenised the values of the _units and _units_detail
+                  data items.
+;
+
+#......................... Block/Data set names
+
+data_pd_block_[pd]
+    _name                       '_pd_block_[pd]'
+    _category                     category_overview
+    _type                         null
+    _definition
+;              _pd_block_id is used to assign a unique ID code to a data block.
+               This code is then used for references between different blocks
+               (see _pd_block_diffractogram_id, _pd_calib_std_external_block_id
+               and _pd_phase_block_id).
+
+               Note that a data block may contain only a single diffraction
+               data set or information about a single crystalline phase.
+               However, a single diffraction measurement may yield structural
+               information on more than one phase, or a single structure
+               determination may use more than one data set. Alternatively,
+               results from a single data set, such as calibration parameters
+               from measurements of a standard, may be used for many subsequent
+               analyses. Through use of the ID code, a reference made between
+               data sets may be preserved when the file is exported from the
+               laboratory from which the CIF originated.
+
+               The ID code assigned to each data block should be unique with
+               respect to an ID code assigned for any other data block in the
+               world. The naming scheme chosen for the block-ID format is
+               designed to ensure uniqueness.
+
+               It is the responsibility of a data archive site or local
+               laboratory to create a catalogue of block ID's if that site
+               wishes to resolve these references.
+;
+
+data_pd_block_diffractogram_id
+    _name                      '_pd_block_diffractogram_id'
+    _category                    pd_proc
+    _type                        char
+    _list                        yes
+    _definition
+;              A block ID code (see _pd_block_id) that identifies
+               diffraction data contained in a data block other
+               than the current block. This will occur most frequently
+               when more than one set of diffraction data
+               is used for a structure determination. The data
+               block containing the diffraction data will contain
+               a _pd_block_id code matching the code in
+               _pd_block_diffractogram_id.
+;
+
+data_pd_block_id
+    _name                      '_pd_block_id'
+    _category                    pd_block
+    _type                        char
+    _list                        both
+    loop_ _example
+                         1991-15-09T16:54|Si-std|B.Toby|D500#1234-987
+                         1991-15-09T16:54|SEPD7234|B.Toby|SEPD.IPNS.ANL.GOV
+    _definition
+;              Used to assign a unique character string to a block.
+               Note that this code is not intended to be parsed; the
+               concatenation of several strings is used in order to
+               generate a string that can reasonably be expected to
+               be unique.
+
+               This code is assigned by the originator of the data set and
+               is used for references between different CIF blocks.
+               The ID will normally be created when the block is first
+               created. It is possible to loop more than one ID for a
+               block: if changes or additions are made to the
+               block later, a new ID may be assigned, but the original name
+               should be retained.
+
+               The format for the ID code is:
+                 <date-time>|<block_name>|<creator_name>|<instr_name>
+
+                <date-time>    is the date and time the CIF was created
+                               or modified.
+
+                <block_name>   is an arbitrary name assigned by the
+                               originator of the data set. It will
+                               usually match the name of the phase
+                               and possibly the name of the current CIF
+                               data block (i.e. the string xxxx in a
+                               data_xxxx identifier). It may be a sample name.
+
+                <creator_name> is the name of the person who measured the
+                               diffractogram, or prepared or modified the CIF.
+
+                <instr_name>  is a unique name (as far as possible) for
+                               the data-collection instrument, preferably
+                               containing the instrument serial number for
+                               commercial instruments. It is also possible to
+                               use the Internet name or address for the
+                               instrument computer as a unique name.
+
+               As blocks are created in a CIF, the original sample identifier
+               (i.e. <block_name>) should be retained, but the <creator_name>
+               may be changed and the <date-time> will always change.
+               The <date-time> will usually match either the
+               _pd_meas_datetime_initiated or the _pd_proc_info_datetime
+               entry.
+
+               Within each section of the code, the following characters
+               may be used:
+                             A-Z a-z 0-9 # & * . : , - _ + / ( ) \ [ ]
+
+               The sections are separated with vertical rules '|' which are
+               not allowed within the sections. Blank spaces may also
+               not be used.  Capitalization may be used within the ID code
+               but should not be considered significant - searches for
+               data-set ID names should be case-insensitive.
+
+               Date-time entries are in the standard CIF format
+               'yyyy-mm-ddThh:mm:ss+zz' Use of seconds and a time zone
+               is optional, but use of hours and minutes is strongly
+               encouraged as this will help ensure that the ID code is unique.
+
+               An archive site that wishes to make CIFs available via
+               the web may substitute the URL for the file containing the
+               appropriate block for the final two sections of the ID
+               (<creator_name> and <instr_name>). Note that this should
+               not be done unless the archive site is prepared to keep the
+               file available online indefinitely.
+;
+
+#......................... Measured Diffractogram Information
+
+data_pd_meas_[pd]
+    _name                     '_pd_meas_[pd]'
+    _category                   category_overview
+    _type                       null
+    loop_
+        _example
+        _example_detail
+#----------------------------------------------------------------------------
+;
+    _pd_meas_info_author_name        'Cranswick, Lachlan'
+    _pd_meas_info_author_email       lachlan@dmp.csiro.au
+    _pd_meas_info_author_address     ?
+    _pd_meas_datetime_initiated      1992-03-23T17:20
+
+    _pd_meas_scan_method             step
+    _pd_meas_2theta_range_min        6.0
+    _pd_meas_2theta_range_max        164.0
+    _pd_meas_2theta_range_inc        0.025
+    _pd_meas_step_count_time         2.0
+;
+;
+    Example 1.
+;
+#----------------------------------------------------------------------------
+    _definition
+;              This section contains the measured diffractogram and information
+               about the conditions used for the measurement of the diffraction
+               data set, prior to processing and application of correction
+               terms. While additional information may be added to the CIF
+               as data are processed and transported between laboratories
+               (possibly with the addition of a new _pd_block_id entry), the
+               information in this section of the CIF will rarely be changed
+               once data collection is complete.
+
+               Where possible, measurements in this section should have no
+               post-collection processing applied (normalizations, corrections,
+               smoothing, zero-offset corrections etc.). Such corrected
+               measurements should be recorded in the _pd_proc_ section.
+
+               Data sets that are measured as counts, where a standard
+               uncertainty can be considered equivalent to the standard
+               deviation and where the standard deviation can be estimated
+               as the square root of the number of counts recorded, should
+               use the _pd_meas_counts_ fields. All other intensity values
+               should be recorded using _pd_meas_intensity_.
+;
+
+data_pd_meas_2theta_fixed
+    _name                      '_pd_meas_2theta_fixed'
+    _category                    pd_meas_method
+    _type                        numb
+    _type_conditions             esd
+    _enumeration_range           -180.0:360.0
+    _definition
+;              The 2\q diffraction angle in degrees for measurements
+               in a white-beam fixed-angle experiment. For measurements
+               where 2\q is scanned, see _pd_meas_2theta_scan or
+               _pd_meas_2theta_range_.
+;
+
+data_pd_meas_2theta_range_
+    loop_ _name                '_pd_meas_2theta_range_min'
+                               '_pd_meas_2theta_range_max'
+                               '_pd_meas_2theta_range_inc'
+    _category                    pd_meas_method
+    _type                        numb
+    _enumeration_range           -180.0:360.0
+    _definition
+;              The range of 2\q diffraction angles in degrees for the
+               measurement of intensities. These may be used in place of the
+               _pd_meas_2theta_scan values for data sets measured with a
+               constant step size.
+;
+
+data_pd_meas_2theta_scan
+    _name                      '_pd_meas_2theta_scan'
+    _category                    pd_data
+    _type                        numb
+    _type_conditions             esd
+    _list                        yes
+    _enumeration_range           -180.0:360.0
+    _definition
+;              2\q diffraction angle (in degrees) for intensity
+               points measured in a scanning method. The scan method used
+               (e.g. continuous or step scan) should be specified in
+               the item _pd_meas_scan_method. For fixed 2\q (white-beam)
+               experiments, use _pd_meas_2theta_fixed. In the case of
+               continuous-scan data sets, the 2\q value should be the
+               value at the midpoint of the counting period. Associated
+               with each _pd_meas_2theta_scan value will be
+               _pd_meas_counts_ items. The 2\q values should
+               not be corrected for nonlinearity,
+               zero offset etc. Corrected values may be specified
+               using _pd_proc_2theta_corrected.
+
+               Note that for data sets collected with constant step size,
+               _pd_meas_2theta_range_ (*_min, *_max and *_inc) may be
+               used instead of _pd_meas_2theta_scan.
+;
+
+data_pd_meas_angle_
+    loop_ _name                '_pd_meas_angle_chi'
+                               '_pd_meas_angle_omega'
+                               '_pd_meas_angle_phi'
+                               '_pd_meas_angle_2theta'
+    _category                    pd_data
+    _type                        numb
+    _list                        both
+    _enumeration_range           -180.0:360.0
+    _definition
+;              The diffractometer angles in degrees for an instrument with a
+               Euler circle. The definitions for these angles follow the
+               convention of International Tables for X-ray Crystallography
+               (1974), Vol. IV, p. 276.
+;
+
+data_pd_meas_counts_
+    loop_ _name                '_pd_meas_counts_total'
+                               '_pd_meas_counts_background'
+                               '_pd_meas_counts_container'
+                               '_pd_meas_counts_monitor'
+    _category                    pd_data
+    _type                        numb
+    _list                        yes
+    _enumeration_range           0:
+    _definition
+;              Counts measured at the measurement point as a function of
+               angle, time, channel or some other variable (see
+               _pd_meas_2theta_ etc.).
+
+               The defined fields are:
+                 _pd_meas_counts_total, scattering from the specimen
+                   (with background, specimen mounting or container
+                   scattering included);
+                 _pd_meas_counts_background, scattering measured
+                   without a specimen, specimen mounting etc., often
+                   referred to as the instrument background;
+                 _pd_meas_counts_container, the specimen container or
+                   mounting without a specimen, includes background;
+                 _pd_meas_counts_monitor, counts measured by an
+                   incident-beam monitor to calibrate the flux on the
+                   specimen.
+
+               Corrections for background, detector dead time etc.
+               should not have been made to these values. Instead use
+               _pd_proc_intensity_ for corrected diffractograms.
+
+               Note that counts-per-second values should be converted to
+               total counts. If the counting time varies for different
+               points, it may be included in the loop using
+               _pd_meas_step_count_time.
+
+               Standard uncertainties should not be quoted for these values.
+               If the standard uncertainties differ from the square root of
+               the number of counts, _pd_meas_intensity_ should be used.
+;
+
+data_pd_meas_datetime_initiated
+    _name                      '_pd_meas_datetime_initiated'
+    _category                    pd_meas_method
+    _type                        char
+    _example                     1990-07-13T14:40
+    _definition
+;              The date and time of the data-set measurement. Entries follow
+               the standard CIF format 'yyyy-mm-ddThh:mm:ss+zz'. Use
+               of seconds and a time zone is optional, but use of hours
+               and minutes is strongly encouraged. Where possible, give the
+               time when the measurement was started rather than when
+               it was completed.
+;
+
+data_pd_meas_detector_id
+    _name                      '_pd_meas_detector_id'
+    _category                    pd_data
+    _type                        char
+    _list                        yes
+    _list_link_parent          '_pd_calib_detector_id'
+    _definition
+;              A code or number which identifies the measuring detector or
+               channel number in a position-sensitive, energy-dispersive
+               or other multiple-detector instrument.
+
+               Calibration information, such as angle offsets or
+               a calibration function to convert channel numbers
+               to Q, energy, wavelength, angle etc. should
+               be described with _pd_calib_ values. If
+               _pd_calibration_conversion_eqn is used, the detector ID's
+               should be the number to be used in the equation.
+;
+
+data_pd_meas_info_author_address
+    _name                      '_pd_meas_info_author_address'
+    _category                    pd_meas_info
+    _type                        char
+    _list                        both
+    _list_reference            '_pd_meas_info_author_name'
+    _definition
+;              The address of the person who measured the data set. If there
+               is more than one person, this will be looped with
+               _pd_meas_info_author_name.
+;
+
+data_pd_meas_info_author_email
+    _name                      '_pd_meas_info_author_email'
+    _category                    pd_meas_info
+    _type                        char
+    _list                        both
+    _list_reference            '_pd_meas_info_author_name'
+    _definition
+;              The e-mail address of the person who measured the data set. If
+               there is more than one person, this will be looped with
+               _pd_meas_info_author_name.
+;
+
+data_pd_meas_info_author_fax
+    _name                      '_pd_meas_info_author_fax'
+    _category                    pd_meas_info
+    _type                        char
+    _list                        both
+    _list_reference            '_pd_meas_info_author_name'
+    _definition
+;              The fax number of the person who measured the data set. If
+               there is more than one person, this will be looped with
+               _pd_meas_info_author_name. The recommended style is
+               the international dialing prefix, followed by the area code in
+               parentheses, followed by the local number with no spaces.
+;
+
+data_pd_meas_info_author_name
+    _name                      '_pd_meas_info_author_name'
+    _category                    pd_meas_info
+    _type                        char
+    _list                        both
+    _definition
+;              The name of the person who measured the data set. The family
+               name(s), followed by a comma and including any dynastic
+               components, precedes the first name(s) or initial(s).
+               For more than one person use a loop to specify multiple values.
+;
+
+data_pd_meas_info_author_phone
+    _name                      '_pd_meas_info_author_phone'
+    _category                    pd_meas_info
+    _type                        char
+    _list                        both
+    _list_reference            '_pd_meas_info_author_name'
+    _definition
+;              The telephone number of the person who measured the data set.
+               If there is more than one person, this will be looped with
+               _pd_meas_info_author_name. The recommended style is
+               the international dialing prefix, followed by the area code in
+               parentheses, followed by the local number with no spaces.
+;
+
+data_pd_meas_intensity_
+    loop_ _name                '_pd_meas_intensity_total'
+                               '_pd_meas_intensity_background'
+                               '_pd_meas_intensity_container'
+                               '_pd_meas_intensity_monitor'
+    _category                    pd_data
+    _type                        numb
+    _type_conditions             esd
+    _list                        yes
+    _definition
+;              Intensity measurements at the measurement point (see
+               the definition of _pd_meas_2theta_).
+
+               The defined fields are:
+                 _pd_meas_intensity_total, scattering from the specimen
+                   (with background, specimen mounting or container
+                   scattering included);
+                 _pd_meas_intensity_background, scattering measured
+                   without a specimen, specimen mounting etc., often
+                   referred to as the instrument background;
+                 _pd_meas_intensity_container, the specimen container or
+                   mounting without a specimen, includes background;
+                 _pd_meas_intensity_monitor, intensity measured by an
+                   incident-beam monitor to calibrate the flux on the specimen.
+
+               Use these entries for measurements where intensity
+               values are not counts (use _pd_meas_counts_ for event-counting
+               measurements where the standard uncertainty is
+               estimated as the square root of the number of counts).
+
+               Corrections for background, detector dead time etc.,
+               should not have been made to these values. Instead use
+               _pd_proc_intensity_ for corrected diffractograms.
+
+               _pd_meas_units_of_intensity should be used to specify
+               the units of the intensity measurements.
+;
+
+data_pd_meas_number_of_points
+    _name                      '_pd_meas_number_of_points'
+    _category                    pd_meas_method
+    _type                        numb
+    _enumeration_range           1:
+    _definition
+;              The total number of points in the measured
+               diffractogram.
+;
+
+data_pd_meas_position
+    _name                      '_pd_meas_position'
+    _category                    pd_data
+    _type                        numb
+    _type_conditions             esd
+    _list                        yes
+    _units                       mm
+    _units_detail                millimetre
+    _definition
+;              A linear distance in millimetres corresponding to the
+               location where an intensity measurement is made.
+               Used for detectors where a distance measurement is made
+               as a direct observable, such as from a microdensitometer
+               trace from film or a strip chart recorder. This is an
+               alternative to _pd_meas_2theta_scan, which should only be
+               used for instruments that record intensities directly
+               against 2\q. For instruments where the position scale
+               is nonlinear, the data item _pd_meas_detector_id should
+               be used to record positions.
+
+               Calibration information, such as angle offsets or a
+               function to convert this distance to a 2\q angle
+               or d-space, should be supplied with the _pd_calib_ values.
+
+               Do not confuse this with the instrument geometry
+               descriptions given by _pd_instr_dist_.
+;
+
+data_pd_meas_rocking_angle
+    _name                      '_pd_meas_rocking_angle'
+    _category                    pd_data
+    _type                        numb
+    _list                        both
+    _units                       deg
+    _units_detail               'degree of arc'
+    _enumeration_range           0:360.0
+    _definition
+;              The angular range in degrees through which a sample is rotated
+               or oscillated during a measurement step
+               (see _pd_meas_rocking_axis).
+;
+
+data_pd_meas_rocking_axis
+    _name                      '_pd_meas_rocking_axis'
+    _category                    pd_meas_method
+    _type                        char
+    loop_ _enumeration           chi
+                                 omega
+                                 phi
+    _definition
+;              Description of the axis (or axes) used to rotate or rock the
+               specimen for better randomization of crystallites
+               (see _pd_meas_rocking_angle).
+;
+
+data_pd_meas_scan_method
+    _name                      '_pd_meas_scan_method'
+    _category                    pd_meas_method
+    _type                        char
+    loop_ _enumeration
+          _enumeration_detail    step    'step scan'
+                                 cont    'continuous scan'
+                                 tof     'time of flight'
+                                 disp    'energy dispersive'
+                                 fixed   'stationary detector'
+    _definition
+;              Code identifying the method for scanning reciprocal space.
+               The designation `fixed' should be used for measurements where
+               film, a stationary position-sensitive or area detector
+               or other non-moving detection mechanism is used to
+               measure diffraction intensities.
+;
+
+data_pd_meas_special_details
+    _name                      '_pd_meas_special_details'
+    _category                    pd_meas_method
+    _type                        char
+    _definition
+;              Special details of the diffraction measurement process.
+               Include information about source instability, degradation etc.
+               However, this item should not be used to record information
+               that can be specified in other _pd_meas_ entries.
+;
+
+data_pd_meas_step_count_time
+    _name                      '_pd_meas_step_count_time'
+    _category                    pd_data
+    _type                        numb
+    _type_conditions             esd
+    _list                        both
+    _units                       s
+    _units_detail                second
+    _enumeration_range           0.0:
+    _definition
+;              The count time in seconds for each intensity measurement.
+               If this value varies for different intensity measurements,
+               then this item will be placed in the loop with the
+               diffraction measurements. If a single fixed value is used,
+               it may be recorded outside the loop.
+;
+
+data_pd_meas_time_of_flight
+    _name                      '_pd_meas_time_of_flight'
+    _category                    pd_data
+    _type                        numb
+    _type_conditions             esd
+    _list                        yes
+    _units                       \ms
+    _units_detail                microsecond
+    _enumeration_range           0:
+    _definition
+;              Measured time in microseconds for time-of-flight neutron
+               measurements. Note that the flight distance may be
+               specified using _pd_instr_dist_ values.
+;
+
+data_pd_meas_units_of_intensity
+    _name                      '_pd_meas_units_of_intensity'
+    _category                    pd_meas_method
+    _type                        char
+    loop_ _example        'estimated from strip chart'
+                          'arbitrary, from film density'
+                          'counts, with automatic dead-time correction applied'
+    _definition
+;              Units for intensity measurements when _pd_meas_intensity_
+               is used. Note that use of 'counts' or 'counts per second'
+               here is strongly discouraged: convert the intensity
+               measurements to counts and use _pd_meas_counts_ and
+               _pd_meas_step_count_time instead of _pd_meas_intensity_.
+;
+
+#........................... Calibration Information
+
+data_pd_calib_[pd]
+    _name                       '_pd_calib_[pd]'
+    _category                     category_overview
+    _type                         null
+    loop_
+        _example
+        _example_detail
+#----------------------------------------------------------------------------
+;
+   _pd_calib_std_external_block_id
+               QuartzPlate|D500#1234-987|B.Toby|91-15-09|14:02
+   _pd_calib_std_external_name
+               'Arkansas Stone quartz plate'
+;
+;
+    Example 1.
+;
+;
+    _pd_calibration_conversion_eqn
+    ; 2\q~actual~ = 2\q~setting~ + arctan(
+      cos(P~1~)/{1/[P~0~ (CC - CH~0~ - P~2~ CC^2^)] - sin(P~1~)})
+    ;
+;
+;
+    Example 2 -
+                2\q~actual~ = 2\q~setting~ + arctan( cos(P~1~) / {1/[P~0~
+                  (CC - CH~0~ - P~2~ CC^2^)] - sin(P~1~)} ).
+
+                This allows for the calibration of 2\q for a linear
+                position-sensitive detector (PSD) where the PSD has been
+                set so that the 'centre channel' (CH~0~) is located at
+                2\q~setting~ as a function of the channel number (CC). In
+                addition to CH~0~, variables P~0~, P~1~ and P~2~ are
+                calibration constants, where P~0~ is the width of a PSD
+                channel in degrees, P~1~ is the angle of the PSD with respect
+                to the perpendicular and P~2~ is a quadratic term for
+                nonlinearities in the detector.
+;
+#----------------------------------------------------------------------------
+    _definition
+;              This section defines the parameters used for the calibration
+               of the instrument that are used directly or indirectly in the
+               interpretation of this data set. The information in this
+               section of the CIF should generally be written when the
+               intensities are first measured, but from then on should remain
+               unchanged. Loops may be used for calibration information that
+               differs by detector channel. The _pd_calibration_ items,
+               however, are never looped.
+;
+
+data_pd_calib_2theta_
+    loop_ _name                '_pd_calib_2theta_offset'
+                               '_pd_calib_2theta_off_point'
+                               '_pd_calib_2theta_off_min'
+                               '_pd_calib_2theta_off_max'
+    _category                    pd_calib
+    _type                        numb
+    _list                        both
+    _list_reference            '_pd_calib_detector_id'
+    _units                       deg
+    _units_detail               'degree of arc'
+    _enumeration_range           -180.0:180.0
+    _definition
+;              _pd_calib_2theta_offset defines an offset angle (in degrees)
+               used to calibrate 2\q (as defined in _pd_meas_2theta_).
+               Calibration is done by adding the offset:
+
+                    2\q~calibrated~ = 2\q~measured~ + 2\q~offset~
+
+               For cases where the _pd_calib_2theta_offset value is
+               not a constant, but rather varies with 2\q, a set
+               of offset values can be supplied in a loop. In this case,
+               the value where the offset has been determined can be
+               specified as _pd_calib_2theta_off_point. Alternatively, a
+               range where the offset is applicable can be specified using
+               _pd_calib_2theta_off_min and _pd_calib_2theta_off_max.
+;
+
+data_pd_calib_detector_id
+    _name                      '_pd_calib_detector_id'
+    _category                    pd_calib
+    _type                        char
+    _list                        yes
+    _list_mandatory              yes
+    _list_link_child           '_pd_meas_detector_id'
+    _definition
+;              A code which identifies the detector or channel number in a
+               position-sensitive, energy-dispersive or other multiple-detector
+               instrument. Note that this code should match the code name used
+               for _pd_meas_detector_id.
+;
+
+data_pd_calib_detector_response
+    _name                      '_pd_calib_detector_response'
+    _category                    pd_calib
+    _type                        numb
+    _list                        yes
+    _list_reference            '_pd_calib_detector_id'
+    _enumeration_range           0.0:
+    _definition
+;              A value that indicates the relative sensitivity of each
+               detector. This can compensate for differences in electronics,
+               size and collimation. Usually, one detector or the mean for
+               all detectors will be assigned the value of 1.
+;
+
+data_pd_calib_std_external_
+    loop_ _name                '_pd_calib_std_external_block_id'
+                               '_pd_calib_std_external_name'
+    _category                    pd_calib
+    _type                        char
+    _list                        both
+    _list_reference            '_pd_calib_detector_id'
+    _definition
+;              Identifies the data set used as an external standard for
+               the diffraction angle or the intensity calibrations.
+               *_name specifies the name of the material and
+               *_id the _pd_block_id for the CIF containing calibration
+               measurements. If more than one data set is used for
+               calibration, these fields may be looped.
+;
+
+data_pd_calib_std_internal_mass_%
+    _name                      '_pd_calib_std_internal_mass_%'
+    _category                    pd_calib
+    _type                        numb
+    _type_conditions             esd
+    _list                        both
+    _list_reference            '_pd_calib_detector_id'
+    _enumeration_range           0.0:100.0
+    _definition
+;              Per cent presence of the internal standard specified by the
+               data item _pd_calib_std_internal_name expressed as 100 times
+               the ratio of the amount of standard added to the original
+               sample mass.
+;
+
+data_pd_calib_std_internal_name
+    _name                      '_pd_calib_std_internal_name'
+    _category                    pd_calib
+    _type                        char
+    _list                        both
+    _list_reference            '_pd_calib_detector_id'
+    loop_ _example              'NIST 640a Silicon standard'
+                                'Al2O3'
+    _definition
+;              Identity of material(s) used as an internal intensity standard.
+;
+
+data_pd_calibration_conversion_eqn
+    _name                      '_pd_calibration_conversion_eqn'
+    _category                    pd_calibration
+    _type                        char
+    _example
+; 2\q~actual~ = 2\q~setting~ + arctan(
+             cos(P~1~) / {1/[P~0~ (CC - CH~0~ - P~2~ CC^2^)] - sin(P~1~)} )
+;
+    _definition
+;              The calibration function for converting a channel number
+               supplied in _pd_meas_detector_id for a position-sensitive
+               or energy-dispersive detector or the distance supplied in
+               _pd_meas_position to Q, energy, angle etc.
+               Use _pd_calib_std_external_ to define a pointer
+               to the file or data block containing the information used
+               to define this function.
+;
+
+data_pd_calibration_special_details
+    _name                      '_pd_calibration_special_details'
+    _category                    pd_calibration
+    _type                        char
+    _definition
+;              Description of how the instrument was
+               calibrated, particularly for instruments where
+               calibration information is used to make hardware
+               settings that would otherwise be invisible once data
+               collection is completed. Do not use this item to specify
+               information that can be specified using other _pd_calib_
+               items.
+;
+
+#............................ Specimen parameters
+
+data_pd_spec_[pd]
+    _name                       '_pd_spec_[pd]'
+    _category                     category_overview
+    _type                         null
+    loop_
+        _example
+        _example_detail
+#----------------------------------------------------------------------------
+;
+    _pd_spec_mounting               ?
+    _pd_spec_mount_mode             transmission
+    _pd_spec_orientation            horizontal
+    _pd_spec_preparation            ?
+;
+;
+    Example 1.
+;
+#----------------------------------------------------------------------------
+    _definition
+;              This section contains information about the specimen used
+               for measurement of the diffraction data set. Note that
+               information about the sample (the batch of material from which
+               the specimen was obtained) is specified in _pd_prep_.
+;
+
+data_pd_spec_description
+     _name                     '_pd_spec_description'
+     _category                   pd_spec
+     _type                       char
+     _definition
+;               A description of the specimen, such as the source of the
+                specimen, identification of standards, mixtures etc.
+;
+
+data_pd_spec_mount_mode
+    _name                      '_pd_spec_mount_mode'
+    _category                    pd_spec
+    _type                        char
+    loop_ _enumeration           reflection
+                                 transmission
+    _definition
+;              A code describing the beam path through the specimen.
+;
+
+data_pd_spec_mounting
+    _name                      '_pd_spec_mounting'
+    _category                    pd_spec
+    _type                        char
+    loop_ _example               'vanadium can with He exchange gas'
+                                 'quartz capillary'
+                                 'packed powder pellet'
+                                 'drifted powder on off-cut Si'
+                                 'drifted powder on Kapton film'
+    _definition
+;              A description of how the specimen is mounted.
+;
+
+data_pd_spec_orientation
+    _name                      '_pd_spec_orientation'
+    _category                    pd_spec
+    _type                        char
+    loop_ _enumeration           horizontal
+                                 vertical
+                                 both
+    _definition
+;              The orientation of the \w (\q) and 2\q axis.
+               Note that this axis is parallel to the specimen axial axis
+               and perpendicular to the plane containing the incident and
+               scattered beams.
+
+               Thus for a horizontal orientation, scattering
+               measurements are made in a plane perpendicular to the
+               ground (the 2\q axis is parallel to the ground);
+               for vertical orientation, scattering measurements are
+               made in a plane parallel with the ground (the 2\q axis
+               is perpendicular to the ground). `Both' is appropriate for
+               experiments where measurements are made in both planes,
+               for example using two-dimensional detectors.
+;
+
+data_pd_spec_preparation
+    _name                      '_pd_spec_preparation'
+    _category                    pd_spec
+    _type                        char
+    loop_ _example               'wet grinding in acetone'
+                              'sieved through a 44 micron (325 mesh/inch) sieve'
+                                 'spray dried in water with 1% clay'
+    _definition
+;              A description of the preparation steps for producing the
+               diffraction specimen from the sample. Include any procedures
+               related to grinding, sieving, spray drying etc. For
+               information relevant to how the sample is synthesized, use
+               the _pd_prep_ entries.
+;
+
+data_pd_spec_shape
+    _name                      '_pd_spec_shape'
+    _category                    pd_spec
+    _type                        char
+    loop_ _enumeration           cylinder
+                                 flat_sheet
+                                 irregular
+    _definition
+;              A code describing the specimen shape.
+;
+
+data_pd_spec_size_
+    loop_ _name                '_pd_spec_size_axial'
+                               '_pd_spec_size_equat'
+                               '_pd_spec_size_thick'
+    _category                    pd_spec
+    _type                        numb
+    _units                       mm
+    _units_detail                millimetre
+    _enumeration_range           0.0:
+    _definition
+;              The size of the specimen in three mutually perpendicular
+               directions in millimetres.
+               The perpendicular to the plane containing the incident
+               and scattered beam is the *_axial direction.
+               In transmission geometry, the scattering vector is parallel
+               to *_equat and in reflection geometry the scattering vector is
+               parallel to *_thick.
+
+;
+
+data_pd_spec_special_details
+    _name                      '_pd_spec_special_details'
+    _category                   pd_spec
+    _type                       char
+    _definition
+;              Descriptive information about the specimen that cannot be
+               included in other data items.
+;
+
+#............................ Instrument parameters
+
+data_pd_instr_[pd]
+    _name                       '_pd_instr_[pd]'
+    _category                     category_overview
+    _type                         null
+    loop_
+        _example
+        _example_detail
+#----------------------------------------------------------------------------
+;
+    _pd_instr_slit_eq_src/spec       1.
+    _pd_instr_slit_eq_anal/detc      0.2
+
+    _pd_instr_geometry              Bragg-Brentano
+    _pd_instr_monochr_post_spec     'graphite (0001)'
+    _pd_instr_cons_illum_flag       no
+;
+;
+    Example 1.
+;
+#----------------------------------------------------------------------------
+    _definition
+;              This section contains information relevant to the instrument
+               used for the diffraction measurement. For most laboratories,
+               very little of this information will change, so a standard file
+               may be prepared and included with each data set.
+
+               Note that several definitions in the core CIF dictionary
+               are relevant here. For example, use:
+                 _diffrn_radiation_wavelength for the source wavelength,
+                 _diffrn_radiation_type for the X-ray wavelength type,
+                 _diffrn_source for the radiation source,
+                 _diffrn_radiation_polarisn_ratio for the source polarization,
+                 _diffrn_radiation_probe for the radiation type.
+               For data sets measured with partially monochromatized radiation,
+               for example, where both K\a~1~ and K\a~2~ are present, it is
+               important that all wavelengths present are included in a
+               loop_ using _diffrn_radiation_wavelength to define the
+               wavelength and _diffrn_radiation_wavelength_wt to define the
+               relative intensity of that wavelength. It is required that
+               _diffrn_radiation_wavelength_id also be present in the
+               wavelength loop. It may also be useful to
+               create a "dummy" ID to use for labelling
+               peaks/reflections where the K\a~1~ and K\a~2~ wavelengths are
+               not resolved. Set _diffrn_radiation_wavelength_wt to be 0 for
+               such a dummy ID.
+
+               In the _pd_instr_ definitions, the term monochromator refers
+               to a primary beam (pre-specimen) monochromator and the term
+               analyser refers to post-diffraction (post-specimen)
+               monochromator.  The analyser may be fixed for specific
+               wavelength or may be capable of being scanned.
+
+               For multiple-detector instruments it may be necessary to loop the
+               *_anal/detc or *_spec/detc values (for  _pd_instr_dist_,
+               _pd_instr_divg_, _pd_instr_slit_ and  _pd_instr_soller_) with
+               the detector ID's (_pd_calib_detector_id).
+
+               It is strongly recommended that the core dictionary term
+               _diffrn_radiation_probe (specifying the nature of the radiation
+               used) is employed for all data sets.
+;
+
+data_pd_instr_2theta_monochr_
+    loop_ _name                 '_pd_instr_2theta_monochr_pre'
+                                '_pd_instr_2theta_monochr_post'
+    _category                    pd_instr
+    _type                        numb
+    _list                        both
+    _units                       deg
+    _units_detail               'degree of arc'
+    _enumeration_range           -180.0:180.0
+    _definition
+;              The 2\q angle for a pre-specimen or post-specimen
+               monochromator (see _pd_instr_monochr_pre_spec and
+               _pd_instr_monochr_post_spec).
+;
+
+data_pd_instr_beam_size_
+    loop_ _name                '_pd_instr_beam_size_ax'
+                               '_pd_instr_beam_size_eq'
+    _category                    pd_data
+    _type                        numb
+    _enumeration_range           0.0:
+    _units                       mm
+    _units_detail                millimetre
+    _definition
+;              Axial and equatorial dimensions of the radiation beam
+               at the specimen position (in millimetres).
+               The perpendicular to the plane containing the incident
+               and scattered beam is the axial (*_ax) direction.
+;
+
+data_pd_instr_cons_illum_flag
+    _name                      '_pd_instr_cons_illum_flag'
+    _category                    pd_instr
+    _type                        char
+    loop_ _enumeration           yes  no
+    _definition
+;              Use 'yes' for instruments where the divergence slit is
+               \q-compensated to yield a constant illumination length
+               (also see _pd_instr_cons_illum_len).
+
+               For other flat-plate instruments, where the illumination
+               length changes with 2\q, specify 'no'. Note that
+               if the length is known, it may be specified using
+               _pd_instr_var_illum_len.
+;
+
+data_pd_instr_cons_illum_len
+    _name                      '_pd_instr_cons_illum_len'
+    _category                    pd_instr
+    _type                        numb
+    _enumeration_range           0.0:
+    _units                       mm
+    _units_detail                millimetre
+    _definition
+;              Length of the specimen that is illuminated by the radiation
+               source (in millimetres).
+
+               Use _pd_instr_cons_illum_len for instruments where
+               the illumination length does not vary with 2\q, by
+               adjustment of the divergence slits (sometimes known
+               as \q-compensated slits).
+               Use _pd_instr_var_illum_len for instruments where
+               the illuminated length of the specimen has been
+               characterized as a function of 2\q, most commonly true
+               with a fixed divergence slit.
+;
+
+data_pd_instr_dist_
+    loop_ _name                '_pd_instr_dist_src/mono'
+                               '_pd_instr_dist_mono/spec'
+                               '_pd_instr_dist_src/spec'
+                               '_pd_instr_dist_spec/anal'
+                               '_pd_instr_dist_anal/detc'
+                               '_pd_instr_dist_spec/detc'
+    _category                    pd_instr
+    _type                        numb
+    _units                       mm
+    _units_detail                millimetre
+    _enumeration_range           0.0:
+    _list                        both
+    _definition
+;              Specifies distances in millimetres for the instrument geometry:
+                 *_src/mono, the distance from the radiation source
+                     to the monochromator;
+                 *_mono/spec, the distance from the monochromator to
+                     the specimen;
+                 *_src/spec, the distance from the radiation source
+                     to the specimen;
+                 *_spec/anal, the distance from the specimen to the
+                     analyser;
+                 *_anal/detc, the distance from the analyser to the
+                     detector;
+                 *_spec/detc, the distance from the specimen to the
+                     detector.
+
+               Note that *_src/spec is used in place of *_src/mono and
+               *_mono/spec if there is no monochromator in use, and
+               *_spec/detc is used in place of *_spec/anal and *_anal/detc
+               if there is no analyser in use.
+;
+
+data_pd_instr_divg_ax_
+    loop_ _name                '_pd_instr_divg_ax_src/mono'
+                               '_pd_instr_divg_ax_mono/spec'
+                               '_pd_instr_divg_ax_src/spec'
+                               '_pd_instr_divg_ax_spec/anal'
+                               '_pd_instr_divg_ax_anal/detc'
+                               '_pd_instr_divg_ax_spec/detc'
+    _category                    pd_instr
+    _type                        numb
+    _enumeration_range           0.0:
+    _units                       deg
+    _units_detail               'degree of arc'
+    _list                        both
+    _definition
+;              Describes collimation in the axial direction
+               (perpendicular to the plane containing the incident
+               and diffracted beams) for the instrument.
+               Values are the maximum divergence angles in
+               degrees, as limited by slits or beamline optics
+               other than Soller slits (see _pd_instr_soller_ax_):
+                 *_src/mono, collimation between the radiation source
+                     and the monochromator;
+                 *_mono/spec, collimation between the monochromator and
+                     the specimen;
+                 *_src/spec, collimation between the radiation source
+                     and the specimen;
+                 *_spec/anal, collimation between the specimen and the
+                     analyser;
+                 *_anal/detc, collimation between the analyser and the
+                     detector;
+                 *_spec/detc, collimation between the specimen and the
+                     detector.
+
+               Note that *_src/spec is used in place of *_src/mono and
+               *_mono/spec if there is no monochromator in use, and
+               *_spec/detc is used in place of *_spec/anal and *_anal/detc
+               if there is no analyser in use.
+;
+
+data_pd_instr_divg_eq_
+    loop_ _name                '_pd_instr_divg_eq_src/mono'
+                               '_pd_instr_divg_eq_mono/spec'
+                               '_pd_instr_divg_eq_src/spec'
+                               '_pd_instr_divg_eq_spec/anal'
+                               '_pd_instr_divg_eq_anal/detc'
+                               '_pd_instr_divg_eq_spec/detc'
+    _category                    pd_instr
+    _type                        numb
+    _enumeration_range           0.0:
+    _units                       deg
+    _units_detail               'degree of arc'
+    _list                        both
+    _definition
+;              Describes collimation in the equatorial plane (the plane
+               containing the incident and diffracted beams) for
+               the instrument. Values are the maximum divergence angles in
+               degrees, as limited by slits or beamline optics
+               other than Soller slits (see _pd_instr_soller_eq_):
+                 *_src/mono, collimation between the radiation source
+                     and the monochromator;
+                 *_mono/spec, collimation between the monochromator and
+                     the specimen;
+                 *_src/spec, collimation between the radiation source
+                     and the specimen;
+                 *_spec/anal, collimation between the specimen and the
+                     analyser;
+                 *_anal/detc, collimation between the analyser and the
+                     detector;
+                 *_spec/detc, collimation between the specimen and the
+                     detector.
+
+               Note that *_src/spec is used in place of *_src/mono and
+               *_mono/spec if there is no monochromator in use, and
+               *_spec/detc is used in place of *_spec/anal and *_anal/detc
+               if there is no analyser in use.
+;
+
+data_pd_instr_geometry
+    _name                      '_pd_instr_geometry'
+    _category                    pd_instr
+    _type                        char
+    loop_ _example        Bragg-Brentano
+                          Guinier
+;                         Parallel-beam non-focusing optics with
+                          channel-cut monochromator and linear
+                          position-sensitive detector
+;
+    _definition
+;              A description of the diffractometer type or geometry.
+;
+
+data_pd_instr_location
+    _name                      '_pd_instr_location'
+    _category                    pd_instr
+    _type                        char
+    _example         'SEPD diffractometer, IPNS, Argonne National Lab (USA)'
+    _definition
+;              The name and location of the instrument where measurements
+               were made. This is used primarily to identify data sets
+               measured away from the author's home facility, at shared
+               resources such as a reactor or spallation source.
+;
+
+data_pd_instr_monochr_
+    loop_ _name                 '_pd_instr_monochr_pre_spec'
+                                '_pd_instr_monochr_post_spec'
+    _category                    pd_instr
+    _type                        char
+    _list                        both
+    loop_ _example              'Zr filter'   'Ge 220'   'none'
+                                'equatorial mounted graphite (0001)'
+                                'Si (111), antiparallel'
+    _definition
+;              Indicates the method used to obtain monochromatic radiation.
+               Use _pd_instr_monochr_pre_spec to describe the primary beam
+               monochromator (pre-specimen monochromation). Use
+               _pd_instr_monochr_post_spec to specify the
+               post-diffraction analyser (post-specimen monochromation).
+
+               When a monochromator crystal is used, the material and the
+               indices of the Bragg reflection are specified.
+
+               Note that monochromators may have either 'parallel' or
+               'antiparallel' orientation. It is assumed that the
+               geometry is parallel unless specified otherwise.
+               In a parallel geometry, the position of the monochromator
+               allows the incident beam and the final post-specimen
+               and post-monochromator beam to be as close to parallel
+               as possible. In a parallel geometry, the diffracting
+               planes in the specimen and monochromator will be parallel
+               when 2\q~monochromator~ is equal to 2\q~specimen~.
+               For further discussion see R. Jenkins & R. Snyder (1996).
+               Introduction to X-ray Powder Diffraction,
+               pp. 164-165. New York: Wiley.
+;
+
+data_pd_instr_slit_ax_
+    loop_ _name                '_pd_instr_slit_ax_src/mono'
+                               '_pd_instr_slit_ax_mono/spec'
+                               '_pd_instr_slit_ax_src/spec'
+                               '_pd_instr_slit_ax_spec/anal'
+                               '_pd_instr_slit_ax_anal/detc'
+                               '_pd_instr_slit_ax_spec/detc'
+    _category                    pd_instr
+    _type                        numb
+    _enumeration_range           0.0:
+    _units                       mm
+    _units_detail                millimetre
+    _list                        both
+    _definition
+;              Describes collimation in the axial direction
+               (perpendicular to the plane containing the incident
+               and diffracted beams) for the instrument as a slit width
+               (as opposed to a divergence angle).
+               Values are the width of the slit (in millimetres) defining:
+                 *_src/mono, collimation between the radiation source
+                     and the monochromator;
+                 *_mono/spec, collimation between the monochromator and
+                     the specimen;
+                 *_src/spec, collimation between the radiation source
+                     and the specimen;
+                 *_spec/anal, collimation between the specimen and the
+                     analyser;
+                 *_anal/detc, collimation between the analyser and the
+                     detector;
+                 *_spec/detc, collimation between the specimen and the
+                     detector.
+
+               Note that *_src/spec is used in place of *_src/mono and
+               *_mono/spec if there is no monochromator in use, and
+               *_spec/detc is used in place of *_spec/anal and *_anal/detc
+               if there is no analyser in use.
+;
+
+data_pd_instr_slit_eq_
+    loop_ _name                '_pd_instr_slit_eq_src/mono'
+                               '_pd_instr_slit_eq_mono/spec'
+                               '_pd_instr_slit_eq_src/spec'
+                               '_pd_instr_slit_eq_spec/anal'
+                               '_pd_instr_slit_eq_anal/detc'
+                               '_pd_instr_slit_eq_spec/detc'
+    _category                    pd_instr
+    _type                        numb
+    _enumeration_range           0.0:
+    _units                       mm
+    _units_detail                millimetre
+    _list                        both
+    _definition
+;              Describes collimation in the equatorial plane (the plane
+               containing the incident and diffracted beams) for the
+               instrument as a slit width (as opposed to a divergence angle).
+               Values are the width of the slit (in millimetres) defining:
+                 *_src/mono, collimation between the radiation source
+                     and the monochromator;
+                 *_mono/spec, collimation between the monochromator and
+                     the specimen;
+                 *_src/spec, collimation between the radiation source
+                     and the specimen;
+                 *_spec/anal, collimation between the specimen and the
+                     analyser;
+                 *_anal/detc, collimation between the analyser and the
+                     detector;
+                 *_spec/detc, collimation between the specimen and the
+                     detector.
+
+               Note that *_src/spec is used in place of *_src/mono and
+               *_mono/spec if there is no monochromator in use, and
+               *_spec/detc is used in place of *_spec/anal and
+               *_anal/detc if there is no analyser in use.
+;
+
+data_pd_instr_soller_ax_
+    loop_ _name                '_pd_instr_soller_ax_src/mono'
+                               '_pd_instr_soller_ax_mono/spec'
+                               '_pd_instr_soller_ax_src/spec'
+                               '_pd_instr_soller_ax_spec/anal'
+                               '_pd_instr_soller_ax_anal/detc'
+                               '_pd_instr_soller_ax_spec/detc'
+    _category                    pd_instr
+    _type                        numb
+    _enumeration_range           0.0:
+    _units                       deg
+    _units_detail               'degree of arc'
+    _list                        both
+    _definition
+;              Describes collimation in the axial direction
+               (perpendicular to the plane containing the incident
+               and diffracted beams) for the instrument.
+               Values are the maximum divergence angles in
+               degrees, as limited by Soller slits located thus:
+                 *_src/mono, collimation between the radiation source
+                     and the monochromator;
+                 *_mono/spec, collimation between the monochromator and
+                     the specimen;
+                 *_src/spec, collimation between the radiation source
+                     and the specimen;
+                 *_spec/anal, collimation between the specimen and the
+                     analyser;
+                 *_anal/detc, collimation between the analyser and the
+                     detector;
+                 *_spec/detc, collimation between the specimen and the
+                     detector.
+
+               Note that *_src/spec is used in place of *_src/mono and
+               *_mono/spec if there is no monochromator in use, and
+               *_spec/detc is used in place of *_spec/anal and
+               *_anal/detc if there is no analyser in use.
+;
+
+data_pd_instr_soller_eq_
+    loop_ _name                '_pd_instr_soller_eq_src/mono'
+                               '_pd_instr_soller_eq_mono/spec'
+                               '_pd_instr_soller_eq_src/spec'
+                               '_pd_instr_soller_eq_spec/anal'
+                               '_pd_instr_soller_eq_anal/detc'
+                               '_pd_instr_soller_eq_spec/detc'
+    _category                    pd_instr
+    _type                        numb
+    _enumeration_range           0.0:
+    _units                       deg
+    _units_detail               'degree of arc'
+    _list                        both
+    _definition
+;              Describes collimation in the equatorial plane (the plane
+               containing the incident and diffracted beams) for
+               the instrument. Values are the maximum divergence angles in
+               degrees, as limited by Soller slits located thus:
+                 *_src/mono, collimation between the radiation source
+                     and the monochromator;
+                 *_mono/spec, collimation between the monochromator and
+                     the specimen;
+                 *_src/spec, collimation between the radiation source
+                     and the specimen;
+                 *_spec/anal, collimation between the specimen and the
+                     analyser;
+                 *_anal/detc, collimation between the analyser and the
+                     detector;
+                 *_spec/detc, collimation between the specimen and the
+                     detector.
+
+               Note that *_src/spec is used in place of *_src/mono and
+               *_mono/spec if there is no monochromator in use, and
+               *_spec/detc is used in place of *_spec/anal and
+               *_anal/detc if there is no analyser in use.
+;
+
+data_pd_instr_source_size_
+    loop_ _name                '_pd_instr_source_size_ax'
+                               '_pd_instr_source_size_eq'
+    _category                    pd_instr
+    _type                        numb
+    _enumeration_range           0.0:
+    _units                       mm
+    _units_detail                millimetre
+    _definition
+;              Axial and equatorial intrinsic dimensions
+               of the radiation source (in millimetres).
+               The perpendicular to the plane containing the incident
+               and scattered beam is the axial (*_ax) direction.
+;
+
+data_pd_instr_special_details
+    _name                      '_pd_instr_special_details'
+    _category                    pd_instr
+    _type                        char
+    _definition
+;              A brief description of the instrument giving
+               details that cannot be given in other
+               _pd_instr_ entries.
+;
+
+data_pd_instr_var_illum_len
+    _name                      '_pd_instr_var_illum_len'
+    _category                    pd_data
+    _list                        yes
+    _type                        numb
+    _enumeration_range           0.0:
+    _units                       mm
+    _units_detail                millimetre
+    _definition
+;              Length of the specimen that is illuminated by the radiation
+               source (in millimetres) for instruments where
+               the illumination length varies with 2\q (fixed
+               divergence slits). The _pd_instr_var_illum_len
+               values should be included in the same loop as the
+               intensity measurements (_pd_meas_).
+
+               See _pd_instr_cons_illum_len for instruments where
+               the divergence slit is \q-compensated to yield a
+               constant illumination length.
+;
+
+#............................. Processed Diffractogram
+
+data_pd_proc_[pd]
+    _name                       '_pd_proc_[pd]'
+    _category                     category_overview
+    _type                         null
+    _definition
+;              This section contains the diffraction data set after processing
+               and application of correction terms. If the data set is
+               reprocessed, this section may be replaced (with the addition of
+               a new _pd_block_id entry).
+;
+
+data_pd_proc_2theta_corrected
+    _name                      '_pd_proc_2theta_corrected'
+    _category                    pd_data
+    _type                        numb
+    _list                        yes
+    _units                       deg
+    _units_detail               'degree of arc'
+    _enumeration_range           -180.0:180.0
+    _definition
+;              The 2\q diffraction angle in degrees of an intensity
+               measurement where 2\q is not constant. Used if
+               corrections such as for nonlinearity, zero offset etc.
+               have been applied to the _pd_meas_2theta_ values or if
+               2\q values are computed. If the 2\q values
+               are evenly spaced, _pd_proc_2theta_range_min,
+               _pd_proc_2theta_range_max and _pd_proc_2theta_range_inc
+               may be used to specify the 2\q values.
+;
+
+data_pd_proc_2theta_range_
+    loop_ _name                '_pd_proc_2theta_range_min'
+                               '_pd_proc_2theta_range_max'
+                               '_pd_proc_2theta_range_inc'
+    _category                    pd_proc_info
+    _type                        numb
+    _units                       deg
+    _units_detail               'degree of arc'
+    _enumeration_range           -180.0:180.0
+    _definition
+;              The range of 2\q diffraction angles in degrees for the
+               measurement of intensities. These may be used in place of the
+               _pd_proc_2theta_corrected values, or in the case of white-beam
+               experiments it will define the fixed 2\q value.
+;
+
+data_pd_proc_d_spacing
+    _name                      '_pd_proc_d_spacing'
+    _category                    pd_data
+    _type                        numb
+    _list                        yes
+    _enumeration_range           0.0:
+    _units                       A
+    _units_detail                angstrom
+    _definition
+;              d-spacing corresponding to an intensity point
+               from Bragg's law, d = \l/(2 sin\q), in units of angstroms.
+;
+
+data_pd_proc_energy_
+    loop_ _name                '_pd_proc_energy_incident'
+                               '_pd_proc_energy_detection'
+    _category                    pd_data
+    _type                        numb
+    _list                        both
+    _units                       eV
+    _units_detail                electronvolt
+    _enumeration_range           0.0:
+    _definition
+;              Incident energy in electronvolts of the source computed
+               from secondary calibration information (time-of-flight
+               and synchrotron data).
+               Detection energy in electronvolts selected by the analyser,
+               if not the same as the incident energy (triple-axis or
+               energy-dispersive data). This may be a single value or may
+               vary for each data point (triple-axis and time-of-flight data).
+;
+
+data_pd_proc_info_author_address
+    _name                      '_pd_proc_info_author_address'
+    _category                    pd_proc_info
+    _type                        char
+    _list                        both
+    _list_reference            '_pd_proc_info_author_name'
+    _definition
+;               The address of the person who processed the data.
+                If there is more than one person, this will be looped with
+                _pd_proc_info_author_name.
+;
+
+data_pd_proc_info_author_email
+    _name                      '_pd_proc_info_author_email'
+    _category                    pd_proc_info
+    _type                        char
+    _list                        both
+    _list_reference            '_pd_proc_info_author_name'
+    _definition
+;               The e-mail address of the person who processed the
+                data.  If there is more than one person, this will be looped
+                with _pd_proc_info_author_name.
+;
+
+data_pd_proc_info_author_fax
+    _name                      '_pd_proc_info_author_fax'
+    _category                    pd_proc_info
+    _type                        char
+    _list                        both
+    _list_reference            '_pd_proc_info_author_name'
+    _definition
+;               The fax number of the person who processed the data.
+                If there is more than one person, this will be looped with
+                _pd_proc_info_author_name. The recommended style is
+                the international dialing prefix, followed by the area code in
+                parentheses, followed by the local number with no spaces.
+;
+
+data_pd_proc_info_author_name
+    _name                      '_pd_proc_info_author_name'
+    _category                    pd_proc_info
+    _type                        char
+    _list                        both
+    _definition
+;               The name of the person who processed the data, if different
+                from the person(s) who measured the data set. The family
+                name(s), followed by a comma and including any dynastic
+                components, precedes the first name(s) or initial(s). For
+                more than one person use a loop to specify multiple values.
+;
+
+data_pd_proc_info_author_phone
+    _name                      '_pd_proc_info_author_phone'
+    _category                    pd_proc_info
+    _type                        char
+    _list                        both
+    _list_reference            '_pd_proc_info_author_name'
+    _definition
+;               The telephone number of the person who processed the data.
+                If there is more than one person, this will be looped
+                with _pd_proc_info_author_name. The recommended style is
+                the international dialing prefix, followed by the area code in
+                parentheses, followed by the local number with no spaces.
+;
+
+data_pd_proc_info_data_reduction
+    _name                      '_pd_proc_info_data_reduction'
+    _category                    pd_proc_info
+    _type                        char
+    _definition
+;              Description of the processing steps applied in the data-reduction
+               process (background subtraction, \a-2 stripping, smoothing
+               etc.). Include details of the program(s) used etc.
+;
+
+data_pd_proc_info_datetime
+    _name                      '_pd_proc_info_datetime'
+    _category                    pd_proc_info
+    _type                        char
+    _list                        both
+    _example                     1990-07-13T14:40
+    _definition
+;              Date(s) and time(s) when the data set was processed.
+               May be looped if multiple processing steps were used.
+
+               Dates and times should be specified in the standard CIF
+               format 'yyyy-mm-ddThh:mm:ss+zz'. Use of seconds and a
+               time zone is optional, but use of hours and minutes is
+               strongly encouraged.
+;
+
+data_pd_proc_info_excluded_regions
+    _name                      '_pd_proc_info_excluded_regions'
+    _category                    pd_proc_info
+    _type                        char
+    _example                    '20 to 21 degrees unreliable due to beam dump'
+    _definition
+;              Description of regions in the diffractogram excluded
+               from processing along with a justification of why the
+               data points were not used.
+;
+
+data_pd_proc_info_special_details
+    _name                      '_pd_proc_info_special_details'
+    _category                    pd_proc_info
+    _type                        char
+    _definition
+;              Detailed description of any non-routine processing steps
+               applied due to any irregularities in this particular data set.
+;
+
+data_pd_proc_intensity_
+    loop_ _name                '_pd_proc_intensity_net'
+                               '_pd_proc_intensity_total'
+                               '_pd_proc_intensity_bkg_calc'
+                               '_pd_proc_intensity_bkg_fix'
+                               '_pd_proc_intensity_incident'
+                               '_pd_proc_intensity_norm'
+    _category                    pd_data
+    _type                        numb
+    _type_conditions             esd
+    _list                        yes
+    _enumeration_range           0.0:
+    _definition
+;              _pd_proc_intensity_net contains intensity values for the
+               processed diffractogram for each data point (see
+               _pd_proc_2theta_, _pd_proc_wavelength etc.) after
+               correction and normalization factors have been applied
+               (in contrast to _pd_meas_counts_ values, which are
+               uncorrected).
+
+               _pd_proc_intensity_total contains intensity values for the
+               processed diffractogram for each data point where
+               background, normalization and other corrections have not
+               been applied.
+
+               Inclusion of s.u.'s for these values is strongly recommended.
+
+               _pd_proc_intensity_bkg_calc is intended to contain the
+               background intensity for every data point where the
+               background function has been fitted or estimated (for example, in
+               all Rietveld and profile fits).
+
+               If the background is estimated for a limited number of points
+               and the calculated background is then extrapolated from
+               these fixed points, indicate the background values for
+               these points with _pd_proc_intensity_bkg_fix. Use a value
+               of '.' for data points where a fixed background has not
+               been defined. The extrapolated background at every point
+               may be specified using _pd_proc_intensity_bkg_calc.
+
+               Background values should be on the same scale as the
+               _pd_proc_intensity_net values. Thus normalization and
+               correction factors should be applied before
+               background subtraction (or should be applied to the
+               background values equally).
+
+               If the intensities have been corrected for a variation of the
+               incident intensity as a function of a data-collection
+               variable (examples: source fluctuations in synchrotrons,
+               \q-compensated slits in conventional diffractometers,
+               spectral corrections for white-beam experiments), the
+               correction function should be specified as
+               _pd_proc_intensity_incident. The normalization should be
+               specified in _pd_proc_intensity_incident as a value to be
+               used to divide the measured intensities to obtained the
+               normalized diffractogram. Thus, the
+               _pd_proc_intensity_incident values should increase as the
+               incident flux is increased.
+
+               The other normalization factors applied to the data set (for
+               example, Lp corrections, compensation for variation in
+               counting time) may be specified in _pd_proc_intensity_norm.
+               The function should be specified as the one used to divide the
+               measured intensities.
+;
+
+data_pd_proc_number_of_points
+    _name                      '_pd_proc_number_of_points'
+    _category                    pd_proc_info
+    _type                        numb
+    _enumeration_range           1:
+    _definition
+;              The total number of data points in the processed diffractogram.
+;
+
+data_pd_proc_recip_len_Q
+    _name                      '_pd_proc_recip_len_Q'
+    _category                    pd_data
+    _type                        numb
+    _list                        yes
+    _enumeration_range           0.0:
+    _units                       A^-1^
+    _units_detail               'reciprocal angstrom'
+    _definition
+;              Length in reciprocal space (|Q|= 2\p/d) corresponding to
+               an intensity point. Units are inverse angstroms.
+;
+
+data_pd_proc_wavelength
+    _name                      '_pd_proc_wavelength'
+    _category                    pd_data
+    _type                        numb
+    _list                        both
+    _enumeration_range           0.0:
+    _units                       A
+    _units_detail                angstrom
+    _definition
+;              Wavelength in angstroms for the incident radiation as
+               computed from secondary calibration information. This will
+               be most appropriate for time-of-flight and synchrotron
+               measurements. This will be a single value for
+               continuous-wavelength methods or may vary for each data point
+               and be looped with the intensity values for energy-dispersive
+               measurements.
+;
+
+#......................... Least-squares (Profile/Rietveld fit) parameters
+
+data_pd_proc_ls_[pd]
+    _name                       '_pd_proc_ls_[pd]'
+    _category                     category_overview
+    _type                         null
+
+    _definition
+;              This section is used to define parameters relevant to a
+               least-squares fit to a powder diffractogram, using a Rietveld
+               or other full-profile (e.g. Pawley or Le Bail methods) fit.
+
+               Note that values in this section refer to full-pattern fitting.
+               Use the appropriate items for single-crystal analyses from the
+               core CIF dictionary for structure refinements using diffraction
+               intensities estimated from a powder diffractogram by
+               pattern-decomposition methods. Also note that many entries in
+               the core _refine_ls_ entries may also be useful (for example
+               _refine_ls_shift/su_*).
+;
+
+data_pd_proc_ls_background_function
+    _name                      '_pd_proc_ls_background_function'
+    _category                    pd_proc_ls
+    _type                        char
+    _definition
+;              Description of the background treatment mechanism used to
+               fit the data set.
+
+               For refinements where the background is computed as a
+               function that is fitted to minimize the difference between
+               the observed and calculated patterns, it is
+               recommended that in addition to a description of the
+               function (e.g. Chebychev polynomial), the actual equation(s)
+               used are included in TeX, or a programming language such
+               as Fortran or C. Include also the values used for the
+               coefficients used in the background function with their
+               s.u.'s. The background values for each data point
+               computed from the function should be specified in
+               _pd_proc_intensity_bkg_calc.
+
+               If background correction is performed using extrapolation
+               from a set of points at fixed locations, these points
+               should be defined using _pd_proc_intensity_bkg_fix, and
+               _pd_proc_ls_background_function should indicate the
+               extrapolation method (linear extrapolation, spline etc.).
+               _pd_proc_ls_background_function should also indicate how the
+               points were determined (automatically, by visual estimation
+               etc.) and whether the values were refined to improve the
+               agreement. The extrapolated background intensity value for
+               each data point should be specified in
+               _pd_proc_intensity_bkg_calc.
+;
+
+data_pd_proc_ls_peak_cutoff
+    _name                      '_pd_proc_ls_peak_cutoff'
+    _category                    pd_proc_ls
+    _type                        numb
+    _definition
+;              Describes where peak-intensity computation is
+               discontinued as a fraction of the intensity of the
+               peak at maximum. Thus for a value of 0.005, the
+               tails of a diffraction peak are neglected
+               after the intensity has dropped below 0.5% of the
+               diffraction intensity at the maximum.
+;
+
+data_pd_proc_ls_pref_orient_corr
+    _name                      '_pd_proc_ls_pref_orient_corr'
+    _category                    pd_proc_ls
+    _type                        char
+    _definition
+;              Description of the preferred-orientation correction if
+               such a correction is used. Omitting this entry
+               implies that no preferred-orientation correction
+               has been used. If a function form is used, it is
+               recommended that the actual equation in TeX, or a
+               programming language, is used to specify the function as
+               well as a giving a description. Include the value(s) used
+               for the correction with s.u.'s.
+;
+
+data_pd_proc_ls_prof_
+    loop_ _name                 '_pd_proc_ls_prof_R_factor'
+                                '_pd_proc_ls_prof_wR_factor'
+                                '_pd_proc_ls_prof_wR_expected'
+    _category                    pd_proc_ls
+    _type                        numb
+    _enumeration_range           0.0:
+    _definition
+;              Rietveld/profile fit R factors.
+
+               Note that the R factor computed for Rietveld refinements
+               using the extracted reflection intensity values (often
+               called the Rietveld or Bragg R factor, R~B~) is not properly
+               a profile R factor. This R factor may be specified using
+               _refine_ls_R_I_factor. (Some authors report
+               _refine_ls_R_Fsqd_factor or _refine_ls_R_factor_all
+               as the Rietveld or Bragg R factor. While it is appropriate
+               to compute and report any or all of these R factors,
+               the names "Rietveld or Bragg R factor" refer strictly to
+               _refine_ls_R_I_factor.)
+
+              _pd_proc_ls_prof_R_factor, often called R~p~, is an
+                unweighted fitness metric for the agreement between the
+                observed and computed diffraction patterns.
+                   R~p~ = sum~i~ | I~obs~(i) - I~calc~(i) |
+                          / sum~i~ ( I~obs~(i) )
+              _pd_proc_ls_prof_wR_factor, often called R~wp~, is a
+                weighted fitness metric for the agreement between the
+                observed and computed diffraction patterns.
+                  R~wp~ = SQRT {
+                           sum~i~ ( w(i) [ I~obs~(i) - I~calc~(i) ]^2^ )
+                           / sum~i~ ( w(i) [I~obs~(i)]^2^ ) }
+
+              _pd_proc_ls_prof_wR_expected, sometimes called the
+                theoretical R~wp~ or R~exp~, is a weighted fitness metric for
+                the statistical precision of the data set. For an idealized fit,
+                where all deviations between the observed intensities and
+                those computed from the model are due to statistical
+                fluctuations, the observed R~wp~ should match the expected
+                R factor. In reality, R~wp~ will always be higher than
+                R~exp~.
+                  R~exp~ = SQRT {
+                                 (n - p)  / sum~i~ ( w(i) [I~obs~(i)]^2^ ) }
+
+                Note that in the above equations,
+                   w(i) is the weight for the ith data point (see
+                        _pd_proc_ls_weight).
+                   I~obs~(i) is the observed intensity for the ith data
+                        point, sometimes referred to as y~i~(obs) or
+                        y~oi~. (See _pd_meas_counts_total,
+                        _pd_meas_intensity_total or _pd_proc_intensity_total.)
+                   I~calc~(i) is the computed intensity for the ith data
+                        point with background and other corrections
+                        applied to match the scale of the observed data set,
+                        sometimes referred to as y~i~(calc) or
+                        y~ci~. (See _pd_calc_intensity_total.)
+                   n is the total number of data points (see
+                        _pd_proc_number_of_points) less the number of
+                        data points excluded from the refinement.
+                   p is the total number of refined parameters.
+;
+
+data_pd_proc_ls_profile_function
+    _name                      '_pd_proc_ls_profile_function'
+    _category                    pd_proc_ls
+    _type                        char
+    _definition
+;              Description of the profile function used to
+               fit the data set. If a function form is used, it is
+               recommended that the actual equation in TeX, or a
+               programming language, is used to specify the function as
+               well as giving a description. Include the values used
+               for the profile-function coefficients and their s.u.'s.
+;
+
+data_pd_proc_ls_special_details
+    _name                      '_pd_proc_ls_special_details'
+    _category                    pd_proc_ls
+    _type                        char
+    _definition
+;              Additional characterization information relevant to
+               non-routine steps used for refinement of a structural model
+               that cannot be specified elsewhere.
+;
+
+data_pd_proc_ls_weight
+    _name                      '_pd_proc_ls_weight'
+    _category                    pd_data
+    _type                        numb
+    _list                        yes
+    _enumeration_range           0:
+    _definition
+;              Weight applied to each profile point. These values
+               may be omitted if the weights are 1/u^2^, where
+               u is the s.u. for the _pd_proc_intensity_net values.
+
+               A weight value of zero is used to indicate a data
+               point not used for refinement (see
+               _pd_proc_info_excluded_regions).
+;
+
+#............................. Calculated Diffractogram
+
+data_pd_calc_[pd]
+    _name                       '_pd_calc_[pd]'
+    _category                     category_overview
+    _type                         null
+
+    _definition
+;              This section is used for storing a computed diffractogram trace.
+               This may be a simulated powder pattern for a material from a
+               program such as LAZY/PULVERIX or the computed intensities from a
+               Rietveld refinement.
+;
+
+
+data_pd_calc_intensity_
+    loop_ _name                 '_pd_calc_intensity_net'
+                                '_pd_calc_intensity_total'
+    _category                    pd_data
+    _type                        numb
+    _list                        yes
+    _enumeration_range           0.0:
+    _definition
+;              Intensity values for a computed diffractogram at
+               each angle setting. Values should be computed at the
+               same locations as the processed diffractogram, and thus
+               the numbers of points will be defined by
+               _pd_proc_number_of_points and point positions may
+               be defined using _pd_proc_2theta_range_ or
+               _pd_proc_2theta_corrected.
+
+               Use _pd_calc_intensity_net if the computed diffractogram
+               does not contain background or normalization corrections
+               and thus is specified on the same scale as the
+               _pd_proc_intensity_net values.
+
+               Use _pd_calc_intensity_total if the computed diffraction
+               pattern includes background or normalization corrections
+               (or both) and thus is specified on the same scale as the
+               observed intensities (_pd_meas_counts_ or _pd_meas_intensity_).
+
+               If an observed pattern is included, _pd_calc_intensity_
+               should be looped with either _pd_proc_intensity_net,
+               _pd_meas_counts_ or _pd_meas_intensity_.
+;
+
+data_pd_calc_method
+    _name                      '_pd_calc_method'
+    _category                    pd_calc
+    _type                        char
+    _definition
+;              A description of the method used for the calculation of
+               the intensities in _pd_calc_intensity_. If the pattern was
+               calculated from crystal structure data, the atom coordinates
+               and other crystallographic information should be included
+               using the core CIF _atom_site_ and _cell_ data items.
+;
+
+
+#......................... Peak Table
+
+data_pd_peak_[pd]
+    _name                       '_pd_peak_[pd]'
+    _category                     category_overview
+    _type                         null
+    _definition
+;              This section contains peak information extracted from the
+               measured or, if present, the processed diffractogram. Each
+               peak in this table will have a unique label (see _pd_peak_id).
+               The reflections and phases associated with each peak will be
+               specified in other sections (see the _pd_refln_ and
+               _pd_phase_ sections).
+
+               Note that peak positions are customarily determined from the
+               processed diffractogram and thus corrections for position
+               and intensity will have been previously applied.
+;
+
+data_pd_peak_2theta_
+    loop_ _name                  '_pd_peak_2theta_centroid'
+                                 '_pd_peak_2theta_maximum'
+    _category                    pd_peak
+    _type                        numb
+    _type_conditions             esd
+    _list                        yes
+    _list_reference            '_pd_peak_id'
+    _units                       deg
+    _units_detail               'degree of arc'
+    _enumeration_range           0.0:180.0
+    _definition
+;              Position of the centroid and maximum of a peak as a
+               2\q angle in degrees.
+;
+
+data_pd_peak_d_spacing
+    _name                      '_pd_peak_d_spacing'
+    _category                    pd_peak
+    _type                        numb
+    _type_conditions             esd
+    _list                        yes
+    _list_reference            '_pd_peak_id'
+    _enumeration_range           0.0:
+    _units                       A
+    _units_detail                angstrom
+    _definition
+;              Peak position as a d-spacing in angstroms.
+;
+
+data_pd_peak_id
+    _name                      '_pd_peak_id'
+    _category                    pd_peak
+    _type                        char
+    _list                        yes
+    _list_mandatory              yes
+    _list_uniqueness           '_pd_peak_id'
+    _list_link_child           '_pd_refln_peak_id'
+    _definition
+;              An arbitrary code is assigned to each peak. Used to link with
+               _pd_refln_peak_id so that multiple hkl and/or phase
+               identifications can be assigned to a single peak.
+               Each peak will have a unique code. In cases
+               where two peaks are severely overlapped, it may be
+               desirable to list them as a single peak.
+
+               A peak ID must be included for every peak.
+;
+
+data_pd_peak_intensity
+    _name                      '_pd_peak_intensity'
+    _category                    pd_peak
+    _type                        numb
+    _type_conditions             esd
+    _list                        yes
+    _list_reference            '_pd_peak_id'
+    _enumeration_range           0.0:
+    _definition
+;              Integrated area for the peak, with the same scaling as
+               the _pd_proc_intensity_ values. It is good practice to
+               include s.u.'s for these values.
+;
+
+data_pd_peak_pk_height
+    _name                      '_pd_peak_pk_height'
+    _category                    pd_peak
+    _type                        numb
+    _type_conditions             esd
+    _list                        yes
+    _list_reference            '_pd_peak_id'
+    _enumeration_range           0.0:
+    _definition
+;              The maximum intensity of the peak, either extrapolated
+               or the highest observed intensity value. The same
+               scaling is used for the _pd_proc_intensity_ values.
+               It is good practice to include s.u.'s for these values.
+;
+
+data_pd_peak_special_details
+    _name                      '_pd_peak_special_details'
+    _category                    pd_peak_method
+    _type                        char
+    _definition
+;              Detailed description of any non-routine processing steps
+               used for peak determination or other comments
+               related to the peak table that cannot be given elsewhere.
+;
+
+data_pd_peak_wavelength_id
+    _name                      '_pd_peak_wavelength_id'
+    _category                    pd_peak
+    _type                        char
+    _list                        yes
+    _list_reference            '_pd_peak_id'
+    _list_link_parent          '_diffrn_radiation_wavelength_id'
+    _definition
+;              Code identifying the wavelength appropriate for this peak
+               from the wavelengths in the _diffrn_radiation_ list.
+               (See _diffrn_radiation_wavelength_id.) Most commonly used
+               to distinguish K\a~1~ peaks from K\a~2~ or to designate
+               where K\a~1~ and K\a~2~ peaks cannot be resolved. For
+               complex peak tables with multiple superimposed peaks,
+               specify wavelengths in the reflection table using
+               _pd_refln_wavelength_id rather than identifying peaks by
+               wavelength.
+;
+
+data_pd_peak_width_2theta
+    _name                      '_pd_peak_width_2theta'
+    _category                    pd_peak
+    _type                        numb
+    _type_conditions             esd
+    _list                        yes
+    _list_reference            '_pd_peak_id'
+    _enumeration_range           0.0:180.0
+    _units                       deg
+    _units_detail               'degree of arc'
+    _definition
+;              Peak width as full-width at half-maximum expressed as
+               a 2\q value in degrees.
+;
+
+data_pd_peak_width_d_spacing
+    _name                      '_pd_peak_width_d_spacing'
+    _category                    pd_peak
+    _type                        numb
+    _type_conditions             esd
+    _list                        yes
+    _list_reference            '_pd_peak_id'
+    _enumeration_range           0.0:
+    _units                       A
+    _units_detail                angstrom
+    _definition
+;              Peak width as full-width at half-maximum expressed as
+               a d-spacing in angstroms.
+;
+
+#............................ Crystalline Phase Assignments
+
+data_pd_phase_[pd]
+    _name                       '_pd_phase_[pd]'
+    _category                     category_overview
+    _type                         null
+
+    _definition
+;              This section contains a description of the crystalline phases
+               contributing to the powder diffraction data set. Note that if
+               multiple-phase Rietveld or other structural analysis is
+               performed, the structural results will be placed in different
+               data blocks, using CIF entries from the core CIF dictionary.
+
+               The _pd_phase_block_id entry points to the CIF block with
+               structural parameters for each crystalline phase. The
+               _pd_phase_id serves to link to _pd_refln_phase_id, which is
+               used to label peaks by phase.
+;
+
+data_pd_phase_block_id
+    _name                      '_pd_phase_block_id'
+    _category                    pd_phase
+    _type                        char
+    _list                        yes
+    _list_reference            '_pd_phase_id'
+    _definition
+;              A block ID code identifying the phase contributing to
+               the diffraction peak. The data block containing the
+               crystallographic information for this phase will be
+               identified with a _pd_block_id code matching the
+               code in _pd_phase_block_id.
+;
+
+data_pd_phase_id
+    _name                      '_pd_phase_id'
+    _category                    pd_phase
+    _type                        char
+    _list                        yes
+    _list_mandatory              yes
+    _list_link_child           '_pd_refln_phase_id'
+    _list_uniqueness           '_pd_phase_id'
+    _definition
+;              A code for each crystal phase used to link with
+               _pd_refln_phase_id.
+;
+
+data_pd_phase_mass_%
+    _name                      '_pd_phase_mass_%'
+    _category                    pd_phase
+    _type                        numb
+    _type_conditions             esd
+    _list                        yes
+    _list_reference            '_pd_phase_id'
+    _enumeration_range           0.0:100.0
+    _definition
+;              Per cent composition of the specified crystal phase
+               expressed as the total mass of the component
+               with respect to the total mass of the specimen.
+;
+
+data_pd_phase_name
+    _name                      '_pd_phase_name'
+    _category                    pd_phase
+    _type                        char
+    _list                        both
+    _list_reference            '_pd_phase_id'
+    _definition
+;              The name of the crystal phase identified by _pd_phase_id.
+               It may be designated as unknown or by a structure type etc.
+;
+
+#............................ Peak Reflection Identification
+
+data_pd_refln_[pd]
+    _name                       '_pd_refln_[pd]'
+    _category                     category_overview
+    _type                         null
+    _definition
+;              This section provides a mechanism to identify each peak in the
+               peak-table section (_pd_peak_) with the phase(s) (_pd_phase_id)
+               and the reflection indices (_refln_index_) associated with the
+               peak.  There are no restrictions on the number of phases or
+               reflections associated with an observed peak. Reflections may
+               also be included that are not observed; use '.' for the
+               _pd_refln_peak_id.
+;
+
+data_pd_refln_peak_id
+    _name                      '_pd_refln_peak_id'
+    _category                    refln
+    _type                        char
+    _list                        yes
+    loop_ _list_reference      '_refln_index_h'
+                               '_refln_index_k'
+                               '_refln_index_l'
+    _list_link_parent          '_pd_peak_id'
+    _definition
+;              Code which identifies the powder diffraction peak that
+               contains the current reflection. This code must match a
+               _pd_peak_id code.
+;
+
+data_pd_refln_phase_id
+    _name                      '_pd_refln_phase_id'
+    _category                    refln
+    _type                        char
+    _list                        yes
+    loop_ _list_reference      '_refln_index_h'
+                               '_refln_index_k'
+                               '_refln_index_l'
+    _list_link_parent          '_pd_phase_id'
+    _definition
+;              Code which identifies the crystal phase associated with this
+               reflection. This code must match a _pd_phase_id code.
+;
+
+data_pd_refln_wavelength_id
+    _name                      '_pd_refln_wavelength_id'
+    _category                    refln
+    _type                        char
+    _list                        yes
+    loop_ _list_reference      '_refln_index_h'
+                               '_refln_index_k'
+                               '_refln_index_l'
+    _list_link_parent          '_diffrn_radiation_wavelength_id'
+    _definition
+;              Code which identifies the wavelength associated with the
+               reflection and the peak pointed to by _pd_refln_peak_id.
+               This code must match a _diffrn_radiation_wavelength_id code.
+;
+
+#............................. Sample Preparation Information
+
+data_pd_prep_[pd]
+    _name                       '_pd_prep_[pd]'
+    _category                     category_overview
+    _type                         null
+    _definition
+;              This section contains descriptive information about how the
+               sample was prepared.
+;
+
+data_pd_prep_conditions
+    _name                      '_pd_prep_conditions'
+    _category                    pd_prep
+    _type                        char
+    _definition
+;              A description of how the material was prepared
+               (reaction conditions etc.)
+;
+
+data_pd_prep_cool_rate
+    _name                      '_pd_prep_cool_rate'
+    _category                    pd_prep
+    _type                        numb
+    _type_conditions             esd
+    _enumeration_range           0.0:
+    _units                       K/min
+    _units_detail               'kelvin per minute'
+    _definition
+;              Cooling rate in kelvins per minute for samples prepared
+               at high temperatures. If the cooling rate is not linear
+               or is unknown (e.g. quenched samples), it should be
+               described in _pd_prep_conditions instead.
+;
+
+data_pd_prep_pressure
+    _name                      '_pd_prep_pressure'
+    _category                    pd_prep
+    _type                        numb
+    _type_conditions             esd
+    _enumeration_range           0.0:
+    _units                       kPa
+    _units_detail                kilopascal
+    _definition
+;              Preparation pressure of the sample in kilopascals. This
+               is particularly important for materials which are metastable
+               at the measurement pressure, _diffrn_ambient_pressure.
+;
+
+data_pd_prep_temperature
+    _name                      '_pd_prep_temperature'
+    _category                    pd_prep
+    _type                        numb
+    _type_conditions             esd
+    _enumeration_range           0.0:
+    _units                       K
+    _units_detail                kelvin
+    _definition
+;              Preparation temperature of the sample in kelvins. This is
+               particularly important for materials which are metastable
+               at the measurement temperature, _diffrn_ambient_temperature.
+;
+
+#............................. Characterisation Information
+
+data_pd_char_[pd]
+    _name                       '_pd_char_[pd]'
+    _category                     category_overview
+    _type                         null
+    _definition
+;   This section contains experimental (non-diffraction) information
+    relevant to the chemical and physical nature of the material.
+;
+
+data_pd_char_atten_coef_mu_
+    loop_ _name                '_pd_char_atten_coef_mu_obs'
+                               '_pd_char_atten_coef_mu_calc'
+    _category                    pd_char
+    _type                        numb
+    _enumeration_range           0.0:
+    _units                       mm^-1^
+    _units_detail                'reciprocal millimetre'
+    _definition
+;              The observed and calculated linear attenuation coefficient,
+               \m, in units of inverse millimetres. Note that this quantity
+               is sometimes referred to as the mass absorption coefficient;
+               however, this term accounts for other potentially significant
+               losses of incident radiation, for example incoherent
+               scattering of neutrons.
+
+               The calculated \m will be obtained from the atomic content of
+               the cell, the average density (allowing for specimen packing)
+               and the radiation wavelength. The observed \m will be
+               determined by a transmission measurement.
+               Note that _pd_char_atten_coef_mu_calc will differ from
+               _exptl_absorpt_coefficient_mu if the packing density is
+               not unity.
+;
+
+data_pd_char_colour
+    _name                      '_pd_char_colour'
+    _category                    pd_char
+    _type                        char
+    loop_ _example               dark_green
+                                 orange_red
+                                 brownish_red
+                                 yellow_metallic
+    _definition
+;              The colour of the material used for the measurement.
+               To facilitate more standardized use of names, the
+               following guidelines for colour naming developed by
+               Peter Bayliss for the International Centre for
+               Diffraction Data (ICDD) should be followed. Note that
+               combinations of descriptors are separated by an
+               underscore.
+
+               Allowed colours are:
+                 colourless, white, black, gray, brown, red, pink,
+                 orange, yellow, green, blue, violet.
+
+               Colours may be modified using prefixes of:
+                 light, dark, whitish, blackish, grayish, brownish,
+                 reddish, pinkish, orangish, yellowish, greenish, bluish.
+
+               Intermediate hues may be indicated with two colours:
+               e.g. blue_green or bluish_green.
+
+               For metallic materials, the term metallic may be added:
+               e.g. reddish_orange_metallic for copper.
+
+               The ICDD standard allows commas to be used for minerals
+               that occur with ranges of colours; however this usage is
+               not appropriate for the description of a single sample.
+;
+
+data_pd_char_particle_morphology
+    _name                      '_pd_char_particle_morphology'
+    _category                    pd_char
+    _type                        char
+    _definition
+;              A description of the sample morphology and estimates for
+               particle sizes (before grinding/sieving, if noted by
+               _pd_spec_preparation). Include the method used for
+               these estimates (SEM, visual estimate etc.).
+;
+
+data_pd_char_special_details
+    _name                      '_pd_char_special_details'
+    _category                    pd_char
+    _type                        char
+    _definition
+;              Additional characterization information relevant to the sample
+               or documentation of non-routine processing steps used
+               for characterization.
+;
+
+#............................. Data Tabulation and Book-keeping Across Tables
+
+data_pd_data_[pd]
+    _name                       '_pd_data_[pd]'
+    _category                     category_overview
+    _type                         null
+    loop_ _example
+          _example_detail
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+;
+    loop_
+      _pd_data_point_id
+      _pd_meas_intensity_total
+      _pd_proc_ls_weight
+      _pd_proc_intensity_bkg_calc
+      _pd_calc_intensity_total
+    1    240(15)       0.00417     214.5   214.5
+    2    219(15)       0.00457     214.3   214.2
+    3    206(14)       0.00485     214.0   214.0
+    4    212(15)       0.00472     213.8   213.7
+    5    190(14)       0.00526     213.5   213.5
+    6    203(14)       0.00493     213.2   213.2
+     # - - - - data truncated for brevity - - - -
+;
+;   Example 1 - data set collected for a two-phase sample (Al~2~O~3~/Si)
+                by B. H. Toby, '1997-01-29T16:37|POWSET_01|B.Toby|..NIST-D5000'.
+;
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+;
+     loop_
+      _pd_meas_point_id
+      _pd_meas_intensity_total
+    1  240(15) 2  219(15) 3  206(14) 4  212(15) 5  190(14) 6  203(14)
+
+     loop_
+      _pd_proc_point_id
+      _pd_proc_ls_weight
+      _pd_proc_intensity_bkg_calc
+    1  0.00417  214.5      2  0.00457  214.3
+    3  0.00485  214.0      4  0.00472  213.8
+    5  0.00526  213.5      6  0.00493  213.2
+
+     loop_
+      _pd_calc_point_id
+      _pd_calc_intensity_total
+    1   214.5 2   214.2 3   214.0 4   213.7 5   213.5 6   213.2
+
+;
+;   Example 2 - the data of Example 1 split into three separate tables.
+;
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+;
+   loop_
+     _pd_meas_point_id
+     _pd_meas_2theta_scan
+     _pd_meas_intensity_total
+            1  21.0   24
+            2  21.2   32
+            3  21.4   67
+            4  21.6   98
+
+   loop_
+     _pd_calc_point_id
+     _pd_proc_2theta_corrected
+     _pd_calc_intensity_total
+            1   21.0  26
+            1a  21.3  56
+            4   21.6  76
+            4a  21.9  90
+
+;
+;   Example 3 - hypothetical example where the measured and calculated
+                points are not in one-to-one correspondence.
+;
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+    _definition
+;              The PD_DATA category contains raw, processed and calculated
+               data points in a diffraction data set. In many cases, it is
+               convenient to tabulate calculated values against the
+               raw and processed measurements, and so the various
+               _pd_meas_, _pd_proc_ and _pd_calc_ data items belonging
+               to this category may be looped together. In some instances,
+               however, it makes more sense to maintain separate tables of
+               the data contributing to the measured and processed
+               diffractograms (for example, a profile may be calculated
+               at 2theta values different from those of the measured
+               data points). To facilitate the identification of equivalent
+               points in these separate tables, separate identifiers are
+               defined.
+;
+
+data_pd_calc_point_id
+    _name                      '_pd_calc_point_id'
+    _category                    pd_data
+    _type                        char
+    loop_ _related_item
+          _related_function    '_pd_data_point_id'  alternate
+    _definition
+;              Arbitrary label identifying a calculated data point. Used to
+               identify a specific entry in a list of values forming the
+               calculated diffractogram. The role of this identifier may
+               be adopted by _pd_data_point_id if measured, processed and
+               calculated intensity values are combined in a single list.
+;
+
+data_pd_data_point_id
+    _name                      '_pd_data_point_id'
+    _category                    pd_data
+    _type                        char
+    _definition
+;              Arbitrary label identifying an entry in the table of
+               diffractogram intensity values.
+;
+
+data_pd_meas_point_id
+    _name                      '_pd_meas_point_id'
+    _category                    pd_data
+    _type                        char
+    loop_ _related_item
+          _related_function    '_pd_data_point_id'  alternate
+    _definition
+;              Arbitrary label identifying a measured data point. Used to
+               identify a specific entry in a list of measured intensities.
+               The role of this identifier may be adopted by
+               _pd_data_point_id if measured, processed and calculated
+               intensity values are combined in a single list.
+;
+
+data_pd_proc_point_id
+    _name                      '_pd_proc_point_id'
+    _category                    pd_data
+    _type                        char
+    loop_ _related_item
+          _related_function
+                               '_pd_data_point_id'            alternate
+                               '_pd_meas_point_id'            alternate
+    _definition
+;              Arbitrary label identifying a processed data point. Used to
+               identify a specific entry in a list of processed intensities.
+               The role of this identifier may be adopted by
+               _pd_data_point_id if measured, processed and calculated
+               intensity values are combined in a single list, or by
+               _pd_meas_point_id if measured and processed lists are
+               combined.
+;
+
+#eof-eof-eof-eof-eof-eof-eof-eof-eof-eof-eof-eof-eof-eof-eof-eof-eof-eof-eof

--- a/dictionaries/cif_pow.dic
+++ b/dictionaries/cif_pow.dic
@@ -1,0 +1,12479 @@
+#\#CIF_2.0
+##############################################################################
+#                                                                            #
+#                        Powder CIF Dictionary                               #
+#                                                                            #
+#  CIF data definitions specifically for powder diffraction applications.    #
+#                                                                            #
+#               Converted from DDL1 to DDLm 26 June 2014                     #
+#                                                                            #
+##############################################################################
+
+data_CIF_POW
+
+    _dictionary.title             CIF_POW
+    _dictionary.class             Instance
+    _dictionary.version           2.5.0
+    _dictionary.date              2025-04-18
+    _dictionary.uri
+https://raw.githubusercontent.com/COMCIFS/Powder_Dictionary/master/cif_pow.dic
+    _dictionary.ddl_conformance   3.11.10
+    _dictionary.namespace         CifPow
+    _description.text
+;
+    The CIF_POW dictionary records the definitions of data items needed in
+    powder diffraction studies. Note that unlike most IUCr CIF
+    dictionaries, the data name is not always constructed as
+    <category>.<object>.
+;
+
+save_PD_GROUP
+
+    _definition.id                PD_GROUP
+    _definition.scope             Category
+    _definition.class             Head
+    _definition.update            2024-12-13
+    _description.text
+;
+    Groups all of the categories of definitions in the powder
+    diffraction study of materials.
+;
+    _name.category_id             CIF_POW
+    _name.object_id               PD_GROUP
+
+    _import.get
+        [
+          {
+           'dupl':Ignore  'file':multi_block_core.dic  'mode':Full
+           'save':MULTIBLOCK_CORE
+          }
+        ]
+
+save_
+
+save_PD_AMORPHOUS
+
+    _definition.id                PD_AMORPHOUS
+    _definition.scope             Category
+    _definition.class             Loop
+    _definition.update            2023-01-08
+    _description.text
+;
+    This section contains information about peaks in an amorphous phase
+    extracted from the measured or, if present, the processed diffractogram.
+    Each peak in this table will have a unique label
+    (see _pd_amorphous.peak_id).
+
+    See PD_PEAK for details on the specific peak parameters that may be
+    recorded. Each amorphous peak may or may not be associated with an indexed
+    reflection, and as such, an "amorphous" phase could represent a material
+    with an unknown crystal structure. Amorphous peaks do not correspond to
+    background, and should not be used as such.
+
+    Note that peak positions are customarily determined from the processed
+    diffractogram, and thus corrections for position and intensity will have
+    been previously applied.
+;
+    _name.category_id             PD_GROUP
+    _name.object_id               PD_AMORPHOUS
+
+    loop_
+      _category_key.name
+         '_pd_amorphous.peak_id'
+         '_pd_amorphous.phase_id'
+
+save_
+
+save_pd_amorphous.peak_id
+
+    _definition.id                '_pd_amorphous.peak_id'
+    _definition.update            2023-01-08
+    _description.text
+;
+    An arbitrary code is assigned to each peak in an amorphous phase.
+
+    Used to link with _pd_peak.id. Each peak will have a unique code. In cases
+    where two peaks are severely overlapped, it may be desirable to list them as
+    a single peak.
+
+    A peak ID must be included for every amorphous peak.
+;
+    _name.category_id             pd_amorphous
+    _name.object_id               peak_id
+    _name.linked_item_id          '_pd_peak.id'
+    _type.purpose                 Link
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Code
+
+save_
+
+save_pd_amorphous.peak_overall_id
+
+    _definition.id                '_pd_amorphous.peak_overall_id'
+    _definition.update            2023-04-13
+    _description.text
+;
+    A code linking to general information about peak description and
+    determination for the amorphous phase peaks.
+;
+    _name.category_id             pd_amorphous
+    _name.object_id               peak_overall_id
+    _name.linked_item_id          '_pd_peak_overall.id'
+    _type.purpose                 Link
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Code
+
+save_
+
+save_pd_amorphous.phase_id
+
+    _definition.id                '_pd_amorphous.phase_id'
+    _definition.update            2023-01-08
+    _description.text
+;
+    The phase (see _pd_phase.id) to which the amorphous peak relates.
+;
+    _name.category_id             pd_amorphous
+    _name.object_id               phase_id
+    _name.linked_item_id          '_pd_phase.id'
+    _type.purpose                 Link
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_PD_BACKGROUND
+
+    _definition.id                PD_BACKGROUND
+    _definition.scope             Category
+    _definition.class             Loop
+    _definition.update            2023-01-09
+    _description.text
+;
+    This category defines various background functions that could be used when
+    calculating diffractograms.
+
+    The data items list here allow for the recording of the various coefficients
+    used, rather than a complete enumeration of the value of the background
+    calculated at every data point; although doing so is still possible - see
+    _pd_proc.intensity_bkg_calc.
+
+    The computed background values should include all normalization corrections,
+    and thus are specified on the same scale as the observed intensities
+    (_pd_meas.counts_* or _pd_meas.intensity_*, and _pd_calc.intensity_total).
+
+    If more than one type of background is specified for a particular
+    diffractogram, then it is assumed they are linearly additive.
+;
+    _name.category_id             PD_GROUP
+    _name.object_id               PD_BACKGROUND
+
+    loop_
+      _category_key.name
+         '_pd_background.diffractogram_id'
+         '_pd_background.id'
+
+    loop_
+      _description_example.case
+      _description_example.detail
+;
+         _pd_diffractogram.id   A_DIFFRACTION_PATTERN
+         loop_
+         _pd_background.id
+         _pd_background.air_or_thermal_diffuse_order
+         _pd_background.air_or_thermal_diffuse_coef_1
+         _pd_background.air_or_thermal_diffuse_coef_2
+         1   0   1.5       0
+         2   1   0.0747    0.954
+         3   2   0.00132   0.912
+;
+;
+         Corresponds to a 2nd order thermal diffuse scattering background
+         equation:
+
+         bkg = (1.5) +
+               (0.0747*q^2^ + 0.954/q^2^) +
+               (0.0132*(q^4^/2) + 0.912*(2/q^4^))
+;
+;
+         _pd_diffractogram.id   A_DIFFRACTION_PATTERN
+         loop_
+         _pd_background.id
+         _pd_background.air_or_thermal_diffuse_coefs_1
+         _pd_background.air_or_thermal_diffuse_coefs_2
+         1   [1.5 0.0747 0.00132]   [0   0.954  0.912]
+;
+;
+         Corresponds to a 2nd order thermal diffuse scattering background
+         equation:
+
+         bkg = (1.5) +
+               (0.0747*q^2^ + 0.954/q^2^) +
+               (0.0132*(q^4^/2) + 0.912*(2/q^4^))
+;
+;
+         _pd_diffractogram.id   A_DIFFRACTION_PATTERN
+         loop_
+         _pd_background.id
+         _pd_background.Chebyshev_order
+         _pd_background.Chebyshev_coef
+         _pd_background.Chebyshev_coef_su
+         _pd_background.X_coordinate
+         1   0     4.219   1.30   time-of-flight
+         2   1    25.114   1.62   time-of-flight
+         3   2   -10.012   1.02   time-of-flight
+         4   3     6.720   0.66   time-of-flight
+;
+;
+         Corresponds to a 3rd order Chebyshev polynomial with the zeroth
+         through third order coefficients having the values 4.219, 25.114,
+         -10.012, and 6.720. Each value has a standard uncertainty of 1.30,
+         1.62, 1.02, and 0.66, respectively.
+
+         The X-coordinate against which the background function is calculated
+         is time-of-flight in microseconds.
+;
+;
+         _pd_diffractogram.id   A_DIFFRACTION_PATTERN
+         loop_
+         _pd_background.id
+         _pd_background.Chebyshev_coefs
+         _pd_background.Chebyshev_coefs_su
+         1   [4.219 25.114 -10.012 6.720]   [1.30 1.62 1.02 0.66]
+;
+;
+         Corresponds to a 3rd order Chebyshev polynomial with the zeroth
+         through third order coefficients having the values 4.219, 25.114,
+         -10.012, and 6.720. Each value has a standard uncertainty of 1.30,
+         1.62, 1.02, and 0.66, respectively.
+;
+;
+         _pd_diffractogram.id   A_DIFFRACTION_PATTERN
+         loop_
+         _pd_background.id
+         _pd_background.line_segment_X
+         _pd_background.line_segment_intensity
+         _pd_background.X_coordinate
+         1    5.0   150.7   2theta_corrected
+         2   10.0    74.3   2theta_corrected
+         3   20.0    36.5   2theta_corrected
+         4   40.0    33.2   2theta_corrected
+         5   80.0    24.5   2theta_corrected
+         6  147.0    35.6   2theta_corrected
+;
+;
+         Corresponds to a 5 line-segment background, fixed at the six X,Y
+         coordinate pairs given. Values of the background for any given x are
+         found by linearly interpolating between the nearest X values given in
+         the above loop.
+
+         The X-coordinate against which the background function is calculated
+         is corrected 2θ in degrees.
+;
+;
+         _pd_diffractogram.id   A_DIFFRACTION_PATTERN
+         loop_
+         _pd_background.id
+         _pd_background.Chebyshev_coefs
+         _pd_background.polynomial_coefs
+         _pd_background.polynomial_powers
+         _pd_background.X_coordinate
+         1
+         [4.219 25.114 -10.012 6.720]
+         [1049.69  5016.63]   [-1 -2]
+         2theta
+;
+;
+         Corresponds to the linear combination of a 3rd order Chebyshev
+         polynomial with a standard polynomial background.
+
+         The Chebyshev polynomial coefficients are 4.219, 25.114, -10.012, and
+         6.720. The standard polynomial equation is
+             bkg = 1049.69/X + 5016.63/X^2^
+
+         The X-coordinate against which the background function is calculated
+         is 2θ in degrees.
+;
+
+save_
+
+save_pd_background.air_or_thermal_diffuse_coef_1
+
+    _definition.id                '_pd_background.air_or_thermal_diffuse_coef_1'
+    _definition.update            2023-02-02
+    _description.text
+;
+    The value of the first coefficient used in an equation representing the
+    background due to thermal diffuse scattering and/or air scattering, in a
+    calculated diffractogram. This equation can account for background
+    contributions at both high and low q. The first coefficient accounts for
+    background contributions that increase with q. Must be given with a
+    _pd_background.air_or_thermal_diffuse_order value.
+
+    The background equation is of the form:
+
+        bkg = Sum( C1~j~ * (q~2*j~/j!) + C2~j~ * (j!/q~2*j~), j=0:N)
+
+    where C1 and C2 represent _pd_background.air_or_thermal_diffuse_coef_1 and
+    coef_2, respectively, j is the order of the equation as given in
+    _pd_background.air_or_thermal_diffuse_order, and q is the magnitude of the
+    diffraction vector, defined as
+
+        q = 4πsin(θ)/λ
+
+    where θ is the diffraction angle and λ is the wavelength of the
+    incident radiation in angstroms.
+;
+    _name.category_id             pd_background
+    _name.object_id               air_or_thermal_diffuse_coef_1
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _units.code                   none
+
+save_
+
+save_pd_background.air_or_thermal_diffuse_coef_1_su
+
+    _definition.id
+        '_pd_background.air_or_thermal_diffuse_coef_1_su'
+    _definition.update            2023-02-02
+    _description.text
+;
+    Standard uncertainty of _pd_background.air_or_thermal_diffuse_coef_1.
+;
+    _name.category_id             pd_background
+    _name.object_id               air_or_thermal_diffuse_coef_1_su
+    _name.linked_item_id          '_pd_background.air_or_thermal_diffuse_coef_1'
+    _units.code                   none
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+save_
+
+save_pd_background.air_or_thermal_diffuse_coef_2
+
+    _definition.id                '_pd_background.air_or_thermal_diffuse_coef_2'
+    _definition.update            2023-02-02
+    _description.text
+;
+    The value of the first coefficient used in an equation representing the
+    background due to thermal diffuse scattering and/or air scattering, in a
+    calculated diffractogram. This equation can account for background
+    contributions at both high and low q. The second coefficient accounts for
+    background contributions that decrease with q. Must be given with a
+    _pd_background.air_or_thermal_diffuse_order value.
+
+    The background equation is of the form:
+
+        bkg = Sum( C1~j~ * (q~2*j~/j!) + C2~j~ * (j!/q~2*j~), j=0:N)
+
+    where C1 and C2 represent _pd_background.air_or_thermal_diffuse_coef_1 and
+    coef_2, respectively, j is the order of the equation as given in
+    _pd_background.air_or_thermal_diffuse_order, and q is the magnitude of the
+    diffraction vector, defined as
+
+        q = 4πsin(θ)/λ
+
+    where θ is the diffraction angle and λ is the wavelength of the
+    incident radiation in angstroms.
+;
+    _name.category_id             pd_background
+    _name.object_id               air_or_thermal_diffuse_coef_2
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _units.code                   none
+
+save_
+
+save_pd_background.air_or_thermal_diffuse_coef_2_su
+
+    _definition.id
+        '_pd_background.air_or_thermal_diffuse_coef_2_su'
+    _definition.update            2023-02-02
+    _description.text
+;
+    Standard uncertainty of _pd_background.air_or_thermal_diffuse_coef_2.
+;
+    _name.category_id             pd_background
+    _name.object_id               air_or_thermal_diffuse_coef_2_su
+    _name.linked_item_id          '_pd_background.air_or_thermal_diffuse_coef_2'
+    _units.code                   none
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+save_
+
+save_pd_background.air_or_thermal_diffuse_coefs_1
+
+    _definition.id
+        '_pd_background.air_or_thermal_diffuse_coefs_1'
+    _definition.update            2023-06-13
+    _description.text
+;
+    List of the first coefficients used in an equation representing the
+    background due to thermal diffuse scattering and/or air scattering, in a
+    calculated diffractogram.
+
+    See _pd_background.air_or_thermal_diffuse_coef_1.
+
+    The position of the coefficient in the list is significant, denoting the
+    order to which it corresponds. The first is the zeroth order, the second
+    is the first, and so on.
+;
+    _name.category_id             pd_background
+    _name.object_id               air_or_thermal_diffuse_coefs_1
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               List
+    _type.dimension               '[]'
+    _type.contents                Real
+    _units.code                   none
+
+save_
+
+save_pd_background.air_or_thermal_diffuse_coefs_1_su
+
+    _definition.id
+        '_pd_background.air_or_thermal_diffuse_coefs_1_su'
+    _definition.update            2023-07-11
+    _description.text
+;
+    Standard uncertainty of _pd_background.air_or_thermal_diffuse_coefs_1.
+;
+    _name.category_id             pd_background
+    _name.object_id               air_or_thermal_diffuse_coefs_1_su
+    _name.linked_item_id
+        '_pd_background.air_or_thermal_diffuse_coefs_1'
+    _type.purpose                 SU
+    _type.source                  Related
+    _type.container               List
+    _type.dimension               '[]'
+    _type.contents                Real
+    _units.code                   none
+
+save_
+
+save_pd_background.air_or_thermal_diffuse_coefs_2
+
+    _definition.id
+        '_pd_background.air_or_thermal_diffuse_coefs_2'
+    _definition.update            2023-06-13
+    _description.text
+;
+    List of the second coefficients used in an equation representing the
+    background due to thermal diffuse scattering and/or air scattering, in a
+    calculated diffractogram.
+
+    See _pd_background.air_or_thermal_diffuse_coef_2.
+
+    The position of the coefficient in the list is significant, denoting the
+    order to which it corresponds. The first is the zeroth order, the second
+    is the first, and so on.
+;
+    _name.category_id             pd_background
+    _name.object_id               air_or_thermal_diffuse_coefs_2
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               List
+    _type.dimension               '[]'
+    _type.contents                Real
+    _units.code                   none
+
+save_
+
+save_pd_background.air_or_thermal_diffuse_coefs_2_su
+
+    _definition.id
+        '_pd_background.air_or_thermal_diffuse_coefs_2_su'
+    _definition.update            2023-07-11
+    _description.text
+;
+    Standard uncertainty of _pd_background.air_or_thermal_diffuse_coefs_2.
+;
+    _name.category_id             pd_background
+    _name.object_id               air_or_thermal_diffuse_coefs_2_su
+    _name.linked_item_id
+        '_pd_background.air_or_thermal_diffuse_coefs_2'
+    _type.purpose                 SU
+    _type.source                  Related
+    _type.container               List
+    _type.dimension               '[]'
+    _type.contents                Real
+    _units.code                   none
+
+save_
+
+save_pd_background.air_or_thermal_diffuse_order
+
+    _definition.id                '_pd_background.air_or_thermal_diffuse_order'
+    _definition.update            2023-02-02
+    _description.text
+;
+    The value of an order used in an equation representing the
+    background due to thermal diffuse scattering and/or air scattering, in a
+    calculated diffractogram. Must be given with
+    _pd_background.air_or_thermal_diffuse_coef_1 and coef_2 values.
+
+    The background equation is of the form:
+
+        bkg = Sum( C1~j~ * (q~2*j~/j!) + C2~j~ * (j!/q~2*j~), j=0:N)
+
+    where C1 and C2 represent _pd_background.air_or_thermal_diffuse_coef_1 and
+    coef_2, respectively, j is the order of the equation as given in
+    _pd_background.air_or_thermal_diffuse_order, and q is the magnitude of the
+    diffraction vector, defined as
+
+        q = 4πsin(θ)/λ
+
+    where θ is the diffraction angle and λ is the wavelength of the
+    incident radiation in angstroms.
+;
+    _name.category_id             pd_background
+    _name.object_id               air_or_thermal_diffuse_order
+    _type.purpose                 Number
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Integer
+    _enumeration.range            0:
+    _units.code                   none
+
+save_
+
+save_pd_background.chebyshev_coef
+
+    _definition.id                '_pd_background.Chebyshev_coef'
+    _definition.update            2023-02-02
+    _description.text
+;
+    The value of a coefficient used in a Chebyshev polynomial equation
+    representing the background in a calculated diffractogram. Must be given
+    with a _pd_background.Chebyshev_order value.
+
+    The Chebyshev polynomial is of the first kind, and can be represented by the
+    recurrence relation
+
+        T~0~(x) = 1
+        T~1~(x) = x
+        T~n+1~(x) = 2 * x * T~n~(x) - T~n-1~(x).
+
+    where n represents the order of the polynomial, and x is the X-coordinate in
+    which the diffractogram was calculated, normalised to the range -1:1.
+
+    The background equation using Chebyshev polynomials is of the form:
+
+        bkg = Sum( coef * T~n~(x))
+;
+    _name.category_id             pd_background
+    _name.object_id               Chebyshev_coef
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _units.code                   none
+
+save_
+
+save_pd_background.chebyshev_coef_su
+
+    _definition.id                '_pd_background.Chebyshev_coef_su'
+    _definition.update            2023-02-02
+    _description.text
+;
+    Standard uncertainty of _pd_background.Chebyshev_coef.
+;
+    _name.category_id             pd_background
+    _name.object_id               Chebyshev_coef_su
+    _name.linked_item_id          '_pd_background.Chebyshev_coef'
+    _units.code                   none
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+save_
+
+save_pd_background.chebyshev_coefs
+
+    _definition.id                '_pd_background.Chebyshev_coefs'
+    _definition.update            2023-06-13
+    _description.text
+;
+    List of coefficients used in a Chebyshev equation representing the
+    background in a calculated diffractogram.
+
+    See _pd_background.Chebyshev_coef.
+
+    The position of the coefficient in the list is significant, denoting the
+    order to which it corresponds. The first is the zeroth order, the second
+    is the first, and so on.
+;
+    _name.category_id             pd_background
+    _name.object_id               Chebyshev_coefs
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               List
+    _type.dimension               '[]'
+    _type.contents                Real
+    _units.code                   none
+
+save_
+
+save_pd_background.chebyshev_coefs_su
+
+    _definition.id                '_pd_background.Chebyshev_coefs_su'
+    _definition.update            2023-07-11
+    _description.text
+;
+    Standard uncertainty of _pd_background.Chebyshev_coefs.
+;
+    _name.category_id             pd_background
+    _name.object_id               Chebyshev_coefs_su
+    _name.linked_item_id          '_pd_background.Chebyshev_coefs'
+    _type.purpose                 SU
+    _type.source                  Related
+    _type.container               List
+    _type.dimension               '[]'
+    _type.contents                Real
+    _units.code                   none
+
+save_
+
+save_pd_background.chebyshev_order
+
+    _definition.id                '_pd_background.Chebyshev_order'
+    _definition.update            2023-02-02
+    _description.text
+;
+    The value of an order used in a Chebyshev polynomial equation
+    representing the background in a calculated diffractogram. Must be given
+    with a _pd_background.Chebyshev_coef value.
+
+    The Chebyshev polynomial is of the first kind, and can be represented by the
+    recurrence relation
+
+        T~0~(x) = 1
+        T~1~(x) = x
+        T~n+1~(x) = 2 * x * T~n~(x) - T~n-1~(x).
+
+    where n represents the order of the polynomial, and x is the X-coordinate in
+    which the diffractogram was calculated, normalised to the range -1:1.
+
+    The background equation using Chebyshev polynomials is of the form:
+
+        bkg = Sum( coef * T~n~(x))
+;
+    _name.category_id             pd_background
+    _name.object_id               Chebyshev_order
+    _type.purpose                 Number
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Integer
+    _enumeration.range            0:
+    _units.code                   none
+
+save_
+
+save_pd_background.cosine_fourier_series_coef
+
+    _definition.id                '_pd_background.cosine_Fourier_series_coef'
+    _definition.update            2023-02-02
+    _description.text
+;
+    The value of a coefficient used in a cosine Fourier series equation
+    representing the background in a calculated diffractogram. Must be given
+    with a _pd_background.cosine_Fourier_series_order value.
+
+    The background equation using a cosine Fourier series is of the form:
+
+        bkg = C~0~ + Sum( C~j~ * cos(x * j), j=1:N)
+
+    where x is the 2θ value for that particular step, or some other
+    X-coordinate normalised to the range 0:180 degrees, j is the order
+    of the coefficient, and N represent the upper limit on the number of
+    coefficients used.
+;
+    _name.category_id             pd_background
+    _name.object_id               cosine_Fourier_series_coef
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _units.code                   none
+
+save_
+
+save_pd_background.cosine_fourier_series_coef_su
+
+    _definition.id                '_pd_background.cosine_Fourier_series_coef_su'
+    _definition.update            2023-02-02
+    _description.text
+;
+    Standard uncertainty of _pd_background.cosine_Fourier_series_coef.
+;
+    _name.category_id             pd_background
+    _name.object_id               cosine_Fourier_series_coef_su
+    _name.linked_item_id          '_pd_background.cosine_Fourier_series_coef'
+    _units.code                   none
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+save_
+
+save_pd_background.cosine_fourier_series_coefs
+
+    _definition.id                '_pd_background.cosine_Fourier_series_coefs'
+    _definition.update            2023-06-13
+    _description.text
+;
+    The value of a coefficient used in a cosine Fourier series equation
+    representing the background in a calculated diffractogram.
+
+    See _pd_background.cosine_Fourier_series_coef.
+
+    The position of the coefficient in the list is significant, denoting the
+    order to which it corresponds. The first is the zeroth order, the second
+    is the first, and so on.
+;
+    _name.category_id             pd_background
+    _name.object_id               cosine_Fourier_series_coefs
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               List
+    _type.dimension               '[]'
+    _type.contents                Real
+    _units.code                   none
+
+save_
+
+save_pd_background.cosine_fourier_series_coefs_su
+
+    _definition.id
+        '_pd_background.cosine_Fourier_series_coefs_su'
+    _definition.update            2023-07-11
+    _description.text
+;
+    Standard uncertainty of _pd_background.cosine_Fourier_series_coefs.
+;
+    _name.category_id             pd_background
+    _name.object_id               cosine_Fourier_series_coefs_su
+    _name.linked_item_id          '_pd_background.cosine_Fourier_series_coefs'
+    _type.purpose                 SU
+    _type.source                  Related
+    _type.container               List
+    _type.dimension               '[]'
+    _type.contents                Real
+    _units.code                   none
+
+save_
+
+save_pd_background.cosine_fourier_series_order
+
+    _definition.id                '_pd_background.cosine_Fourier_series_order'
+    _definition.update            2023-01-14
+    _description.text
+;
+    The value of an order used in a cosine Fourier series equation
+    representing the background in a calculated diffractogram. Must be given
+    with a _pd_background.cosine_Fourier_series_coef value.
+
+    The background equation using a cosine Fourier series is of the form:
+
+        bkg = C~0~ + Sum( C~j~ * cos(x * j), j=1:N)
+
+    where x is the 2θ value for that particular step, or some other
+    X-coordinate normalised to the range 0:180 degrees, j is the order
+    of the coefficient, and N represent the upper limit on the number of
+    coefficients used.
+;
+    _name.category_id             pd_background
+    _name.object_id               cosine_Fourier_series_order
+    _type.purpose                 Number
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Integer
+    _enumeration.range            0:
+    _units.code                   none
+
+save_
+
+save_pd_background.debye_diffuse_amp
+
+    _definition.id                '_pd_background.Debye_diffuse_amp'
+    _definition.update            2023-02-02
+    _description.text
+;
+    The value of the amplitude in a Debye diffuse scattering equation
+    representing the background in a calculated diffractogram.
+
+    The background equation is of the form
+
+        bkg = amplitude * sinc(distance * q) * exp(-displacement * q^2^)
+
+    where sinc(X) is defined as
+
+        sinc(X) = sin(X) / X
+
+    and where q is the magnitude of the diffraction vector, defined as
+
+        q = 4πsin(θ)/λ
+
+    where θ is the diffraction angle and λ is the wavelength of the
+    incident radiation in angstroms.
+;
+    _name.category_id             pd_background
+    _name.object_id               Debye_diffuse_amp
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _units.code                   none
+
+save_
+
+save_pd_background.debye_diffuse_amp_su
+
+    _definition.id                '_pd_background.Debye_diffuse_amp_su'
+    _definition.update            2023-02-02
+    _description.text
+;
+    Standard uncertainty of _pd_background.Debye_diffuse_amp.
+;
+    _name.category_id             pd_background
+    _name.object_id               Debye_diffuse_amp_su
+    _name.linked_item_id          '_pd_background.Debye_diffuse_amp'
+    _units.code                   none
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+save_
+
+save_pd_background.debye_diffuse_displace
+
+    _definition.id                '_pd_background.Debye_diffuse_displace'
+    _definition.update            2023-02-02
+    _description.text
+;
+    The value of the displacement in a Debye diffuse scattering equation
+    representing the background in a calculated diffractogram.
+
+    The background equation is of the form
+
+        bkg = amplitude * sinc(distance * q) * exp(-displacement * q^2^)
+
+    where sinc(X) is defined as
+
+        sinc(X) = sin(X) / X
+
+    and where q is the magnitude of the diffraction vector, defined as
+
+        q = 4πsin(θ)/λ
+
+    where θ is the diffraction angle and λ is the wavelength of the
+    incident radiation in angstroms.
+;
+    _name.category_id             pd_background
+    _name.object_id               Debye_diffuse_displace
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _units.code                   angstrom_squared
+
+save_
+
+save_pd_background.debye_diffuse_displace_su
+
+    _definition.id                '_pd_background.Debye_diffuse_displace_su'
+    _definition.update            2023-01-09
+    _description.text
+;
+    Standard uncertainty of _pd_background.Debye_diffuse_displace.
+;
+    _name.category_id             pd_background
+    _name.object_id               Debye_diffuse_displace_su
+    _name.linked_item_id          '_pd_background.Debye_diffuse_displace'
+    _units.code                   angstrom_squared
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+save_
+
+save_pd_background.debye_diffuse_dist
+
+    _definition.id                '_pd_background.Debye_diffuse_dist'
+    _definition.update            2023-02-02
+    _description.text
+;
+    The value of the distance in a Debye diffuse scattering equation
+    representing the background in a calculated diffractogram.
+
+    The background equation is of the form
+
+        bkg = amplitude * sinc(distance * q) * exp(-displacement * q^2^)
+
+    where sinc(X) is defined as
+
+        sinc(X) = sin(X) / X
+
+    and where q is the magnitude of the diffraction vector, defined as
+
+        q = 4πsin(θ)/λ
+
+    where θ is the diffraction angle and λ is the wavelength of the
+    incident radiation in angstroms.
+;
+    _name.category_id             pd_background
+    _name.object_id               Debye_diffuse_dist
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _units.code                   angstroms
+
+save_
+
+save_pd_background.debye_diffuse_dist_su
+
+    _definition.id                '_pd_background.Debye_diffuse_dist_su'
+    _definition.update            2023-02-02
+    _description.text
+;
+    Standard uncertainty of _pd_background.Debye_diffuse_dist.
+;
+    _name.category_id             pd_background
+    _name.object_id               Debye_diffuse_dist_su
+    _name.linked_item_id          '_pd_background.Debye_diffuse_dist'
+    _units.code                   angstroms
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+save_
+
+save_pd_background.diffractogram_id
+
+    _definition.id                '_pd_background.diffractogram_id'
+    _definition.update            2023-01-08
+    _description.text
+;
+    A diffractogram id to which the background equation relates.
+;
+    _name.category_id             pd_background
+    _name.object_id               diffractogram_id
+    _name.linked_item_id          '_pd_diffractogram.id'
+    _type.purpose                 Link
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_pd_background.id
+
+    _definition.id                '_pd_background.id'
+    _definition.update            2023-01-08
+    _description.text
+;
+    An arbitrary code identifying part of a background equation.
+;
+    _name.category_id             pd_background
+    _name.object_id               id
+    _type.purpose                 Key
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Word
+
+save_
+
+save_pd_background.line_segment_intensities
+
+    _definition.id                '_pd_background.line_segment_intensities'
+    _definition.update            2023-06-13
+    _description.text
+;
+    List of intensities used to create many straight-line segments representing
+    the background in a calculated diffractogram.
+
+    See _pd_background.line_segment_intensity.
+
+    Must be in the same order as the X-coordinate values in
+    _pd_background.line_segment_Xs.
+;
+    _name.category_id             pd_background
+    _name.object_id               line_segment_intensities
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               List
+    _type.dimension               '[]'
+    _type.contents                Real
+    _units.code                   none
+
+save_
+
+save_pd_background.line_segment_intensities_su
+
+    _definition.id                '_pd_background.line_segment_intensities_su'
+    _definition.update            2023-07-11
+    _description.text
+;
+    Standard uncertainty of _pd_background.line_segment_intensities.
+;
+    _name.category_id             pd_background
+    _name.object_id               line_segment_intensities_su
+    _name.linked_item_id          '_pd_background.line_segment_intensities'
+    _type.purpose                 SU
+    _type.source                  Related
+    _type.container               List
+    _type.dimension               '[]'
+    _type.contents                Real
+    _units.code                   none
+
+save_
+
+save_pd_background.line_segment_intensity
+
+    _definition.id                '_pd_background.line_segment_intensity'
+    _definition.update            2023-02-02
+    _description.text
+;
+    The Y coordinate in an X,Y coordinate pair representing an X coordinate as
+    defined in _pd_background.X_coordinate and intensity on the same scale as
+    the calculated diffractogram intensities. Must be given with a value
+    of _pd_background.line_segment_X to create a valid X,Y coordinate pair.
+
+    It is intended that at least two X,Y coordinate pairs are given, and that
+    the line segments between them form the background function.
+
+    The value of the background function at a point x, is of the form:
+
+               (intensity_2 - intensity_1)
+        bkg =  --------------------------- * (x - X_1) + intensity_1
+                       (X_2 - X_1)
+
+    where the X-coordinate is the coordinate in which the diffractogram was
+    calculated, and the function is defined only over the range X_1:X_2,
+    where X_1 and X_2 are taken as the closest values of
+    _pd_background.line_segment_X to the given x value, and intensity_1 and
+    intensity_2 are their associated intensity values.
+;
+    _name.category_id             pd_background
+    _name.object_id               line_segment_intensity
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _units.code                   none
+
+save_
+
+save_pd_background.line_segment_intensity_su
+
+    _definition.id                '_pd_background.line_segment_intensity_su'
+    _definition.update            2023-02-02
+    _description.text
+;
+    Standard uncertainty of _pd_background.line_segment_intensity.
+;
+    _name.category_id             pd_background
+    _name.object_id               line_segment_intensity_su
+    _name.linked_item_id          '_pd_background.line_segment_intensity'
+    _units.code                   none
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+save_
+
+save_pd_background.line_segment_x
+
+    _definition.id                '_pd_background.line_segment_X'
+    _definition.update            2023-02-02
+    _description.text
+;
+    The X-coordinate in an X,Y coordinate pair representing an X coordinate as
+    defined in _pd_background.X_coordinate and intensity on the same scale as
+    the calculated diffractogram intensities. Must be given with a value
+    of _pd_background.line_segment_intensity to create a valid X,Y coordinate
+    pair.
+
+    It is intended that at least two X,Y coordinate pairs are given, and that
+    the line segments between them form the background function.
+
+    The value of the background function at a point x, is of the form:
+
+               (intensity_2 - intensity_1)
+        bkg =  --------------------------- * (x - X_1) + intensity_1
+                       (X_2 - X_1)
+
+    where the X-coordinate is the coordinate in which the diffractogram was
+    calculated, and the function is defined only over the range X_1:X_2,
+    where X_1 and X_2 are taken as the closest values of
+    _pd_background.line_segment_X to the given x value, and intensity_1 and
+    intensity_2 are their associated intensity values.
+;
+    _name.category_id             pd_background
+    _name.object_id               line_segment_X
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _units.code                   none
+
+save_
+
+save_pd_background.line_segment_xs
+
+    _definition.id                '_pd_background.line_segment_Xs'
+    _definition.update            2023-06-13
+    _description.text
+;
+    List of X-coordinates used to create many straight-line segments
+    representing the background in a calculated diffractogram.
+
+    See _pd_background.line_segment_X.
+
+    Must be in the same order as the intensity values in
+    _pd_background.line_segment_intensities.
+;
+    _name.category_id             pd_background
+    _name.object_id               line_segment_Xs
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               List
+    _type.dimension               '[]'
+    _type.contents                Real
+    _units.code                   none
+
+save_
+
+save_pd_background.peak_id
+
+    _definition.id                '_pd_background.peak_id'
+    _definition.update            2023-01-08
+    _description.text
+;
+    An arbitrary code is assigned to a peak in the background.
+
+    Used to link with _pd_peak.id. Each peak will have a unique code. In cases
+    where two peaks are severely overlapped, it may be desirable to list them as
+    a single peak.
+
+    A peak ID must be included for every amorphous peak.
+;
+    _name.category_id             pd_background
+    _name.object_id               peak_id
+    _name.linked_item_id          '_pd_peak.id'
+    _type.purpose                 Link
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Code
+
+save_
+
+save_pd_background.peak_overall_id
+
+    _definition.id                '_pd_background.peak_overall_id'
+    _definition.update            2023-04-13
+    _description.text
+;
+    A code linking to general information about peak description and
+    determination for the background peaks.
+;
+    _name.category_id             pd_background
+    _name.object_id               peak_overall_id
+    _name.linked_item_id          '_pd_peak_overall.id'
+    _type.purpose                 Link
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Code
+
+save_
+
+save_pd_background.polynomial_coef
+
+    _definition.id                '_pd_background.polynomial_coef'
+    _definition.update            2023-02-02
+    _description.text
+;
+    The value of a coefficient used in a polynomial equation representing the
+    background in a calculated diffractogram. Must be given with a
+    _pd_background.polynomial_power value.
+
+    The background equation is of the form:
+
+        bkg = Sum( coef * X_coord ^ power)
+
+    where the X-coordinate is coordinate in which the diffractogram was
+    calculated.
+;
+    _name.category_id             pd_background
+    _name.object_id               polynomial_coef
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _units.code                   arbitrary
+
+save_
+
+save_pd_background.polynomial_coef_su
+
+    _definition.id                '_pd_background.polynomial_coef_su'
+    _definition.update            2023-02-02
+    _description.text
+;
+    Standard uncertainty of _pd_background.polynomial_coef.
+;
+    _name.category_id             pd_background
+    _name.object_id               polynomial_coef_su
+    _name.linked_item_id          '_pd_background.polynomial_coef'
+    _units.code                   arbitrary
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+save_
+
+save_pd_background.polynomial_coefs
+
+    _definition.id                '_pd_background.polynomial_coefs'
+    _definition.update            2023-06-13
+    _description.text
+;
+    List of coefficients used in a polynomial equation representing the
+    background in a calculated diffractogram.
+
+    See _pd_background.polynomial_coef.
+
+    Must be in the same order as the powers in
+    _pd_background.polynomial_powers. Values at the same index in each list
+    are corresponding coefficient-power pairs.
+;
+    _name.category_id             pd_background
+    _name.object_id               polynomial_coefs
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               List
+    _type.dimension               '[]'
+    _type.contents                Real
+    _units.code                   arbitrary
+
+save_
+
+save_pd_background.polynomial_coefs_su
+
+    _definition.id                '_pd_background.polynomial_coefs_su'
+    _definition.update            2023-07-11
+    _description.text
+;
+    Standard uncertainty of _pd_background.polynomial_coefs.
+;
+    _name.category_id             pd_background
+    _name.object_id               polynomial_coefs_su
+    _name.linked_item_id          '_pd_background.polynomial_coefs'
+    _type.purpose                 SU
+    _type.source                  Related
+    _type.container               List
+    _type.dimension               '[]'
+    _type.contents                Real
+    _units.code                   arbitrary
+
+save_
+
+save_pd_background.polynomial_power
+
+    _definition.id                '_pd_background.polynomial_power'
+    _definition.update            2023-01-08
+    _description.text
+;
+    The value of a power used in a polynomial equation representing the
+    background in a calculated diffractogram. Must be given with a
+    _pd_background.polynomial_coef value.
+
+    The background equation is of the form:
+
+        bkg = Sum( coef * X_coord ^ power)
+
+    where the X-coordinate is coordinate in which the diffractogram was
+    calculated.
+;
+    _name.category_id             pd_background
+    _name.object_id               polynomial_power
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _units.code                   none
+
+save_
+
+save_pd_background.polynomial_power_su
+
+    _definition.id                '_pd_background.polynomial_power_su'
+    _definition.update            2023-01-08
+    _description.text
+;
+    Standard uncertainty of _pd_background.polynomial_power.
+;
+    _name.category_id             pd_background
+    _name.object_id               polynomial_power_su
+    _name.linked_item_id          '_pd_background.polynomial_power'
+    _units.code                   none
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+save_
+
+save_pd_background.polynomial_powers
+
+    _definition.id                '_pd_background.polynomial_powers'
+    _definition.update            2023-06-13
+    _description.text
+;
+    List of powers used in a polynomial equation representing the background
+    in a calculated diffractogram.
+
+    See _pd_background.polynomial_power.
+
+    Must be in the same order as the powers in _pd_background.polynomial_coefs.
+    Values at the same index in each list are corresponding coefficient-power
+    pairs.
+;
+    _name.category_id             pd_background
+    _name.object_id               polynomial_powers
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               List
+    _type.dimension               '[]'
+    _type.contents                Real
+    _units.code                   none
+
+save_
+
+save_pd_background.polynomial_powers_su
+
+    _definition.id                '_pd_background.polynomial_powers_su'
+    _definition.update            2023-07-11
+    _description.text
+;
+    Standard uncertainty of _pd_background.polynomial_powers.
+;
+    _name.category_id             pd_background
+    _name.object_id               polynomial_powers_su
+    _name.linked_item_id          '_pd_background.polynomial_powers'
+    _type.purpose                 SU
+    _type.source                  Related
+    _type.container               List
+    _type.dimension               '[]'
+    _type.contents                Real
+    _units.code                   none
+
+save_
+
+save_pd_background.special_details
+
+    _definition.id                '_pd_background.special_details'
+    _definition.update            2023-01-18
+    _description.text
+;
+    Description of background details that cannot otherwise be recorded using
+    other PD_BACKGROUND data items.
+;
+    _name.category_id             pd_background
+    _name.object_id               special_details
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_pd_background.x_coordinate
+
+    _definition.id                '_pd_background.X_coordinate'
+    _definition.update            2023-01-18
+    _description.text
+;
+    The type of X-coordinate against which the PD_BACKGROUND values were
+    calculated where the explicit X-coordinate type of the background data item
+    is not given.
+
+    If the background data item explicitly states with which X-coordinate it is
+    calculated, then that takes precedence over any value here.
+;
+    _name.category_id             pd_background
+    _name.object_id               X_coordinate
+    _type.purpose                 State
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Word
+
+    loop_
+      _enumeration_set.state
+      _enumeration_set.detail
+         2theta
+;
+         Measured 2θ diffraction angle.
+;
+         2theta_corrected
+;
+         Corrected 2θ diffraction angle.
+;
+         channel
+;
+         Channel number in a position-sensitive, energy-dispersive or other
+         multiple-detector instrument.
+;
+         position
+;
+         A measured linear distance corresponding to the location where an
+         intensity measurement was made.
+;
+         time-of-flight
+;
+         Measured time for time-of-flight neutron measurements.
+;
+         d_spacing
+;
+         Calculated d-spacing corresponding to a data point.
+;
+         energy
+;
+         Incident energy of the source.
+;
+         recip_len_q
+;
+         Length in reciprocal space (|Q|= 2π/d) corresponding to a data point.
+;
+         wavelength
+;
+         Incident wavelength of the source.
+;
+         other
+;
+         The X-coordinate should be described in _pd_background.special_details.
+;
+save_
+
+save_PD_BLOCK
+
+    _definition.id                PD_BLOCK
+    _definition.scope             Category
+    _definition.class             Loop
+    _definition.update            2025-04-18
+    _description.text
+;
+    **DEPRECATED**
+    Use _pd_phase.id, _pd_diffractogram.id, or _audit.block_code' as
+    necessary.
+
+    _pd_block.id is used to assign a unique ID code to a data block.
+    This code is then used for references between different blocks
+    (see _pd_block_diffractogram.id, _pd_phase_block.id and
+    _pd_qpa_external_std.diffractogram_block_id).
+
+    Note that a data block may contain only a single diffraction
+    data set or information about a single crystalline phase.
+    However, a single diffraction measurement may yield structural
+    information on more than one phase, or a single structure
+    determination may use more than one data set. Alternatively,
+    results from a single data set, such as calibration parameters
+    from measurements of a standard, may be used for many subsequent
+    analyses. Through use of the ID code, a reference made between
+    data sets may be preserved when the file is exported from the
+    laboratory from which the CIF originated.
+
+    The ID code assigned to each data block should be unique with
+    respect to an ID code assigned for any other data block in the
+    world. The naming scheme chosen for the block-ID format is
+    designed to ensure uniqueness.
+
+    It is the responsibility of a data archive site or local
+    laboratory to create a catalogue of block IDs if that site
+    wishes to resolve these references.
+;
+    _name.category_id             PD_GROUP
+    _name.object_id               PD_BLOCK
+    _category_key.name            '_pd_block.id'
+
+save_
+
+save_pd_block.id
+
+    _definition.id                '_pd_block.id'
+    loop_
+      _definition_replaced.id
+      _definition_replaced.by
+         1                        '_pd_phase.id'
+         2                        '_pd_diffractogram.id'
+         3                        '_audit.block_code'
+    _alias.definition_id          '_pd_block_id'
+    _definition.update            2025-04-18
+    _description.text
+;
+    **DEPRECATED**
+    Use _pd_phase.id, _pd_diffractogram.id, or _audit.block_code,
+    as necessary.
+
+    Used to assign a unique character string to a block.
+    Note that this code is not intended to be parsed; the
+    concatenation of several strings is used in order to
+    generate a string that can reasonably be expected to
+    be unique.
+
+    This code is assigned by the originator of the data set and
+    is used for references between different CIF blocks.
+    The ID will normally be created when the block is first
+    created. It is possible to loop more than one ID for a
+    block: if changes or additions are made to the
+    block later, a new ID may be assigned, but the original name
+    should be retained.
+
+    The suggested format for the ID code is:
+      <date-time>|<block_name>|<creator_name>|<instr_name>
+
+     <date-time>    is the date and time the CIF was created
+                    or modified.
+
+     <block_name>   is an arbitrary name assigned by the
+                    originator of the data set. It will
+                    usually match the name of the phase
+                    and possibly the name of the current CIF
+                    data block (i.e. the string xxxx in a
+                    data_xxxx identifier). It may be a sample name.
+
+     <creator_name> is the name of the person who measured the
+                    diffractogram, or prepared or modified the CIF.
+
+     <instr_name>  is a unique name (as far as possible) for
+                    the data-collection instrument, preferably
+                    containing the instrument serial number for
+                    commercial instruments. It is also possible to
+                    use the Internet name or address for the
+                    instrument computer as a unique name.
+
+    As blocks are created in a CIF, the original sample identifier
+    (i.e. <block_name>) should be retained, but the <creator_name>
+    may be changed and the <date-time> will always change.
+    The <date-time> will usually match either the
+    _pd_meas.datetime_initiated or the _pd_proc.info_datetime
+    entry.
+
+    Within each section of the code, the following characters
+    may be used:
+                  A-Z a-z 0-9 # & * . : , - _ + / ( ) \ [ ]
+
+    The sections are separated with vertical rules '|' which are
+    not allowed within the sections. Blank spaces may also
+    not be used. Capitalization may be used within the ID code
+    but should not be considered significant - searches for
+    data-set ID names should be case-insensitive.
+
+    Date-time entries follow the standard RFC 3339 ABNF format
+    'yyyy-mm-ddThh:mm:ss{Z|[+-]zz:zz}'.
+
+    An archive site that wishes to make CIFs available via
+    the web may substitute the URL for the file containing the
+    appropriate block for the final two sections of the ID
+    (<creator_name> and <instr_name>). Note that this should
+    not be done unless the archive site is prepared to keep the
+    file available online indefinitely.
+;
+    _name.category_id             pd_block
+    _name.object_id               id
+    _type.purpose                 Encode
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Text
+
+    loop_
+      _description_example.case
+         1991-09-15T16:54:00Z|Si-std|B.Toby|D500#1234-987
+         1991-09-15T16:54:00Z|SEPD7234|B.Toby|SEPD.IPNS.ANL.GOV
+
+save_
+
+save_PD_BLOCK_DIFFRACTOGRAM
+
+    _definition.id                PD_BLOCK_DIFFRACTOGRAM
+    _definition.scope             Category
+    _definition.class             Loop
+    _definition.update            2025-04-18
+    _description.text
+;
+     **DEPRECATED**
+    Use _pd_diffractogram.id, as necessary.
+
+    A number of diffractograms may contribute to the
+    determination of the structure of a single phase.
+    The _pd_block.ids of those diffractograms should
+    be listed here.
+;
+    _name.category_id             PD_GROUP
+    _name.object_id               PD_BLOCK_DIFFRACTOGRAM
+    _category_key.name            '_pd_block_diffractogram.id'
+
+save_
+
+save_pd_block_diffractogram.id
+
+    _definition.id                '_pd_block_diffractogram.id'
+    _definition_replaced.id       1
+    _definition_replaced.by       '_pd_diffractogram.id'
+    _alias.definition_id          '_pd_block_diffractogram_id'
+    _definition.update            2025-04-18
+    _description.text
+;
+    **DEPRECATED**
+    Use _pd_diffractogram.id, as necessary.
+
+    A block ID code (see _pd_block.id) that identifies
+    diffraction data contained in a data block other
+    than the current block. This will occur most frequently
+    when more than one set of diffraction data
+    is used for a structure determination. The data
+    block containing the diffraction data will contain
+    a _pd_block.id code matching the code in
+    _pd_block_diffractogram.id.
+;
+    _name.category_id             pd_block_diffractogram
+    _name.object_id               id
+    _name.linked_item_id          '_pd_block.id'
+    _type.purpose                 Link
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_PD_CALC_COMPONENT
+
+    _definition.id                PD_CALC_COMPONENT
+    _definition.scope             Category
+    _definition.class             Loop
+    _definition.update            2023-01-08
+    _description.text
+;
+    This section is used for storing the phase-specific
+    components of a computed diffractogram, such as
+    intensities calculated from a Rietveld refinement.
+;
+    _name.category_id             PD_GROUP
+    _name.object_id               PD_CALC_COMPONENT
+
+    loop_
+      _category_key.name
+         '_pd_calc_component.diffractogram_id'
+         '_pd_calc_component.point_id'
+         '_pd_calc_component.phase_id'
+
+    _description_example.case
+;
+         _pd_phase.id           A_PHASE
+         _pd_diffractogram.id   A_DIFFRACTOGRAM
+
+         loop_
+         _pd_calc_component.point_id
+         _pd_calc_component.intensity_total
+         0    25.994961
+         1    26.200290
+         2    26.404083
+         # further calculated points...
+;
+    _description_example.detail
+;
+         This shows the usual case where a single phase and diffractogram
+         combination is present in a single data block; the values of
+         _pd_calc_component.phase_id and _pd_calc_component.diffractogram_id
+         are taken directly from the parent items _pd_phase.id and
+         _pd_diffractogram.id.
+
+         The first three data points of the calculated diffraction pattern
+         corresponding only to the contribution of the phase with the
+         _pd_phase.id value of 'A_PHASE', including any background, are given.
+         The diffractogram to which this profile belongs has the
+         _pd_diffractogram.id value of 'A_DIFFRACTOGRAM'. The values of
+         _pd_calc_component.point_id must correspond to the _pd_data.point_id
+         values to which the _pd_calc_component.intensity_total values belong.
+;
+
+save_
+
+save_pd_calc_component.diffractogram_id
+
+    _definition.id                '_pd_calc_component.diffractogram_id'
+    _definition.update            2023-01-06
+    _description.text
+;
+    The diffractogram(s) (see _pd_diffractogram.id) to which these component
+    intensities form part of the _pd_calc.intensity_total or
+    _pd_calc.intensity_net values.
+;
+    _name.category_id             pd_calc_component
+    _name.object_id               diffractogram_id
+    _name.linked_item_id          '_pd_diffractogram.id'
+    _type.purpose                 Link
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_pd_calc_component.intensity_net
+
+    _definition.id                '_pd_calc_component.intensity_net'
+    _definition.update            2022-10-12
+    _description.text
+;
+    Intensity values for the contribution of a phase to a
+    computed diffractogram for each data point. Values
+    should be computed at the same locations as the processed
+    diffractogram, and thus the numbers of points will be
+    defined by _pd_proc.number_of_points. Point positions
+    may be defined using _pd_proc.2theta_range_*,
+    _pd_proc.2theta_corrected, _pd_proc.d_spacing, or other
+    appropriate x-coordinates.
+
+    Use _pd_calc_component.intensity_net if the computed
+    component contribution diffraction pattern does not
+    include background or normalization corrections and thus
+    is specified on the same scale as the
+    _pd_proc.intensity_net values.
+
+    In order to properly associate data between loops,
+    _pd_calc_component.intensity_net must be looped with
+    _pd_calc_component.point_id, and the
+    measured/processed/calculated data must be looped with
+    _pd_data.point_id.
+;
+    _name.category_id             pd_calc_component
+    _name.object_id               intensity_net
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   none
+
+save_
+
+save_pd_calc_component.intensity_total
+
+    _definition.id                '_pd_calc_component.intensity_total'
+    _definition.update            2022-10-12
+    _description.text
+;
+    Intensity values for the contribution of a phase to a
+    computed diffractogram for each data point. Values
+    should be computed at the same locations as the processed
+    diffractogram, and thus the numbers of points will be
+    defined by _pd_proc.number_of_points. Point positions
+    may be defined using _pd_proc.2theta_range_*,
+    _pd_proc.2theta_corrected, _pd_proc.d_spacing, or other
+    appropriate x-coordinates.
+
+    Use _pd_calc_component.intensity_total if the computed
+    component contribution diffraction pattern includes background
+    or normalization corrections (or both) and thus is specified on
+    the same scale as the observed intensities (_pd_meas.counts_*
+    or _pd_meas.intensity_*).
+
+    In order to properly associate data between loops,
+    _pd_calc_component.intensity_net must be looped with
+    _pd_calc_component.point_id, and the
+    measured/processed/calculated data must be looped with
+    _pd_data.point_id.
+;
+    _name.category_id             pd_calc_component
+    _name.object_id               intensity_total
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   none
+
+save_
+
+save_pd_calc_component.phase_id
+
+    _definition.id                '_pd_calc_component.phase_id'
+    _definition.update            2023-01-06
+    _description.text
+;
+    The phase (see _pd_phase.id) from which the component intensities
+    were calculated.
+;
+    _name.category_id             pd_calc_component
+    _name.object_id               phase_id
+    _name.linked_item_id          '_pd_phase.id'
+    _type.purpose                 Link
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_pd_calc_component.point_id
+
+    _definition.id                '_pd_calc_component.point_id'
+    _definition.update            2022-10-12
+    _description.text
+;
+    Arbitrary label identifying a calculated component data
+    point. Used to identify a specific entry in a list of values
+    forming the calculated component diffractogram.
+
+    The value of _pd_calc_component.point_id must be the same as
+    the value of _pd_data.point_id given to the equivalent data point
+    in the measured/processed/calculated diffractogram to which
+    this component belongs.
+;
+    _name.category_id             pd_calc_component
+    _name.object_id               point_id
+    _name.linked_item_id          '_pd_data.point_id'
+    _type.purpose                 Link
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Code
+
+save_
+
+save_PD_CALC_OVERALL
+
+    _definition.id                PD_CALC_OVERALL
+    _definition.scope             Category
+    _definition.class             Set
+    _definition.update            2016-10-18
+    _description.text
+;
+    Items in this category record overall features of the computed
+    diffractogram.
+;
+    _name.category_id             PD_GROUP
+    _name.object_id               PD_CALC_OVERALL
+    _category_key.name            '_pd_calc_overall.diffractogram_id'
+
+save_
+
+save_pd_calc.method
+
+    _definition.id                '_pd_calc.method'
+    _alias.definition_id          '_pd_calc_method'
+    _definition.update            2023-01-18
+    _description.text
+;
+    A description of the method used for the calculation of the
+    intensities in _pd_calc.intensity_*. If the pattern was
+    calculated from crystal structure data for a single phase, the
+    atom coordinates and other crystallographic information should
+    be included in the datablock using the core CIF ATOM_SITE and
+    CELL data items. If multiple phases were used, these should
+    be listed in the pd_phase category.
+;
+    _name.category_id             pd_calc_overall
+    _name.object_id               method
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+
+    loop_
+      _description_example.case
+         'Rietveld'
+         'Pawley'
+         'Le Bail'
+         'Independent peak fitting'
+
+save_
+
+save_pd_calc_overall.component_presentation_order
+
+    _definition.id
+        '_pd_calc_overall.component_presentation_order'
+    _definition.update            2023-06-13
+    _description.text
+;
+    List of _pd_phase.ids specifying the order in which
+    the individual phases' calculated components are given
+    within _pd_calc.component_intensities_*.
+;
+    _name.category_id             pd_calc_overall
+    _name.object_id               component_presentation_order
+    _type.purpose                 Encode
+    _type.source                  Assigned
+    _type.container               List
+    _type.dimension               '[]'
+    _type.contents                Code
+
+save_
+
+save_pd_calc_overall.diffractogram_id
+
+    _definition.id                '_pd_calc_overall.diffractogram_id'
+    _definition.update            2023-01-12
+    _description.text
+;
+    The diffractogram (see _pd_diffractogram.id) to which the associated
+    features relate.
+;
+    _name.category_id             pd_calc_overall
+    _name.object_id               diffractogram_id
+    _name.linked_item_id          '_pd_diffractogram.id'
+    _type.purpose                 Link
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_PD_CALIB
+
+    _definition.id                PD_CALIB
+    _definition.scope             Category
+    _definition.class             Loop
+    _definition.update            2023-06-05
+    _description.text
+;
+    This category is deprecated. Please see PD_CALIB_DETECTED_INTENSITY and
+    PD_QPA_INTERNAL_STD.
+
+    This section defines the parameters used for the calibration
+    of the instrument that are used directly or indirectly in the
+    interpretation of this data set. The information in this
+    section of the CIF should generally be written when the
+    intensities are first measured, but from then on should remain
+    unchanged. Loops may be used for calibration information that
+    differs by detector channel.
+;
+    _name.category_id             PD_GROUP
+    _name.object_id               PD_CALIB
+    _category_key.name            '_pd_calib.detector_id'
+
+save_
+
+save_pd_calib.detector_id
+
+    _definition.id                '_pd_calib.detector_id'
+    _definition_replaced.id       1
+    _definition_replaced.by       '_pd_calib_detected_intensity.detector_id'
+    _alias.definition_id          '_pd_calib_detector_id'
+    _definition.update            2023-06-09
+    _description.text
+;
+    This item is deprecated. Please see
+    _pd_calib_detected_intensity.detector_id.
+
+    A code which identifies the detector or channel number in a
+    position-sensitive, energy-dispersive or other multiple-detector
+    instrument for which the individual instrument geometry is being
+    defined. This code should match the code name used for
+    _pd_instr_detector.id.
+;
+    _name.category_id             pd_calib
+    _name.object_id               detector_id
+    _name.linked_item_id          '_pd_instr_detector.id'
+    _type.purpose                 Link
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Code
+
+save_
+
+save_pd_calib.detector_response
+
+    _definition.id                '_pd_calib.detector_response'
+    _definition_replaced.id       1
+    _definition_replaced.by
+        '_pd_calib_detected_intensity.detector_response'
+    _alias.definition_id          '_pd_calib_detector_response'
+    _definition.update            2023-06-05
+    _description.text
+;
+    This item is deprecated. Please see
+    _pd_calib_detected_intensity.detector_response.
+
+    A value that indicates the relative sensitivity of each
+    detector. This can compensate for differences in electronics,
+    size and collimation. Usually, one detector or the mean for
+    all detectors will be assigned the value of 1.
+;
+    _name.category_id             pd_calib
+    _name.object_id               detector_response
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   none
+
+save_
+
+save_pd_calib.detector_response_su
+
+    _definition.id                '_pd_calib.detector_response_su'
+    _definition_replaced.id       1
+    _definition_replaced.by
+        '_pd_calib_detected_intensity.detector_response_su'
+    _definition.update            2023-06-05
+    _description.text
+;
+    This item is deprecated. Please see
+    _pd_calib_detected_intensity.detector_response_su.
+
+    Standard uncertainty of _pd_calib.detector_response.
+;
+    _name.category_id             pd_calib
+    _name.object_id               detector_response_su
+    _name.linked_item_id          '_pd_calib.detector_response'
+    _units.code                   none
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+save_
+
+save_pd_calib.std_internal_mass_percent
+
+    _definition.id                '_pd_calib.std_internal_mass_percent'
+    _definition_replaced.id       1
+    _definition_replaced.by       '_pd_qpa_internal_std.mass_percent'
+    _definition.update            2023-01-06
+    _description.text
+;
+    **DEPRECATED**
+    Please see _pd_qpa_internal_std.mass_percent.
+
+    Per cent presence of the internal standard specified by the
+    data item _pd_calib.std_internal_name expressed as 100 times
+    the mass of standard added divided by the sum of the mass of
+    standard added and the original sample mass.
+;
+    _name.category_id             pd_calib
+    _name.object_id               std_internal_mass_percent
+    _type.purpose                 Measurand
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:100.0
+    _units.code                   none
+
+save_
+
+save_pd_calib.std_internal_mass_percent_su
+
+    _definition.id                '_pd_calib.std_internal_mass_percent_su'
+    _definition_replaced.id       1
+    _definition_replaced.by       '_pd_qpa_internal_std.mass_percent_su'
+    _definition.update            2023-01-06
+    _description.text
+;
+    **DEPRECATED**
+    Please see _pd_qpa_internal_std.mass_percent_su.
+
+    Standard uncertainty of _pd_calib.std_internal_mass_percent.
+;
+    _name.category_id             pd_calib
+    _name.object_id               std_internal_mass_percent_su
+    _name.linked_item_id          '_pd_calib.std_internal_mass_percent'
+    _units.code                   none
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+save_
+
+save_pd_calib.std_internal_name
+
+    _definition.id                '_pd_calib.std_internal_name'
+    _definition_replaced.id       1
+    _definition_replaced.by       .
+    _alias.definition_id          '_pd_calib_std_internal_name'
+    _definition.update            2023-06-05
+    _description.text
+;
+    This item is deprecated. Please see PD_QPA_INTERNAL_STD for alternate
+    methods of identifying an internal standard.
+
+    Identity of material(s) used as an internal intensity standard.
+;
+    _name.category_id             pd_calib
+    _name.object_id               std_internal_name
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+
+    loop_
+      _description_example.case
+         'NIST 640a Silicon standard'
+         'Al2O3'
+
+save_
+
+save_PD_CALIB_D_TO_TOF
+
+    _definition.id                PD_CALIB_D_TO_TOF
+    _definition.scope             Category
+    _definition.class             Loop
+    _definition.update            2022-10-11
+    _description.text
+;
+    This section defines the parameters used for the calibration
+    of time-of-flight from d-spacing for neutron data.
+
+    The calibration equation is of the form:
+
+    TOF = Sum( c~i~ * d^p~i~, i=0:N)
+
+    where TOF is the time-of-flight in microseconds, d is the
+    d-spacing in angstroms, c~i~ is the ith coefficient, and
+    p~i~ is the ith power.
+
+    A loop is used to specify all terms of the correction
+    per histogram.
+;
+    _name.category_id             PD_GROUP
+    _name.object_id               PD_CALIB_D_TO_TOF
+
+    loop_
+      _category_key.name
+         '_pd_calib_d_to_tof.diffractogram_id'
+         '_pd_calib_d_to_tof.id'
+
+    loop_
+      _description_example.case
+      _description_example.detail
+;
+         loop_
+         _pd_calib_d_to_tof.id
+         _pd_calib_d_to_tof.power
+         _pd_calib_d_to_tof.coeff
+         0    0  -2.062
+         DIFC 1  746.8
+         t2   2  0.08099
+;
+;
+         Corresponds to the calibration equation:
+         time_of_flight =   -2.062
+                          + 746.8 * d_spacing
+                          + 0.08099 * d_spacing^2^
+;
+;
+         loop_
+         _pd_calib_d_to_tof.id
+         _pd_calib_d_to_tof.power
+         _pd_calib_d_to_tof.coeff
+         _pd_calib_d_to_tof.coeff_su
+         0     0   -2.062    2.09
+         DIFC  1   746.8     1.14
+         t2    2   0.08099   0.102
+         DIFB  -1  0.00232   0.0013
+;
+;
+         Corresponds to the calibration equation:
+         time_of_flight =   -2.062
+                          + 746.8 * d_spacing
+                          + 0.08099 * d_spacing^2^
+                          + 0.00232 / d_spacing
+;
+
+save_
+
+save_pd_calib_d_to_tof.coeff
+
+    _definition.id                '_pd_calib_d_to_tof.coeff'
+    _definition.update            2022-09-30
+    _description.text
+;
+    The value of the coefficient used in the equation to convert
+    d-spacing into time-of-flight.
+;
+    _name.category_id             pd_calib_d_to_tof
+    _name.object_id               coeff
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _method.purpose               Definition
+    _method.expression
+;
+    with pc as pd_calib_d_to_tof
+    if (pc.power == 0) {
+        _units.code = "microseconds"
+        }
+    else if (pc.power == 1) {
+        _units.code = "microseconds_per_angstrom"
+        }
+    else if (pc.power == 2) {
+        _units.code = "microseconds_per_angstrom_squared"
+        }
+    else if (pc.power == 3) {
+        _units.code = "microseconds_per_angstrom_cubed"
+    }
+    else if (pc.power == -1) {
+        _units.code = "angstroms_per_microsecond"
+    }
+    else _units.code = UNKNOWN
+;
+
+save_
+
+save_pd_calib_d_to_tof.coeff_su
+
+    _definition.id                '_pd_calib_d_to_tof.coeff_su'
+    _definition.update            2023-07-11
+    _description.text
+;
+    Standard uncertainty of _pd_calib_d_to_tof.coeff.
+;
+    _name.category_id             pd_calib_d_to_tof
+    _name.object_id               coeff_su
+    _name.linked_item_id          '_pd_calib_d_to_tof.coeff'
+    _type.purpose                 SU
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Real
+    _method.purpose               Definition
+    _method.expression
+;
+    with pc as pd_calib_d_to_tof
+    if (pc.power == 0) {
+        _units.code = "microseconds"
+        }
+    else if (pc.power == 1) {
+        _units.code = "microseconds_per_angstrom"
+        }
+    else if (pc.power == 2) {
+        _units.code = "microseconds_per_angstrom_squared"
+        }
+    else if (pc.power == 3) {
+        _units.code = "microseconds_per_angstrom_cubed"
+    }
+    else if (pc.power == -1) {
+        _units.code = "angstroms_per_microsecond"
+    }
+    else _units.code = UNKNOWN
+;
+
+save_
+
+save_pd_calib_d_to_tof.diffractogram_id
+
+    _definition.id                '_pd_calib_d_to_tof.diffractogram_id'
+    _definition.update            2023-01-12
+    _description.text
+;
+    The diffractogram (see _pd_diffractogram.id) to which the calibration
+    relates.
+;
+    _name.category_id             pd_calib_d_to_tof
+    _name.object_id               diffractogram_id
+    _name.linked_item_id          '_pd_diffractogram.id'
+    _type.purpose                 Link
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_pd_calib_d_to_tof.id
+
+    _definition.id                '_pd_calib_d_to_tof.id'
+    _definition.update            2022-09-30
+    _description.text
+;
+    An arbitrary code which identifies a specific term of the
+    calibration equation.
+;
+    _name.category_id             pd_calib_d_to_tof
+    _name.object_id               id
+    _type.purpose                 Key
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Code
+
+save_
+
+save_pd_calib_d_to_tof.power
+
+    _definition.id                '_pd_calib_d_to_tof.power'
+    _definition.update            2022-09-30
+    _description.text
+;
+    The value of the power used in the equation to convert
+    d-spacing into time-of-flight.
+;
+    _name.category_id             pd_calib_d_to_tof
+    _name.object_id               power
+    _type.purpose                 Number
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Real
+    _units.code                   none
+
+save_
+
+save_PD_CALIB_DETECTED_INTENSITY
+
+    _definition.id                PD_CALIB_DETECTED_INTENSITY
+    _definition.scope             Category
+    _definition.class             Loop
+    _definition.update            2023-01-21
+    _description.text
+;
+    This section defines the parameters used for the intensity calibration of
+    the detectors which are used directly or indirectly in the
+    interpretation of this data set. The information in this section of the CIF
+    should generally be written when the intensities are first measured, but
+    from then on should remain unchanged. Loops may be used for calibration
+    information that differs by detector channel or ID.
+
+    Common intensity calibration procedures include, but are not limited to:
+     i)  the application of a known, uniform, flood-field; or
+     ii) scanning a detector bank across a peak, or the direct-beam.
+
+    The above examples provide experimental methods to assign values to
+    _pd_calib_detected_intensity.detector_response which place each detector on
+    a common scale. Note that these are only indicative examples.
+
+    This category is only intended to record detector-related response to
+    a beam incident on the detector. To record variations in intensity during
+    the measurement of a diffractogram, see _pd_meas.intensity_monitor and
+    _pd_meas.counts_monitor.
+;
+    _name.category_id             PD_GROUP
+    _name.object_id               PD_CALIB_DETECTED_INTENSITY
+
+    loop_
+      _category_key.name
+         '_pd_calib_detected_intensity.detector_id'
+         '_pd_calib_detected_intensity.id'
+
+save_
+
+save_pd_calib_detected_intensity.detector_id
+
+    _definition.id                '_pd_calib_detected_intensity.detector_id'
+    _definition.update            2023-06-09
+    _description.text
+;
+    A code which identifies the detector or channel number in a
+    position-sensitive, energy-dispersive or other multiple-detector
+    instrument for which the individual instrument geometry is being
+    defined. This code should match the code name used for
+    _pd_instr_detector.id.
+;
+    _name.category_id             pd_calib_detected_intensity
+    _name.object_id               detector_id
+    _name.linked_item_id          '_pd_instr_detector.id'
+    _type.purpose                 Link
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Code
+
+save_
+
+save_pd_calib_detected_intensity.detector_response
+
+    _definition.id
+        '_pd_calib_detected_intensity.detector_response'
+    _definition.update            2023-04-07
+    _description.text
+;
+    A value that indicates the relative sensitivity of each detector. That is, a
+    value of 0.5 indicates that the detector records half as much intensity as
+    it should, and a value of 2 indicates that the detector records twice as
+    much intensity as it should. To bring all detectors on to a common scale,
+    the observed intensity should be divided by the value of
+    _pd_calib_detected_intensity.detector_response
+
+    This can compensate for differences in electronics, size and collimation.
+    Usually, one detector, or the mean for all detectors, will be assigned the
+    value of 1.
+;
+    _name.category_id             pd_calib_detected_intensity
+    _name.object_id               detector_response
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   none
+
+save_
+
+save_pd_calib_detected_intensity.detector_response_su
+
+    _definition.id
+        '_pd_calib_detected_intensity.detector_response_su'
+    _definition.update            2023-01-21
+    _description.text
+;
+    Standard uncertainty of _pd_calib_detected_intensity.detector_response.
+;
+    _name.category_id             pd_calib_detected_intensity
+    _name.object_id               detector_response_su
+    _name.linked_item_id
+        '_pd_calib_detected_intensity.detector_response'
+    _units.code                   none
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+save_
+
+save_pd_calib_detected_intensity.diffractogram_id
+
+    _definition.id
+        '_pd_calib_detected_intensity.diffractogram_id'
+    _definition.update            2023-01-21
+    _description.text
+;
+    A code which identifies the particular diffractogram from which this
+    intensity calibration was taken, if it was calibrated by a specimen.
+;
+    _name.category_id             pd_calib_detected_intensity
+    _name.object_id               diffractogram_id
+    _name.linked_item_id          '_pd_diffractogram.id'
+    _type.purpose                 Link
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_pd_calib_detected_intensity.id
+
+    _definition.id                '_pd_calib_detected_intensity.id'
+    _definition.update            2023-01-21
+    _description.text
+;
+    A code to uniquely identify each intensity calibration.
+;
+    _name.category_id             pd_calib_detected_intensity
+    _name.object_id               id
+    _type.purpose                 Key
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Text
+    _enumeration.default          .
+
+save_
+
+save_pd_calib_detected_intensity.phase_id
+
+    _definition.id                '_pd_calib_detected_intensity.phase_id'
+    _definition.update            2023-01-21
+    _description.text
+;
+    A code which identifies the particular phase from which this intensity was
+    taken, if it was calibrated by a specimen.
+;
+    _name.category_id             pd_calib_detected_intensity
+    _name.object_id               phase_id
+    _name.linked_item_id          '_pd_phase.id'
+    _type.purpose                 Link
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_pd_calib_detected_intensity.special_details
+
+    _definition.id                '_pd_calib_detected_intensity.special_details'
+    _definition.update            2023-01-21
+    _description.text
+;
+    Description of detected intensity calibration details that cannot otherwise
+    be recorded using other PD_CALIB_DETECTED_INTENSITY data items
+;
+    _name.category_id             pd_calib_detected_intensity
+    _name.object_id               special_details
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_PD_CALIB_INCIDENT_INTENSITY
+
+    _definition.id                PD_CALIB_INCIDENT_INTENSITY
+    _definition.scope             Category
+    _definition.class             Set
+    _definition.update            2023-06-10
+    _description.text
+;
+    This section defines the parameters used for the incident intensity
+    calibration of the instrument which is used directly or indirectly in the
+    interpretation of this data set. The information in this section of the CIF
+    should generally be written when the intensities are first measured, but
+    from then on should remain unchanged.
+
+    One common intensity calibration procedures involves data collection from a
+    standard amount of crystalline sample, which allows a value to be assigned
+    to _pd_calib_incident_intensity.incident_intensity, to place different
+    diffractograms on a common scale. Note that this is only an indicative
+    example.
+;
+    _name.category_id             PD_GROUP
+    _name.object_id               PD_CALIB_INCIDENT_INTENSITY
+    _category_key.name            '_pd_calib_incident_intensity.instr_id'
+
+save_
+
+save_pd_calib_incident_intensity.diffractogram_id
+
+    _definition.id
+        '_pd_calib_incident_intensity.diffractogram_id'
+    _definition.update            2023-01-21
+    _description.text
+;
+    A code which identifies the particular diffractogram from which this
+    intensity calibration was taken, if it was calibrated by a specimen.
+;
+    _name.category_id             pd_calib_incident_intensity
+    _name.object_id               diffractogram_id
+    _name.linked_item_id          '_pd_diffractogram.id'
+    _type.purpose                 Link
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_pd_calib_incident_intensity.incident_counts
+
+    _definition.id                '_pd_calib_incident_intensity.incident_counts'
+    _definition.update            2023-06-17
+    _description.text
+;
+    A value that indicates the number of counts incident on the specimen per
+    second. This value is a constant for each diffractogram. For point-wise
+    corrections, see _pd_meas.counts_monitor.
+
+    Standard uncertainties should not be quoted for this value. If the standard
+    uncertainties differ from the square root of the number of counts,
+    _pd_calib_incident_intensity.incident_intensity should be used.
+;
+    _name.category_id             pd_calib_incident_intensity
+    _name.object_id               incident_counts
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Integer
+    _enumeration.range            0:
+    _units.code                   counts_per_second
+
+save_
+
+save_pd_calib_incident_intensity.incident_intensity
+
+    _definition.id
+        '_pd_calib_incident_intensity.incident_intensity'
+    _definition.update            2023-01-21
+    _description.text
+;
+    A value that indicates the intensity incident on the specimen per second.
+    This value is a constant for each diffractogram. For point-wise corrections,
+    see _pd_meas.intensity_monitor.
+
+    Use this entry for measurements where intensity values are not counts (use
+    _pd_calib_incident_intensity.incident_counts for event-counting
+    measurements, where the standard uncertainty is estimated as the square root
+    of the number of counts).
+;
+    _name.category_id             pd_calib_incident_intensity
+    _name.object_id               incident_intensity
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   hertz
+
+save_
+
+save_pd_calib_incident_intensity.incident_intensity_su
+
+    _definition.id
+        '_pd_calib_incident_intensity.incident_intensity_su'
+    _definition.update            2023-06-17
+    _description.text
+;
+    Standard uncertainty of _pd_calib_incident_intensity.incident_intensity.
+;
+    _name.category_id             pd_calib_incident_intensity
+    _name.object_id               incident_intensity_su
+    _name.linked_item_id
+        '_pd_calib_incident_intensity.incident_intensity'
+    _units.code                   hertz
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+save_
+
+save_pd_calib_incident_intensity.instr_id
+
+    _definition.id                '_pd_calib_incident_intensity.instr_id'
+    _definition.update            2023-06-10
+    _description.text
+;
+    The instrument (see _pd_instr.id) to which the calibration relates.
+;
+    _name.category_id             pd_calib_incident_intensity
+    _name.object_id               instr_id
+    _name.linked_item_id          '_pd_instr.id'
+    _type.purpose                 Link
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_pd_calib_incident_intensity.phase_id
+
+    _definition.id                '_pd_calib_incident_intensity.phase_id'
+    _definition.update            2023-01-21
+    _description.text
+;
+    A code which identifies the particular phase from which this intensity was
+    taken, if it was calibrated by a specimen.
+;
+    _name.category_id             pd_calib_incident_intensity
+    _name.object_id               phase_id
+    _name.linked_item_id          '_pd_phase.id'
+    _type.purpose                 Link
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_pd_calib_incident_intensity.special_details
+
+    _definition.id                '_pd_calib_incident_intensity.special_details'
+    _definition.update            2023-01-21
+    _description.text
+;
+    Description of intensity calibration details that cannot otherwise be
+    recorded using other PD_CALIB_INCIDENT_INTENSITY data items
+;
+    _name.category_id             pd_calib_incident_intensity
+    _name.object_id               special_details
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_PD_CALIB_OFFSET
+
+    _definition.id                PD_CALIB_OFFSET
+    _definition.scope             Category
+    _definition.class             Loop
+    _definition.update            2023-06-05
+    _description.text
+;
+    This category is deprecated. Please see PD_CALIB_XCOORD and
+    PD_CALIB_XCOORD_OVERALL.
+
+    Data items in this category define an offset angle (in degrees)
+    used to calibrate 2θ (as defined in _pd_meas.2theta_*).
+    Calibration is done by adding the offset:
+
+         2θ~calibrated~ = 2θ~measured~ + 2θ~offset~
+
+    For cases where the _pd_calib.2theta_offset value is
+    not a constant, but rather varies with 2θ, a set
+    of offset values is supplied in a loop. In this case,
+    the value where the offset has been determined can be
+    specified as _pd_calib.2theta_off_point. Alternatively, a
+    range where the offset is applicable can be specified using
+    _pd_calib.2theta_off_min and _pd_calib.2theta_off_max.
+;
+    _name.category_id             PD_GROUP
+    _name.object_id               PD_CALIB_OFFSET
+
+    loop_
+      _category_key.name
+         '_pd_calib_offset.id'
+         '_pd_calib_offset.detector_id'
+
+save_
+
+save_pd_calib.2theta_off_max
+
+    _definition.id                '_pd_calib.2theta_off_max'
+
+    _definition_replaced.id       1
+    _definition_replaced.by       .
+
+    _alias.definition_id          '_pd_calib_2theta_off_max'
+    _definition.update            2023-06-05
+    _description.text
+;
+    This item is deprecated. Please see PD_CALIB_XCOORD. In general,
+    calibrations are now carried out over the given range, removing the need
+    to explicitly provide minima and maxima.
+
+    The maximum nominal 2θ value to which the offset given by
+    _pd_calib.2theta_offset applies.
+;
+    _name.category_id             pd_calib_offset
+    _name.object_id               2theta_off_max
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            -180.0:180.0
+    _units.code                   degrees
+
+save_
+
+save_pd_calib.2theta_off_min
+
+    _definition.id                '_pd_calib.2theta_off_min'
+
+    _definition_replaced.id       1
+    _definition_replaced.by       .
+
+    _alias.definition_id          '_pd_calib_2theta_off_min'
+    _definition.update            2023-06-05
+    _description.text
+;
+    This item is deprecated. Please see PD_CALIB_XCOORD. In general,
+    calibrations are now carried out over the given range, removing the need
+    to explicitly provide minima and maxima.
+
+    The minimum nominal 2θ value to which the offset given by
+    _pd_calib.2theta_offset applies.
+;
+    _name.category_id             pd_calib_offset
+    _name.object_id               2theta_off_min
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            -180.0:180.0
+    _units.code                   degrees
+
+save_
+
+save_pd_calib.2theta_off_point
+
+    _definition.id                '_pd_calib.2theta_off_point'
+
+    _definition_replaced.id       1
+    _definition_replaced.by       '_pd_calib_xcoord.2theta_nominal'
+
+    _alias.definition_id          '_pd_calib_2theta_off_point'
+    _definition.update            2023-06-05
+    _description.text
+;
+    This item is deprecated. Please see _pd_calib_xcoord.2theta_nominal.
+
+    The nominal 2θ value to which the offset given in
+    _pd_calib.2theta_offset applies.
+;
+    _name.category_id             pd_calib_offset
+    _name.object_id               2theta_off_point
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            -180.0:180.0
+    _units.code                   degrees
+
+save_
+
+save_pd_calib.2theta_offset
+
+    _definition.id                '_pd_calib.2theta_offset'
+
+    _definition_replaced.id       1
+    _definition_replaced.by       '_pd_calib_xcoord.2theta_offset'
+
+    _alias.definition_id          '_pd_calib_2theta_offset'
+    _definition.update            2023-06-05
+    _description.text
+;
+    This item is deprecated. Please see _pd_calib_xcoord.2theta_offset.
+
+    _pd_calib.2theta_offset defines an offset angle (in degrees)
+    used to calibrate 2θ (as defined in _pd_meas.2theta_*).
+    Calibration is done by adding the offset:
+
+         2θ~calibrated~ = 2θ~measured~ + 2θ~offset~
+;
+    _name.category_id             pd_calib_offset
+    _name.object_id               2theta_offset
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            -180.0:180.0
+    _units.code                   degrees
+
+save_
+
+save_pd_calib.2theta_offset_su
+
+    _definition.id                '_pd_calib.2theta_offset_su'
+
+    _definition_replaced.id       1
+    _definition_replaced.by       '_pd_calib_xcoord.2theta_offset_su'
+
+    _definition.update            2023-06-05
+    _description.text
+;
+    This item is deprecated. Please see _pd_calib_xcoord.2theta_offset_su.
+
+    Standard uncertainty of _pd_calib.2theta_offset.
+;
+    _name.category_id             pd_calib_offset
+    _name.object_id               2theta_offset_su
+    _name.linked_item_id          '_pd_calib.2theta_offset'
+    _units.code                   degrees
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+save_
+
+save_pd_calib_offset.detector_id
+
+    _definition.id                '_pd_calib_offset.detector_id'
+
+    _definition_replaced.id       1
+    _definition_replaced.by       '_pd_calib_xcoord_overall.detector_id'
+
+    _definition.update            2023-06-05
+    _description.text
+;
+    This item is deprecated. Please see _pd_calib_xcoord_overall.detector_id.
+
+    The detector to which the offset values relate.
+    As a default value is defined, the detector id may be
+    omitted if only a single detector is present.
+;
+    _name.category_id             pd_calib_offset
+    _name.object_id               detector_id
+    _name.linked_item_id          '_pd_calib.detector_id'
+    _type.purpose                 Link
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Code
+    _enumeration.default          .
+
+save_
+
+save_pd_calib_offset.id
+
+    _definition.id                '_pd_calib_offset.id'
+
+    _definition_replaced.id       1
+    _definition_replaced.by       '_pd_calib_xcoord.id'
+
+    _definition.update            2023-06-05
+    _description.text
+;
+    This item is deprecated. Please see _pd_calib_xcoord.id.
+
+    An arbitrary code which identifies a particular 2θ offset
+    description. As a default value is defined, this may be
+    omitted if only a single offset is provided.
+;
+    _name.category_id             pd_calib_offset
+    _name.object_id               id
+    _type.purpose                 Key
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Code
+    _enumeration.default          .
+
+save_
+
+save_PD_CALIB_STD
+
+    _definition.id                PD_CALIB_STD
+    _definition.scope             Category
+    _definition.class             Loop
+    _definition.update            2023-06-05
+    _description.text
+;
+    This category is deprecated. Please see PD_CALIB_DETECTED_INTENSITY,
+    PD_CALIB_INCIDENT_INTENSITY, PD_CALIB_WAVELENGTH, and
+    PD_CALIB_XCOORD_OVERALL.
+
+    This category identifies the external standards used for the calibration
+    of the instrument that are used directly or indirectly in the
+    interpretation of this data set. The information in this
+    section of the CIF should generally be written when the
+    intensities are first measured, but from then on should remain
+    unchanged. Loops may be used for calibration information that
+    differs by detector channel or when multiple standards are
+    used (for example, separately for angular and gain calibration).
+
+    For quantitative phase analysis by the external standard approach,
+    please see PD_QPA_EXTERNAL_STD.
+;
+    _name.category_id             PD_GROUP
+    _name.object_id               PD_CALIB_STD
+
+    loop_
+      _category_key.name
+         '_pd_calib_std.detector_id'
+         '_pd_calib_std.external_block_id'
+
+save_
+
+save_pd_calib_std.detector_id
+
+    _definition.id                '_pd_calib_std.detector_id'
+
+    loop_
+      _definition_replaced.id
+      _definition_replaced.by
+         1                        '_pd_calib_detected_intensity.detector_id'
+         2                        '_pd_calib_xcoord_overall.detector_id'
+
+    _definition.update            2023-06-09
+    _description.text
+;
+    This item is deprecated. Please see _pd_calib_detected_intensity.detector_id
+    or _pd_calib_xcoord_overall.detector_id, as necessary.
+
+    A code which identifies the detector or channel number in a
+    position-sensitive, energy-dispersive or other multiple-detector
+    instrument for which the individual instrument geometry is being
+    defined. This code should match the code name used for
+    _pd_instr_detector.id.
+;
+    _name.category_id             pd_calib_std
+    _name.object_id               detector_id
+    _name.linked_item_id          '_pd_instr_detector.id'
+    _type.purpose                 Link
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Code
+
+    _enumeration.default          .
+
+save_
+
+save_pd_calib_std.external_block_id
+
+    _definition.id                '_pd_calib_std.external_block_id'
+
+    loop_
+      _definition_replaced.id
+      _definition_replaced.by
+         1                      '_pd_calib_detected_intensity.diffractogram_id'
+         2                      '_pd_calib_incident_intensity.diffractogram_id'
+         3                      '_pd_calib_wavelength.diffractogram_id'
+         4                      '_pd_calib_xcoord_overall.diffractogram_id'
+
+    _alias.definition_id          '_pd_calib_std_external_block_id'
+    _definition.update            2023-06-05
+    _description.text
+;
+    This item is deprecated. Please see:
+      - _pd_calib_detected_intensity.diffractogram_id
+      - _pd_calib_incident_intensity.diffractogram_id
+      - _pd_calib_wavelength.diffractogram_id
+      - _pd_calib_xcoord_overall.diffractogram_id
+    as necessary.
+
+    Identifies the _pd_block.id used as an external standard for the
+    diffraction angle or the intensity calibrations.
+
+    For quantitative phase analysis by the external standard approach,
+    please see PD_QPA_EXTERNAL_STD.
+;
+    _name.category_id             pd_calib_std
+    _name.object_id               external_block_id
+    _name.linked_item_id          '_pd_block.id'
+    _type.purpose                 Link
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_pd_calib_std.external_name
+
+    _definition.id                '_pd_calib_std.external_name'
+    _definition_replaced.id       1
+    _definition_replaced.by       .
+    _alias.definition_id          '_pd_calib_std_external_name'
+    _definition.update            2023-06-05
+    _description.text
+;
+    This item is deprecated. Please see:
+      - PD_CALIB_DETECTED_INTENSITY
+      - PD_CALIB_INCIDENT_INTENSITY
+      - PD_CALIB_WAVELENGTH
+      - PD_CALIB_XCOORD
+      - PD_CALIB_XCOORD_OVERALL
+    as necessary, for information on how to identify the external standard used.
+
+    Identifies the name of the material used as an external standard for
+    the diffraction angle or the intensity calibrations.
+;
+    _name.category_id             pd_calib_std
+    _name.object_id               external_name
+    _type.purpose                 Describe
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_PD_CALIB_WAVELENGTH
+
+    _definition.id                PD_CALIB_WAVELENGTH
+    _definition.scope             Category
+    _definition.class             Loop
+    _definition.update            2023-01-17
+    _description.text
+;
+    This category allows for linking to the diffractograms and phases used in
+    the calibration of the wavelength used directly or indirectly in the
+    interpretation of this data set.
+
+    Loops may be used when multiple phases and/or diffractograms are used for
+    calibration. In this case, the given wavelength is a best-fit to all phases
+    and diffractograms.
+
+    See also _diffrn_radiation_wavelength.determination.
+;
+    _name.category_id             PD_GROUP
+    _name.object_id               PD_CALIB_WAVELENGTH
+
+    loop_
+      _category_key.name
+         '_pd_calib_wavelength.diffractogram_id'
+         '_pd_calib_wavelength.diffrn_id'
+         '_pd_calib_wavelength.phase_id'
+
+    loop_
+      _description_example.case
+      _description_example.detail
+;
+       _audit.schema            Custom
+
+       loop_
+       _pd_calib_wavelength.diffrn_id
+       _pd_calib_wavelength.diffractogram_id
+       _pd_calib_wavelength.phase_id
+       DIFFRN_EXP_1   DIFFRACTOGRAM_1   NIST_SILICON
+       DIFFRN_EXP_1   DIFFRACTOGRAM_1   NIST_LAB6
+       DIFFRN_EXP_1   DIFFRACTOGRAM_2   NIST_SILICON
+       DIFFRN_EXP_1   DIFFRACTOGRAM_2   NIST_LAB6
+;
+;
+       The incident wavelength used in the measurement identified by the
+       _diffrn.id 'DIFFRN_EXP_1' was refined from two different
+       diffractograms with _pd_diffractogram.id values of 'DIFFRACTOGRAM_1'
+       and 'DIFFRACTOGRAM_2'. In these diffractograms, the same two phases
+       appeared, with _pd_phase.id values of 'NIST_SILICON' and 'NIST_LAB6',
+       As more than one diffractogram and phase was used, the wavelength
+       is a best-fit over all data. Because information relating to
+       more than one diffractogram and phase is collected in a single
+       data block, _audit.schema is set to "Custom".
+;
+;
+       _diffrn.id                              DIFFRN_EXP_A
+       _pd_calib_wavelength.diffractogram_id   DIFFRACTOGRAM_A
+       _pd_calib_wavelength.phase_id           ACME_CORUNDUM
+;
+;
+       The incident wavelength used in the measurement identified by the
+       _diffrn.id 'DIFFRN_EXP_A' was refined from a diffractogram with a
+       _pd_diffractogram.id value of 'DIFFRACTOGRAM_A'. In this
+       diffractogram, a phase with a _pd_phase.id value of 'ACME_CORUNDUM'
+       was used to calibrate the wavelength against known unit cell
+       parameters.
+;
+
+save_
+
+save_pd_calib_wavelength.diffractogram_id
+
+    _definition.id                '_pd_calib_wavelength.diffractogram_id'
+    _definition.update            2023-01-17
+    _description.text
+;
+    A code which identifies a diffractogram which was used in the calibration of
+    the wavelength.
+;
+    _name.category_id             pd_calib_wavelength
+    _name.object_id               diffractogram_id
+    _name.linked_item_id          '_pd_diffractogram.id'
+    _type.purpose                 Link
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_pd_calib_wavelength.diffrn_id
+
+    _definition.id                '_pd_calib_wavelength.diffrn_id'
+    _definition.update            2023-01-17
+    _description.text
+;
+    A code which identifies the diffraction experiment to which this calibration
+    belongs.
+;
+    _name.category_id             pd_calib_wavelength
+    _name.object_id               diffrn_id
+    _name.linked_item_id          '_diffrn.id'
+    _type.purpose                 Link
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Word
+
+save_
+
+save_pd_calib_wavelength.phase_id
+
+    _definition.id                '_pd_calib_wavelength.phase_id'
+    _definition.update            2023-01-17
+    _description.text
+;
+    A code which identifies a phase whose cell parameters were used in the
+    calibration of the wavelength.
+;
+    _name.category_id             pd_calib_wavelength
+    _name.object_id               phase_id
+    _name.linked_item_id          '_pd_phase.id'
+    _type.purpose                 Link
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_pd_calib_wavelength.special_details
+
+    _definition.id                '_pd_calib_wavelength.special_details'
+    _definition.update            2023-01-17
+    _description.text
+;
+    Description of intensity calibration details that cannot otherwise be
+    recorded using other PD_CALIB_WAVELENGTH data items
+;
+    _name.category_id             pd_calib_wavelength
+    _name.object_id               special_details
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_PD_CALIB_XCOORD
+
+    _definition.id                PD_CALIB_XCOORD
+    _definition.scope             Category
+    _definition.class             Loop
+    _definition.update            2023-06-10
+    _description.text
+;
+    This section defines the parameters used for the calibration of the
+    X-coordinate axis of the instrument used directly or indirectly in the
+    interpretation of this data set; that is, 2\q, time-of-flight, or
+    position.
+
+    Calibration is carried out be adding the offset value:
+
+        X-coord~calibrated~ = X-coord~meas~ + X-coord~offset~
+
+    For cases where the offset value is not a constant, but rather varies
+    with X-coordinate, a set of offset values is supplied in a loop. In this
+    case, the value where the offset has been determined can be specified as
+    _pd_calib_xcoord.*_nominal. These values may need to be interpolated to
+    be applied to their respective diffractograms.
+
+    Alternatively, if the offset has been determined at each measurement
+    point in the diffractogram, _pd_calib_xcoord.point_id may be used to
+    specify the offset on a per-point basis.
+;
+    _name.category_id             PD_GROUP
+    _name.object_id               PD_CALIB_XCOORD
+
+    loop_
+      _category_key.name
+         '_pd_calib_xcoord.diffractogram_id'
+         '_pd_calib_xcoord.id'
+
+    loop_
+      _description_example.case
+      _description_example.detail
+;
+         _pd_diffractogram.id   A_DIFFRACTION_PATTERN
+         loop_
+          _pd_calib_xcoord.point_id
+          _pd_calib_xcoord.2theta_offset
+          1   0.01
+          2   0.01
+          3   0.02
+          4   0.02
+          ...
+
+          loop_
+          _pd_data.point_id
+          _pd_meas.2theta_scan
+          _pd_meas.counts_total
+          _pd_calc.intensity_total
+          1   10.01   1234    1234.1
+          2   10.03   1235    1235.3
+          3   10.05   1352    1236.5
+          4   10.07   1324    1237.7
+          ...
+;
+;
+         Calibration offset values are provided for each data point in the
+         diffractogram.
+;
+;
+         _pd_diffractogram.id   A_DIFFRACTION_PATTERN
+         loop_
+          _pd_calib_xcoord.id
+          _pd_calib_xcoord.2theta_nominal
+          _pd_calib_xcoord.2theta_offset
+          a   10.00   0.01
+          b   12.00   0.02
+          c   14.00   0.03
+          d   16.00   0.04
+          ...
+
+          loop_
+          _pd_data.point_id
+          _pd_meas.2theta_scan
+          _pd_meas.counts_total
+          _pd_calc.intensity_total
+          1   10.01   1234    1234.1
+          2   10.03   1235    1235.3
+          3   10.05   1352    1236.5
+          4   10.07   1324    1237.7
+          ...
+;
+;
+         Calibration offsets and the nominal 2\q values to which they apply are
+         listed, along with the diffraction pattern to which they apply. With
+         the given calibration data, an interpolation must be made to obtain a
+         value for each data point.
+;
+;
+            loop_
+            _pd_calib_xcoord_overall.id
+            _pd_calib_xcoord_overall.detector_id
+            _pd_calib_xcoord_overall.diffractogram_id
+            _pd_calib_xcoord_overall.phase_id
+            _pd_calib_xcoord_overall.special_details
+            A   det1   CALIBRATION_DIFFRACTOGRAM   NIST_SRM640E   .
+            B   det2   .   .   "Scanned through direct beam with fine slit."
+
+          loop_
+          _pd_calib_xcoord.id
+          _pd_calib_xcoord.position_nominal
+          _pd_calib_xcoord.position_offset
+          _pd_calib_xcoord.overall_id
+          a   10.00   0.01   A
+          b   10.00   0.02   B
+          c   12.00   0.03   A
+          d   12.00   0.03   B
+          ...
+;
+;
+         Calibration offsets and the nominal position values to which they apply
+         are listed. The given _pd_calib_xcoord.overall_id refers to the
+         PD_CALIB_XCOORD_OVERALL category items given above.
+
+         An interpolation must be made to obtain a value for each data point.
+;
+
+save_
+
+save_pd_calib_xcoord.2theta_nominal
+
+    _definition.id                '_pd_calib_xcoord.2theta_nominal'
+    _definition.update            2023-01-17
+    _description.text
+;
+    The nominal 2\q value to which the offset given in
+    _pd_calib_xcoord.2theta_offset applies.
+;
+    _name.category_id             pd_calib_xcoord
+    _name.object_id               2theta_nominal
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            -180.0:180.0
+    _units.code                   degrees
+
+save_
+
+save_pd_calib_xcoord.2theta_offset
+
+    _definition.id                '_pd_calib_xcoord.2theta_offset'
+    _definition.update            2023-01-17
+    _description.text
+;
+    _pd_calib_xcoord.2theta_offset defines an offset angle (in degrees) used
+    to calibrate 2\q (as defined in _pd_meas.2theta_). Calibration is done
+    by adding the offset:
+
+         2\q~calibrated~ = 2\q~measured~ + 2\q~offset~
+;
+    _name.category_id             pd_calib_xcoord
+    _name.object_id               2theta_offset
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            -180.0:180.0
+    _units.code                   degrees
+
+save_
+
+save_pd_calib_xcoord.2theta_offset_su
+
+    _definition.id                '_pd_calib_xcoord.2theta_offset_su'
+    _definition.update            2023-01-17
+    _description.text
+;
+    Standard uncertainty of _pd_calib_xcoord.2theta_offset.
+;
+    _name.category_id             pd_calib_xcoord
+    _name.object_id               2theta_offset_su
+    _name.linked_item_id          '_pd_calib_xcoord.2theta_offset'
+    _units.code                   degrees
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+save_
+
+save_pd_calib_xcoord.diffractogram_id
+
+    _definition.id                '_pd_calib_xcoord.diffractogram_id'
+    _definition.update            2023-06-10
+    _description.text
+;
+    The diffractogram (see _pd_diffractogram.id) to which the calibration
+    relates.
+;
+    _name.category_id             pd_calib_xcoord
+    _name.object_id               diffractogram_id
+    _name.linked_item_id          '_pd_diffractogram.id'
+    _type.purpose                 Link
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_pd_calib_xcoord.id
+
+    _definition.id                '_pd_calib_xcoord.id'
+    _definition.update            2023-01-17
+    _description.text
+;
+    A code to uniquely identify each X-coordinate calibration.
+;
+    _name.category_id             pd_calib_xcoord
+    _name.object_id               id
+    _type.purpose                 Key
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_pd_calib_xcoord.overall_id
+
+    _definition.id                '_pd_calib_xcoord.overall_id'
+    _definition.update            2023-05-06
+    _description.text
+;
+    A code which identifies the particular set of overall calibration conditions
+    under which the calibration was calculated.
+;
+    _name.category_id             pd_calib_xcoord
+    _name.object_id               overall_id
+    _name.linked_item_id          '_pd_calib_xcoord_overall.id'
+    _type.purpose                 Link
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_pd_calib_xcoord.point_id
+
+    _definition.id                '_pd_calib_xcoord.point_id'
+    _definition.update            2023-01-17
+    _description.text
+;
+    Arbitrary label identifying a data point in a diffractogram. Used to
+    identify a specific entry in a list of values forming the diffractogram
+    to which the X-coordinate calibration applies.
+;
+    _name.category_id             pd_calib_xcoord
+    _name.object_id               point_id
+    _name.linked_item_id          '_pd_data.point_id'
+    _type.purpose                 Link
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Code
+
+save_
+
+save_pd_calib_xcoord.position_nominal
+
+    _definition.id                '_pd_calib_xcoord.position_nominal'
+    _definition.update            2023-01-17
+    _description.text
+;
+    The nominal position value to which the offset given in
+    _pd_calib_xcoord.position_offset applies.
+;
+    _name.category_id             pd_calib_xcoord
+    _name.object_id               position_nominal
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _units.code                   millimetres
+
+save_
+
+save_pd_calib_xcoord.position_offset
+
+    _definition.id                '_pd_calib_xcoord.position_offset'
+    _definition.update            2023-01-17
+    _description.text
+;
+    _pd_calib_xcoord.position_offset defines an offset position (in
+    millimetres) used to calibrate position (as defined in
+    _pd_meas.position). Calibration is done by adding the offset:
+
+         position~calibrated~ = position~measured~ + position~offset~
+;
+    _name.category_id             pd_calib_xcoord
+    _name.object_id               position_offset
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _units.code                   millimetres
+
+save_
+
+save_pd_calib_xcoord.position_offset_su
+
+    _definition.id                '_pd_calib_xcoord.position_offset_su'
+    _definition.update            2023-01-17
+    _description.text
+;
+    Standard uncertainty of _pd_calib_xcoord.position_offset.
+;
+    _name.category_id             pd_calib_xcoord
+    _name.object_id               position_offset_su
+    _name.linked_item_id          '_pd_calib_xcoord.position_offset'
+    _units.code                   millimetres
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+save_
+
+save_pd_calib_xcoord.time_of_flight_nominal
+
+    _definition.id                '_pd_calib_xcoord.time_of_flight_nominal'
+    _definition.update            2023-01-17
+    _description.text
+;
+    The nominal time-of-flight value to which the offset given in
+    _pd_calib_xcoord.time_of_flight_offset applies.
+;
+    _name.category_id             pd_calib_xcoord
+    _name.object_id               time_of_flight_nominal
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _units.code                   microseconds
+
+save_
+
+save_pd_calib_xcoord.time_of_flight_offset
+
+    _definition.id                '_pd_calib_xcoord.time_of_flight_offset'
+    _definition.update            2023-01-17
+    _description.text
+;
+    _pd_calib_xcoord.time_of_flight_offset defines an offset time (in
+    microseconds) used to calibrate time-of-flight (TOF) (as defined in
+    _pd_meas.time_of_flight). Calibration is done by adding the offset:
+
+    TOF~calibrated~ = TOF~measured~ + TOF~offset~
+;
+    _name.category_id             pd_calib_xcoord
+    _name.object_id               time_of_flight_offset
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _units.code                   microseconds
+
+save_
+
+save_pd_calib_xcoord.time_of_flight_offset_su
+
+    _definition.id                '_pd_calib_xcoord.time_of_flight_offset_su'
+    _definition.update            2023-01-17
+    _description.text
+;
+    Standard uncertainty of _pd_calib_xcoord.time_of_flight_offset.
+;
+    _name.category_id             pd_calib_xcoord
+    _name.object_id               time_of_flight_offset_su
+    _name.linked_item_id          '_pd_calib_xcoord.time_of_flight_offset'
+    _units.code                   microseconds
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+save_
+
+save_PD_CALIB_XCOORD_OVERALL
+
+    _definition.id                PD_CALIB_XCOORD_OVERALL
+    _definition.scope             Category
+    _definition.class             Loop
+    _definition.update            2023-05-06
+    _description.text
+;
+    This category gives the overall information about the x-coordinate
+    calibration applied to a given diffractogram.
+;
+    _name.category_id             PD_GROUP
+    _name.object_id               PD_CALIB_XCOORD_OVERALL
+
+    loop_
+      _category_key.name
+         '_pd_calib_xcoord_overall.detector_id'
+         '_pd_calib_xcoord_overall.id'
+
+    loop_
+      _description_example.case
+      _description_example.detail
+;
+         loop_
+         _pd_calib_xcoord_overall.id
+         _pd_calib_xcoord_overall.detector_id
+         d1   det1
+         d2   det2
+;
+;
+         Calibration offsets given using PD_CALIB_XCOORD category data items
+         will correspond to calibrations carried out on the given two detectors.
+;
+;
+         loop_
+         _pd_calib_xcoord_overall.id
+         _pd_calib_xcoord_overall.detector_id
+         _pd_calib_xcoord_overall.diffractogram_id
+         _pd_calib_xcoord_overall.phase_id
+         1   A   CALIBRATION_DIFFRACTOGRAM_A   NIST_SRM640E
+         2   B   CALIBRATION_DIFFRACTOGRAM_B   NIST_SRM640E
+         3   C   CALIBRATION_DIFFRACTOGRAM_C   NIST_SRM640E
+;
+;
+         Calibration offsets given using PD_CALIB_XCOORD category data items
+         will correspond to calibrations carried out on the given three
+         detectors derived from analysis of the given diffractograms and phase.
+
+         Calibration values will be given using PD_CALIB_XCOORD category data
+         items.
+;
+;
+         loop_
+         _pd_calib_xcoord_overall.id
+         _pd_calib_xcoord_overall.detector_id
+         _pd_calib_xcoord_overall.diffractogram_id
+         _pd_calib_xcoord_overall.phase_id
+         _pd_calib_xcoord_overall.special_details
+         A   det1   CALIBRATION_DIFFRACTOGRAM   NIST_SRM640E   .
+         B   det2   .   .   "Scanned through direct beam with fine slit."
+;
+;
+         Different detectors can be calibrated through different means. Here,
+         det1 was calibrated through the analysis of a diffractogram and a
+         known reference material, whereas det2 was calibrated by scanning the
+         detector through the direct beam.
+
+         Calibration values will be given using PD_CALIB_XCOORD category data
+         items.
+;
+
+save_
+
+save_pd_calib_xcoord_overall.detector_id
+
+    _definition.id                '_pd_calib_xcoord_overall.detector_id'
+    _definition.update            2023-06-09
+    _description.text
+;
+    A code which identifies the detector or channel number in a
+    position-sensitive, energy-dispersive or other multiple-detector
+    instrument for which the individual instrument geometry is being
+    defined. This code should match the code name used for
+    _pd_instr_detector.id.
+;
+    _name.category_id             pd_calib_xcoord_overall
+    _name.object_id               detector_id
+    _name.linked_item_id          '_pd_instr_detector.id'
+    _type.purpose                 Link
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Code
+
+save_
+
+save_pd_calib_xcoord_overall.diffractogram_id
+
+    _definition.id                '_pd_calib_xcoord_overall.diffractogram_id'
+    _definition.update            2023-05-06
+    _description.text
+;
+    A code which identifies the particular diffractogram from which this
+    X-coordinate calibration was taken, if it was calibrated by a specimen.
+;
+    _name.category_id             pd_calib_xcoord_overall
+    _name.object_id               diffractogram_id
+    _name.linked_item_id          '_pd_diffractogram.id'
+    _type.purpose                 Link
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_pd_calib_xcoord_overall.id
+
+    _definition.id                '_pd_calib_xcoord_overall.id'
+    _definition.update            2023-05-06
+    _description.text
+;
+    A code to uniquely identify the overall values associated with a group of
+    calibration points.
+;
+    _name.category_id             pd_calib_xcoord_overall
+    _name.object_id               id
+    _type.purpose                 Key
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_pd_calib_xcoord_overall.phase_id
+
+    _definition.id                '_pd_calib_xcoord_overall.phase_id'
+    _definition.update            2023-05-06
+    _description.text
+;
+    A code which identifies the particular phase used in calibrating the
+    X-coordinate, if it was calibrated by a specimen. The phase can be
+    an internal or external standard.
+;
+    _name.category_id             pd_calib_xcoord_overall
+    _name.object_id               phase_id
+    _name.linked_item_id          '_pd_phase.id'
+    _type.purpose                 Link
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_pd_calib_xcoord_overall.special_details
+
+    _definition.id                '_pd_calib_xcoord_overall.special_details'
+    _definition.update            2023-05-06
+    _description.text
+;
+    Description of X-coordinate calibration details that cannot otherwise
+    be recorded using other PD_CALIB_XCOORD_OVERALL data items.
+;
+    _name.category_id             pd_calib_xcoord_overall
+    _name.object_id               special_details
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_PD_CALIBRATION
+
+    _definition.id                PD_CALIBRATION
+    _definition.scope             Category
+    _definition.class             Set
+    _definition.update            2016-10-17
+    _description.text
+;
+    This section contains calibration information that is
+    not looped
+;
+    _name.category_id             PD_GROUP
+    _name.object_id               PD_CALIBRATION
+
+save_
+
+save_pd_calibration.conversion_eqn
+
+    _definition.id                '_pd_calibration.conversion_eqn'
+    _alias.definition_id          '_pd_calibration_conversion_eqn'
+    _definition.update            2023-01-21
+    _description.text
+;
+    The calibration function for converting a channel number
+    supplied in _pd_meas.detector_id for a position-sensitive
+    or energy-dispersive detector or the distance supplied in
+    _pd_meas.position to Q, energy, angle etc.
+
+    Use _pd_calib_std.external_block_id to define a pointer to
+    the data block containing the data used to determine the
+    parameter values in this function.
+;
+    _name.category_id             pd_calibration
+    _name.object_id               conversion_eqn
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+    _description_example.case
+;
+    2θ~actual~ = 2θ~setting~ + arctan(
+     cos(P~1~) / {1/[P~0~ (CC - CH~0~ - P~2~ CC^2^)] - sin(P~1~)})
+;
+
+save_
+
+save_pd_calibration.special_details
+
+    _definition.id                '_pd_calibration.special_details'
+    _alias.definition_id          '_pd_calibration_special_details'
+    _definition.update            2016-10-17
+    _description.text
+;
+    Description of how the instrument was
+    calibrated, particularly for instruments where
+    calibration information is used to make hardware
+    settings that would otherwise be invisible once data
+    collection is completed. Do not use this item to specify
+    information that can be specified using other
+    PD_CALIBRATION or PD_CALIB items.
+;
+    _name.category_id             pd_calibration
+    _name.object_id               special_details
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_PD_CHAR
+
+    _definition.id                PD_CHAR
+    _definition.scope             Category
+    _definition.class             Set
+    _definition.update            2023-06-04
+    _description.text
+;
+    This section contains experimental (non-diffraction) information relevant to
+    the chemical and physical nature of the material from which the sample is
+    drawn.
+
+    'Specimen', 'sample', and 'material' have specific meanings, and sometimes
+    cannot be specifically deliniated. The 'specimen' is the artefact placed
+    into the beam from which the diffraction measurement is taken, and is
+    described in PD_SPEC. The specimen is made from the 'sample', which can have
+    information specified in PD_PREP. The sample is drawn from a 'material',
+    which may exist in an actual or idealised sense, which can have information
+    specified in PD_CHAR. For example: the material might be BaTiO3, the
+    sample might be a specific batch from a specific manufacturer, and the
+    specimen is the material taken from the bottle and placed in the instrument.
+
+;
+    _name.category_id             PD_GROUP
+    _name.object_id               PD_CHAR
+    _category_key.name            '_pd_char.id'
+
+save_
+
+save_pd_char.atten_coef_mu_calc
+
+    _definition.id                '_pd_char.atten_coef_mu_calc'
+    _alias.definition_id          '_pd_char_atten_coef_mu_calc'
+    _definition.update            2023-01-22
+    _description.text
+;
+    The calculated linear attenuation coefficient, μ, in units
+    of inverse millimetres, also known as the linear absorption
+    coefficient. The value is obtained from the atomic content of
+    each of the phases in the material, the average density
+    (allowing for packing density), and the radiation wavelength.
+    Note that _pd_char.atten_coef_mu_calc will differ from the value
+    based on phase quantities and _exptl_absorpt.coefficient_mu for
+    each phase if the packing density is not unity.
+;
+    _name.category_id             pd_char
+    _name.object_id               atten_coef_mu_calc
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   reciprocal_millimetres
+
+save_
+
+save_pd_char.atten_coef_mu_calc_su
+
+    _definition.id                '_pd_char.atten_coef_mu_calc_su'
+    _definition.update            2022-10-27
+    _description.text
+;
+    Standard uncertainty of _pd_char.atten_coef_mu_calc.
+;
+    _name.category_id             pd_char
+    _name.object_id               atten_coef_mu_calc_su
+    _name.linked_item_id          '_pd_char.atten_coef_mu_calc'
+    _units.code                   reciprocal_millimetres
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+save_
+
+save_pd_char.atten_coef_mu_obs
+
+    _definition.id                '_pd_char.atten_coef_mu_obs'
+    _alias.definition_id          '_pd_char_atten_coef_mu_obs'
+    _definition.update            2022-10-11
+    _description.text
+;
+    The observed linear attenuation coefficient, μ, in units
+    of inverse millimetres, also known as the linear absorption
+    coefficient. The value is determined by a transmission
+    measurement.
+;
+    _name.category_id             pd_char
+    _name.object_id               atten_coef_mu_obs
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   reciprocal_millimetres
+
+save_
+
+save_pd_char.atten_coef_mu_obs_su
+
+    _definition.id                '_pd_char.atten_coef_mu_obs_su'
+    _definition.update            2022-10-27
+    _description.text
+;
+    Standard uncertainty of _pd_char.atten_coef_mu_obs.
+;
+    _name.category_id             pd_char
+    _name.object_id               atten_coef_mu_obs_su
+    _name.linked_item_id          '_pd_char.atten_coef_mu_obs'
+    _units.code                   reciprocal_millimetres
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+save_
+
+save_pd_char.colour
+
+    _definition.id                '_pd_char.colour'
+    _alias.definition_id          '_pd_char_colour'
+    _definition.update            2014-06-20
+    _description.text
+;
+    The colour of the material used for the measurement.
+    To facilitate more standardized use of names, the
+    following guidelines for colour naming developed by
+    Peter Bayliss for the International Centre for
+    Diffraction Data (ICDD) should be followed. Note that
+    combinations of descriptors are separated by an
+    underscore.
+
+    Allowed colours are:
+      colourless, white, black, gray, brown, red, pink,
+      orange, yellow, green, blue, violet.
+
+    Colours may be modified using prefixes of:
+      light, dark, whitish, blackish, grayish, brownish,
+      reddish, pinkish, orangish, yellowish, greenish, bluish.
+
+    Intermediate hues may be indicated with two colours:
+    e.g. blue_green or bluish_green.
+
+    For metallic materials, the term metallic may be added:
+    e.g. reddish_orange_metallic for copper.
+
+    The ICDD standard allows commas to be used for minerals
+    that occur with ranges of colours; however this usage is
+    not appropriate for the description of a single sample.
+;
+    _name.category_id             pd_char
+    _name.object_id               colour
+    _type.purpose                 Encode
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Code
+
+    loop_
+      _description_example.case
+         dark_green
+         orange_red
+         brownish_red
+         yellow_metallic
+
+save_
+
+save_pd_char.id
+
+    _definition.id                '_pd_char.id'
+    _definition.update            2023-06-04
+    _description.text
+;
+    Arbitrary label identifying a material.
+;
+    _name.category_id             pd_char
+    _name.object_id               id
+    _type.purpose                 Key
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_pd_char.mass_atten_coef_mu_calc
+
+    _definition.id                '_pd_char.mass_atten_coef_mu_calc'
+    _definition.update            2022-10-11
+    _description.text
+;
+    The calculated mass attenuation coefficient, μ^*^, in units of square
+    millimetres per gram, also known as the mass absorption coefficient. The
+    calculated μ^*^ will be obtained from the atomic content of each phase and
+    the radiation wavelength.
+;
+    _name.category_id             pd_char
+    _name.object_id               mass_atten_coef_mu_calc
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   millimetres_squared_per_gram
+
+save_
+
+save_pd_char.mass_atten_coef_mu_calc_su
+
+    _definition.id                '_pd_char.mass_atten_coef_mu_calc_su'
+    _definition.update            2022-10-27
+    _description.text
+;
+    Standard uncertainty of _pd_char.mass_atten_coef_mu_calc.
+;
+    _name.category_id             pd_char
+    _name.object_id               mass_atten_coef_mu_calc_su
+    _name.linked_item_id          '_pd_char.mass_atten_coef_mu_calc'
+    _units.code                   millimetres_squared_per_gram
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+save_
+
+save_pd_char.mass_atten_coef_mu_meas
+
+    _definition.id                '_pd_char.mass_atten_coef_mu_meas'
+    _definition.update            2023-01-16
+    _description.text
+;
+    The measured mass attenuation coefficient, μ^*^, in units of square
+    millimetres per gram, also known as the mass absorption coefficient. The
+    measured μ^*^ will be normally be determined by a transmission measurement
+    coupled with a density measurement.
+;
+    _name.category_id             pd_char
+    _name.object_id               mass_atten_coef_mu_meas
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   millimetres_squared_per_gram
+
+save_
+
+save_pd_char.mass_atten_coef_mu_meas_su
+
+    _definition.id                '_pd_char.mass_atten_coef_mu_meas_su'
+    _definition.update            2023-01-16
+    _description.text
+;
+    Standard uncertainty of _pd_char.mass_atten_coef_mu_meas.
+;
+    _name.category_id             pd_char
+    _name.object_id               mass_atten_coef_mu_meas_su
+    _name.linked_item_id          '_pd_char.mass_atten_coef_mu_meas'
+    _units.code                   millimetres_squared_per_gram
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+save_
+
+save_pd_char.particle_morphology
+
+    _definition.id                '_pd_char.particle_morphology'
+    _alias.definition_id          '_pd_char_particle_morphology'
+    _definition.update            2014-06-20
+    _description.text
+;
+    A description of the sample morphology and estimates for
+    particle sizes (before grinding/sieving, if noted by
+    _pd_spec.preparation). Include the method used for
+    these estimates (SEM, visual estimate etc.).
+;
+    _name.category_id             pd_char
+    _name.object_id               particle_morphology
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_pd_char.special_details
+
+    _definition.id                '_pd_char.special_details'
+    _alias.definition_id          '_pd_char_special_details'
+    _definition.update            2014-06-20
+    _description.text
+;
+    Additional characterization information relevant to the sample
+    or documentation of non-routine processing steps used
+    for characterization.
+;
+    _name.category_id             pd_char
+    _name.object_id               special_details
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_PD_DATA
+
+    _definition.id                PD_DATA
+    _definition.scope             Category
+    _definition.class             Loop
+    _definition.update            2022-10-11
+    _description.text
+;
+    The PD_DATA category is a "container" category that is defined
+    in order to allow raw, processed, and calculated data points
+    in a diffraction data set to be optionally tabulated together.
+    As PD_CALC, PD_MEAS, and PD_PROC are all subcategories of this
+    category, the various items belonging to those categories may
+    be looped together or separately, as desired.
+;
+    _name.category_id             PD_GROUP
+    _name.object_id               PD_DATA
+
+    loop_
+      _category_key.name
+         '_pd_data.point_id'
+         '_pd_data.diffractogram_id'
+
+    loop_
+      _description_example.case
+      _description_example.detail
+;
+         loop_
+         _pd_data.point_id
+         _pd_meas.2theta_scan
+         _pd_meas.intensity_total
+         _pd_calc.intensity_total
+         _pd_proc.intensity_bkg_calc
+         1   5.001   43.364   25.994961   25.994961
+         2   5.004   38.007   26.200290   26.200290
+         3   5.007   38.318   26.404083   26.404083
+         4   5.010   41.877   26.606346   26.606346
+         #further data points follow
+;
+;
+         Tabulation of diffraction data consisting of measured and calculated
+         data. The measured diffraction angle and measured intensity are given.
+         The calculated diffraction pattern intensity, including background, is
+         given, and finally, the calculated background is listed.
+
+         The category key value associated with _pd_data.point_id is given
+         with every data point. In the usual case that only one diffractogram
+         is present in the data block, the category key value associated with
+         _pd_data.diffractogram_id would be taken from the value associated
+         with the data name _pd_diffractogram.id given in that data block.
+;
+;
+         loop_
+         _pd_data.point_id
+         _pd_meas.time_of_flight
+         _pd_proc.d_spacing
+         _pd_proc.intensity_total
+         _pd_proc.ls_weight
+         _pd_calc.intensity_total
+         _pd_proc.intensity_bkg_calc
+         0   1110.30100   1.489225   0.60008   6528.86960   0.553025   0.504217
+         1   1114.74220   1.495170   0.63531   6316.37917   0.571286   0.504020
+         2   1119.20117   1.501138   0.64690   6107.85715   0.593895   0.503826
+         3   1123.67798   1.507131   0.65580   6162.14696   0.620014   0.503635
+         4   1128.17269   1.513147   0.69097   5674.48379   0.647871   0.503449
+         #further data points follow
+;
+;
+         Tabulation of diffraction data consisting of measured, processed, and
+         calculated data. The measured time-of-flight is given along with the
+         corresponding d-values; The parameters for this conversion may be
+         given elsewhere using PD_CALIB_D_TO_TOF data items. The measured
+         intensity is not given, only the processed intensity is listed. The
+         weighting associated with each data point in the diffraction pattern
+         modelling process is given, along with the calculated intensity and
+         background.
+
+         The category key value associated with _pd_data.point_id is given
+         with every data point. In the usual case that only one diffractogram
+         is present in the data block, the category key value associated with
+         _pd_data.diffractogram_id would be taken from the value associated
+         with the data name _pd_diffractogram.id given in that data block.
+;
+;
+         loop_
+         _pd_data.point_id
+         _pd_meas.2theta_scan
+         _pd_proc.2theta_corrected
+         _pd_meas.intensity_total
+         _pd_calc.intensity_total
+         0   3.99875   3.907132   1061.8   1076.653
+         1   4.03625   3.944633   1053.9   1074.628
+         2   4.07375   3.982134   1060.2   1072.667
+         3   4.11125   4.019635   1017.3   1070.768
+         #further data points follow
+;
+;
+         Tabulation of diffraction data consisting of measured, processed, and
+         calculated data. The measured diffraction angle is given, along with
+         diffraction angles corrected for any instrument alignment or
+         specimen displacement. Finally, the measured intensity and intensity
+         calculated from a model are given. The two intensities include
+         background and are on the same scale.
+
+         The category key value associated with _pd_data.point_id is given
+         with every data point. In the usual case that only one diffractogram
+         is present in the data block, the category key value associated with
+         _pd_data.diffractogram_id would be taken from the value associated
+         with the data name _pd_diffractogram.id given in that data block.
+;
+;
+         loop_
+         _pd_data.point_id
+         _pd_meas.2theta_scan
+         _pd_meas.counts_total
+         1   4.03   154
+         2   4.09   140
+         3   4.15   134
+         4   4.21   171
+         #further data points follow
+;
+;
+         Tabulation of diffraction data consisting only of measured data. The
+         intensity is measured in counts, including background. The
+         X-coordinate is 2θ degrees as given by the diffractometer.
+
+         The category key value associated with _pd_data.point_id is given
+         with every data point. In the usual case that only one diffractogram
+         is present in the data block, the category key value associated with
+         _pd_data.diffractogram_id would be taken from the value associated
+         with the data name _pd_diffractogram.id given in that data block.
+;
+
+save_
+
+save_pd_data.diffractogram_id
+
+    _definition.id                '_pd_data.diffractogram_id'
+    _definition.update            2022-12-16
+    _description.text
+;
+    Label identifying the diffraction measurement that the
+    data tabulated in the PD_DATA category belong to. This
+    may be omitted in the usual case that only one diffraction
+    measurement is present in a data block.
+;
+    _name.category_id             pd_data
+    _name.object_id               diffractogram_id
+    _name.linked_item_id          '_pd_diffractogram.id'
+    _type.purpose                 Link
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_pd_data.point_id
+
+    _definition.id                '_pd_data.point_id'
+    _alias.definition_id          '_pd_data_point_id'
+    _definition.update            2014-06-20
+    _description.text
+;
+    Arbitrary label identifying an entry in the table of
+    diffractogram intensity values. This should be used in
+    preference to the pd_calc/pd_calc_component/pd_meas/pd_proc
+    point_id data items whenever data items from more than
+    one of the pd_calc/pd_calc_component/pd_proc/pd_meas
+    categories are looped together.
+;
+    _name.category_id             pd_data
+    _name.object_id               point_id
+    _type.purpose                 Key
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Code
+
+save_
+
+save_PD_CALC
+
+    _definition.id                PD_CALC
+    _definition.scope             Category
+    _definition.class             Loop
+    _definition.update            2022-10-11
+    _description.text
+;
+    This section is used for storing a computed diffractogram trace.
+    This may be a simulated powder pattern for a material from a
+    program such as LAZY/PULVERIX or the computed intensities from a
+    Rietveld refinement.
+;
+    _name.category_id             PD_DATA
+    _name.object_id               PD_CALC
+
+    loop_
+      _category_key.name
+         '_pd_calc.point_id'
+         '_pd_calc.diffractogram_id'
+
+save_
+
+save_pd_calc.component_intensities_net
+
+    _definition.id                '_pd_calc.component_intensities_net'
+    _definition.update            2023-06-17
+    _description.text
+;
+    List of intensity values for the contributions of an
+    arbitrary number of individual phases to a computed
+    diffractogram for each data point. Values are listed
+    in the order given by _pd_calc_overall.component_presentation_order.
+    Values should be computed at the same locations as the
+    processed diffractogram, and thus the numbers of points
+    will be defined by _pd_proc.number_of_points. Point
+    positions may be defined using _pd_proc.2theta_range_*,
+    _pd_proc.2theta_corrected, _pd_proc.d_spacing, or other
+    appropriate x-coordinates.
+
+    Use _pd_calc.component_intensities_net if the computed
+    component contribution diffraction patterns do not
+    include background or normalization corrections and thus
+    are specified on the same scale as the
+    _pd_proc.intensity_net values.
+
+    _pd_calc.component_intensities_* should be looped with
+    either _pd_proc.intensity_net, _pd_meas.counts_*, and/or
+    _pd_meas.intensity_*.
+;
+    _name.category_id             pd_calc
+    _name.object_id               component_intensities_net
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               List
+    _type.dimension               '[]'
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   none
+
+save_
+
+save_pd_calc.component_intensities_total
+
+    _definition.id                '_pd_calc.component_intensities_total'
+    _definition.update            2023-06-17
+    _description.text
+;
+    List of intensity values for the contributions of an
+    arbitrary number of individual phases to a computed
+    diffractogram at each data point. Values are listed
+    in the order given by _pd_calc_overall.component_presentation_order.
+    Values should be computed at the same locations as the
+    processed diffractogram, and thus the numbers of points
+    will be defined by _pd_proc.number_of_points. Point
+    positions may be defined using _pd_proc.2theta_range_*,
+    _pd_proc.2theta_corrected, _pd_proc.d_spacing, or other
+    appropriate x-coordinates.
+
+    Use _pd_calc.component_intensities_total if the computed
+    component contribution diffraction patterns include background
+    or normalization corrections (or both), and thus are specified
+    on the same scale as the observed intensities (_pd_meas.counts_*
+    or _pd_meas.intensity_*).
+
+    _pd_calc.component_intensities_* should be looped with
+    either _pd_proc.intensity_net, _pd_meas.counts_*, and/or
+    _pd_meas.intensity_*.
+;
+    _name.category_id             pd_calc
+    _name.object_id               component_intensities_total
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               List
+    _type.dimension               '[]'
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   none
+
+save_
+
+save_pd_calc.diffractogram_id
+
+    _definition.id                '_pd_calc.diffractogram_id'
+    _definition.update            2023-06-23
+    _description.text
+;
+    Label identifying the calculated diffractogram that the
+    calculated data belong to. This may be omitted in the usual
+    case that only one calculation is present in a data block.
+;
+    _name.category_id             pd_calc
+    _name.object_id               diffractogram_id
+    _name.linked_item_id          '_pd_data.diffractogram_id'
+    _type.purpose                 Link
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_pd_calc.intensity_net
+
+    _definition.id                '_pd_calc.intensity_net'
+    _alias.definition_id          '_pd_calc_intensity_net'
+    _definition.update            2022-12-04
+    _description.text
+;
+    Intensity values for a computed diffractogram at
+    each data point. Values should be computed at the
+    same locations as the processed diffractogram, and thus
+    the numbers of points will be defined by
+    _pd_proc.number_of_points and point positions may
+    be defined using _pd_proc.2theta_range_* or
+    _pd_proc.2theta_corrected.
+
+    Use _pd_calc.intensity_net if the computed diffractogram
+    does not contain background or normalization corrections
+    and thus is specified on the same scale as the
+    _pd_proc.intensity_net values.
+
+    If an observed pattern is included, _pd_calc.intensity_*
+    should be looped with either _pd_proc.intensity_net,
+    _pd_meas.counts_* or _pd_meas.intensity_*.
+;
+    _name.category_id             pd_calc
+    _name.object_id               intensity_net
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   none
+    _method.purpose               Evaluation
+    _method.expression
+;
+    t = 0
+    loop pcc as pd_calc_component {
+        t += pcc.intensity_net
+    }
+    pd_calc.intensity_net = t
+;
+
+save_
+
+save_pd_calc.intensity_total
+
+    _definition.id                '_pd_calc.intensity_total'
+    _alias.definition_id          '_pd_calc_intensity_total'
+    _definition.update            2022-12-04
+    _description.text
+;
+    Intensity values for a computed diffractogram at
+    each data point. Values should be computed at the
+    same locations as the processed diffractogram, and thus
+    the numbers of points will be defined by
+    _pd_proc.number_of_points and point positions may
+    be defined using _pd_proc.2theta_range_* or
+    _pd_proc.2theta_corrected.
+
+    Use _pd_calc.intensity_total if the computed diffraction
+    pattern includes background or normalization corrections
+    (or both) and thus is specified on the same scale as the
+    observed intensities (_pd_meas.counts_* or _pd_meas.intensity_*).
+    If an observed pattern is included, _pd_calc.intensity_*
+    should be looped with either _pd_proc.intensity_net,
+    _pd_meas.counts_* or _pd_meas.intensity_*.
+;
+    _name.category_id             pd_calc
+    _name.object_id               intensity_total
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   none
+    _method.purpose               Evaluation
+    _method.expression
+;
+    t = pd_proc.intensity_bkg_calc
+    loop pcc as pd_calc_component {
+        t += pcc.intensity_total - pd_proc.intensity_bkg_calc
+    }
+    pd_calc.intensity_total = t
+;
+
+save_
+
+save_pd_calc.point_id
+
+    _definition.id                '_pd_calc.point_id'
+    _alias.definition_id          '_pd_calc_point_id'
+    _definition.update            2022-12-04
+    _description.text
+;
+    Arbitrary label identifying a calculated data point. Used to
+    identify a specific entry in a list of values forming the
+    calculated diffractogram. The role of this identifier may
+    be adopted by _pd_data.point_id if measured, processed, and/or
+    calculated intensity values are combined in a single list.
+;
+    _name.category_id             pd_calc
+    _name.object_id               point_id
+    _name.linked_item_id          '_pd_data.point_id'
+    _type.purpose                 Link
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Code
+
+save_
+
+save_PD_MEAS
+
+    _definition.id                PD_MEAS
+    _definition.scope             Category
+    _definition.class             Loop
+    _definition.update            2025-04-18
+    _description.text
+;
+    This section contains the measured diffractogram prior to
+    processing and application of correction terms. While additional
+    information may be added to the CIF as data are processed and
+    transported between laboratories, the information in this section of
+    the CIF will rarely be changed once data collection is complete.
+
+    Where possible, measurements in this section should have no
+    post-collection processing applied (normalizations, corrections,
+    smoothing, zero-offset corrections etc.). Such corrected
+    measurements should be recorded in the PD_PROC section.
+
+    Data sets that are measured as counts, where a standard
+    uncertainty can be considered equivalent to the standard
+    deviation and where the standard deviation can be estimated
+    as the square root of the number of counts recorded, should
+    use the _pd_meas.counts_* fields. All other intensity values
+    should be recorded using _pd_meas.intensity_*.
+;
+    _name.category_id             PD_DATA
+    _name.object_id               PD_MEAS
+
+    loop_
+      _category_key.name
+         '_pd_meas.point_id'
+         '_pd_meas.diffractogram_id'
+
+save_
+
+save_pd_instr.dist_spec_vdetc
+
+    _definition.id                '_pd_instr.dist_spec_vdetc'
+    _definition.update            2022-12-04
+    _description.text
+;
+    Distance from the specimen to the virtual detector (in millimetres).
+    The virtual detector is point in space at which the detector is
+    sampling the diffracted radiation from the point of view of the
+    specimen, e.g. the specimen-receiving slit distance in a point-detector,
+    Bragg-Brentano diffractometer. This distance is also referred to as
+    the 'secondary radius', or the 'diffracted beam radius'.
+
+    Where the specimen-detector distance is difficult to define, for example,
+    for a large, flat, area detector, the distance refers to the closest
+    approach of the detector to the specimen.
+
+    See the discussion on 'detector circle' or 'goniometer circle' in
+    International Tables Vol H, S2.1.4.1 for further information.
+;
+    _name.category_id             pd_meas
+    _name.object_id               dist_spec_vdetc
+    _type.purpose                 Number
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   millimetres
+
+save_
+
+save_pd_instr.dist_vsrc_spec
+
+    _definition.id                '_pd_instr.dist_vsrc_spec'
+    _definition.update            2022-12-04
+    _description.text
+;
+    Distance from the virtual source to the specimen (in millimetres).
+    The virtual source is point in space from which the incident radiation
+    can be said to be coming from the point of view of the specimen.
+    This distance is also referred to as the 'primary radius', or the
+    'incident beam radius'.
+
+    See the discussion on 'detector circle' or 'goniometer circle' in
+    International Tables Vol H, S2.1.4.1 for further information.
+;
+    _name.category_id             pd_meas
+    _name.object_id               dist_vsrc_spec
+    _type.purpose                 Number
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   millimetres
+
+save_
+
+save_pd_instr.var_illum_len
+
+    _definition.id                '_pd_instr.var_illum_len'
+    _alias.definition_id          '_pd_instr_var_illum_len'
+    _definition.update            2016-10-20
+    _description.text
+;
+    Length of the specimen that is illuminated by the radiation
+    source (in millimetres) for instruments where
+    the illumination length varies with 2θ (fixed
+    divergence slits). The _pd_instr.var_illum_len
+    values should be included in the same loop as the
+    intensity measurements (_pd_meas.* items).
+
+    See _pd_instr.cons_illum_len for instruments where
+    the divergence slit is θ-compensated to yield a
+    constant illumination length.
+;
+    _name.category_id             pd_meas
+    _name.object_id               var_illum_len
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   millimetres
+
+save_
+
+save_pd_meas.2theta_scan
+
+    _definition.id                '_pd_meas.2theta_scan'
+
+    loop_
+      _alias.definition_id
+         '_pd_meas_2theta_scan'
+         '_pd_meas_angle_2theta'
+
+    _definition.update            2022-10-11
+    _description.text
+;
+    2θ diffraction angle (in degrees) for intensity
+    points measured in a scanning method. The scan method used
+    (e.g. continuous or step scan) should be specified in
+    the item _pd_meas.scan_method. For fixed 2θ (white-beam)
+    experiments, use _pd_meas.2theta_fixed. In the case of
+    continuous-scan data sets, the 2θ value should be the
+    value at the midpoint of the counting period. Associated
+    with each _pd_meas.2theta_scan value will be
+    _pd_meas.counts_* items. The 2θ values should
+    not be corrected for nonlinearity,
+    zero offset etc. Corrected values may be specified
+    using _pd_proc.2theta_corrected.
+
+    Note that for data sets collected with constant step size,
+    _pd_meas.2theta_range_* (min, max and inc) may be used
+    instead of _pd_meas.2theta_scan. _pd_meas.2theta_angle was
+    originally a distinct but cognate definition and should not be
+    used in new files.
+;
+    _name.category_id             pd_meas
+    _name.object_id               2theta_scan
+    _type.purpose                 Measurand
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            -180.0:360.0
+    _units.code                   degrees
+
+save_
+
+save_pd_meas.2theta_scan_su
+
+    _definition.id                '_pd_meas.2theta_scan_su'
+    _definition.update            2022-10-27
+    _description.text
+;
+    Standard uncertainty of _pd_meas.2theta_scan.
+;
+    _name.category_id             pd_meas
+    _name.object_id               2theta_scan_su
+    _name.linked_item_id          '_pd_meas.2theta_scan'
+    _units.code                   degrees
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+save_
+
+save_pd_meas.counts_background
+
+    _definition.id                '_pd_meas.counts_background'
+    _alias.definition_id          '_pd_meas_counts_background'
+    _definition.update            2022-12-30
+    _description.text
+;
+    Counts recorded at each measurement point as a function of
+    angle, time, channel, or some other variable (see
+    _pd_meas.2theta_* etc.). These counts are measured without
+    a specimen, specimen mounting etc., often referred to
+    as the instrument background.
+
+    Corrections for background, detector dead time etc.
+    should not have been made to these values. Instead, make the
+    corrections and record the result using
+    _pd_proc.intensity_net, _norm, or _total, as appropriate,
+    for corrected diffractograms.
+
+    Note that counts-per-second values should be converted to
+    total counts. If the counting time varies for different
+    points, it may be included in the loop using
+    _pd_meas.step_count_time.
+
+    Standard uncertainties should not be quoted for these values.
+    If the standard uncertainties differ from the square root of
+    the number of counts, _pd_meas.intensity_* should be used.
+;
+    _name.category_id             pd_meas
+    _name.object_id               counts_background
+    _type.purpose                 Number
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Integer
+    _enumeration.range            0:
+    _units.code                   counts
+
+save_
+
+save_pd_meas.counts_container
+
+    _definition.id                '_pd_meas.counts_container'
+    _alias.definition_id          '_pd_meas_counts_container'
+    _definition.update            2022-12-04
+    _description.text
+;
+    Counts recorded at each measurement point as a function of
+    angle, time, channel, or some other variable (see
+    _pd_meas.2theta_* etc.). These counts are measured from a
+    specimen container or mounting without a specimen, includes
+    background.
+
+    Corrections for background, detector dead time etc.
+    should not have been made to these values. Instead use
+    _pd_proc.intensity_* for corrected diffractograms.
+
+    Note that counts-per-second values should be converted to
+    total counts. If the counting time varies for different
+    points, it may be included in the loop using
+    _pd_meas.step_count_time.
+
+    Standard uncertainties should not be quoted for these values.
+    If the standard uncertainties differ from the square root of
+    the number of counts, _pd_meas.intensity_* should be used.
+;
+    _name.category_id             pd_meas
+    _name.object_id               counts_container
+    _type.purpose                 Number
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Integer
+    _enumeration.range            0:
+    _units.code                   counts
+
+save_
+
+save_pd_meas.counts_monitor
+
+    _definition.id                '_pd_meas.counts_monitor'
+    _alias.definition_id          '_pd_meas_counts_monitor'
+    _definition.update            2022-12-04
+    _description.text
+;
+    Counts recorded at each measurement point as a function of
+    angle, time, channel, or some other variable (see
+    _pd_meas.2theta_* etc.). These counts are measured by an
+    incident-beam monitor to calibrate the flux on the specimen.
+
+    Corrections for background, detector dead time etc.
+    should not have been made to these values. Instead use
+    _pd_proc.intensity_* for corrected diffractograms.
+
+    Note that counts-per-second values should be converted to
+    total counts. If the counting time varies for different
+    points, it may be included in the loop using
+    _pd_meas.step_count_time.
+
+    Standard uncertainties should not be quoted for these values.
+    If the standard uncertainties differ from the square root of
+    the number of counts, _pd_meas.intensity_* should be used.
+;
+    _name.category_id             pd_meas
+    _name.object_id               counts_monitor
+    _type.purpose                 Number
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Integer
+    _enumeration.range            0:
+    _units.code                   counts
+
+save_
+
+save_pd_meas.counts_total
+
+    _definition.id                '_pd_meas.counts_total'
+    _alias.definition_id          '_pd_meas_counts_total'
+    _definition.update            2022-12-04
+    _description.text
+;
+    Counts recorded at each measurement point as a function of
+    angle, time, channel, or some other variable (see
+    _pd_meas.2theta_* etc.). These counts are measured from the
+    specimen with background, specimen mounting, and/or container
+    scattering included.
+
+    Corrections for background, detector dead time etc.
+    should not have been made to these values. Instead use
+    _pd_proc.intensity_* for corrected diffractograms.
+
+    Note that counts-per-second values should be converted to
+    total counts. If the counting time varies for different
+    points, it may be included in the loop using
+    _pd_meas.step_count_time.
+
+    Standard uncertainties should not be quoted for these values.
+    If the standard uncertainties differ from the square root of
+    the number of counts, _pd_meas.intensity_* should be used.
+;
+    _name.category_id             pd_meas
+    _name.object_id               counts_total
+    _type.purpose                 Number
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Integer
+    _enumeration.range            0:
+    _units.code                   counts
+
+save_
+
+save_pd_meas.detector_id
+
+    _definition.id                '_pd_meas.detector_id'
+    _alias.definition_id          '_pd_meas_detector_id'
+    _definition.update            2023-06-09
+    _description.text
+;
+    A code which identifies the detector or channel number in a
+    position-sensitive, energy-dispersive or other multiple-detector
+    instrument for which the individual instrument geometry is being
+    defined. This code should match the code name used for
+    _pd_instr_detector.id.
+
+    Calibration information, such as angle offsets or a calibration
+    function to convert channel numbers to Q, energy, wavelength,
+    angle etc. should be described using PD_CALIB_XCOORD and/or
+    PD_CALIBRATION data items. If _pd_calibration.conversion_eqn is
+    used, the detector IDs should be the number to be used in the
+    equation.
+;
+    _name.category_id             pd_meas
+    _name.object_id               detector_id
+    _name.linked_item_id          '_pd_instr_detector.id'
+    _type.purpose                 Link
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Code
+
+save_
+
+save_pd_meas.diffractogram_id
+
+    _definition.id                '_pd_meas.diffractogram_id'
+    _definition.update            2023-06-23
+    _description.text
+;
+    Label identifying the diffraction measurement that the
+    data tabulated in the PD_MEAS category belong to. This
+    may be omitted in the usual case that only one diffraction
+    measurement is present in a data block.
+;
+    _name.category_id             pd_meas
+    _name.object_id               diffractogram_id
+    _name.linked_item_id          '_pd_data.diffractogram_id'
+    _type.purpose                 Link
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_pd_meas.intensity_background
+
+    _definition.id                '_pd_meas.intensity_background'
+    _alias.definition_id          '_pd_meas_intensity_background'
+    _definition.update            2022-12-30
+    _description.text
+;
+    Intensity recorded at each measurement point as a function of
+    angle, time, channel, or some other variable (see
+    _pd_meas.2theta_* etc.). These intensities are measured
+    without a specimen, specimen mounting etc., often
+    referred to as the instrument background.
+
+    Use these entries for measurements where intensity
+    values are not counts (use _pd_meas.counts_* for event-counting
+    measurements where the standard uncertainty is
+    estimated as the square root of the number of counts).
+
+    Corrections for background, detector dead time etc.
+    should not have been made to these values. Instead, make the
+    corrections and record the result using
+    _pd_proc.intensity_net, _norm, or _total, as appropriate,
+    for corrected diffractograms.
+
+    _pd_meas.units_of_intensity should be used to specify
+    the units of the intensity measurements.
+;
+    _name.category_id             pd_meas
+    _name.object_id               intensity_background
+    _type.purpose                 Measurand
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Real
+    _units.code                   none
+
+save_
+
+save_pd_meas.intensity_background_su
+
+    _definition.id                '_pd_meas.intensity_background_su'
+    _definition.update            2022-09-28
+    _description.text
+;
+    Standard uncertainty of _pd_meas.intensity_background.
+;
+    _name.category_id             pd_meas
+    _name.object_id               intensity_background_su
+    _name.linked_item_id          '_pd_meas.intensity_background'
+    _units.code                   none
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+save_
+
+save_pd_meas.intensity_container
+
+    _definition.id                '_pd_meas.intensity_container'
+    _alias.definition_id          '_pd_meas_intensity_container'
+    _definition.update            2022-12-30
+    _description.text
+;
+    Intensity recorded at each measurement point as a function of
+    angle, time, channel, or some other variable (see
+    _pd_meas.2theta_* etc.). These intensities are measured from
+    the specimen container or mounting without a specimen, includes
+    background.
+
+    Use these entries for measurements where intensity
+    values are not counts (use _pd_meas.counts_* for event-counting
+    measurements where the standard uncertainty is
+    estimated as the square root of the number of counts).
+
+    Corrections for background, detector dead time etc.
+    should not have been made to these values. Instead, make the
+    corrections and record the result using
+    _pd_proc.intensity_net, _norm, or _total, as appropriate,
+    for corrected diffractograms.
+
+    _pd_meas.units_of_intensity should be used to specify
+    the units of the intensity measurements.
+;
+    _name.category_id             pd_meas
+    _name.object_id               intensity_container
+    _type.purpose                 Measurand
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Real
+    _units.code                   none
+
+save_
+
+save_pd_meas.intensity_container_su
+
+    _definition.id                '_pd_meas.intensity_container_su'
+    _definition.update            2022-09-28
+    _description.text
+;
+    Standard uncertainty of _pd_meas.intensity_container.
+;
+    _name.category_id             pd_meas
+    _name.object_id               intensity_container_su
+    _name.linked_item_id          '_pd_meas.intensity_container'
+    _units.code                   none
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+save_
+
+save_pd_meas.intensity_monitor
+
+    _definition.id                '_pd_meas.intensity_monitor'
+    _alias.definition_id          '_pd_meas_intensity_monitor'
+    _definition.update            2023-01-18
+    _description.text
+;
+    Intensity recorded at each measurement point as a function of
+    angle, time, channel, or some other variable (see
+    _pd_meas.2theta_* etc.). These intensities are measured by an
+    incident-beam monitor to calibrate the flux on the specimen.
+    For a single value used to scale an entire diffractogram, see
+    _pd_calib_incident_intensity.incident_intensity.
+
+    Use these entries for measurements where intensity
+    values are not counts (use _pd_meas.counts_* for event-counting
+    measurements where the standard uncertainty is
+    estimated as the square root of the number of counts).
+
+    Corrections for background, detector dead time etc.
+    should not have been made to these values. Instead, make the
+    corrections and record the result using
+    _pd_proc.intensity_net, _norm, or _total, as appropriate,
+    for corrected diffractograms.
+
+    _pd_meas.units_of_intensity should be used to specify
+    the units of the intensity measurements.
+;
+    _name.category_id             pd_meas
+    _name.object_id               intensity_monitor
+    _type.purpose                 Measurand
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Real
+    _units.code                   none
+
+save_
+
+save_pd_meas.intensity_monitor_su
+
+    _definition.id                '_pd_meas.intensity_monitor_su'
+    _definition.update            2022-09-28
+    _description.text
+;
+    Standard uncertainty of _pd_meas.intensity_monitor.
+;
+    _name.category_id             pd_meas
+    _name.object_id               intensity_monitor_su
+    _name.linked_item_id          '_pd_meas.intensity_monitor'
+    _units.code                   none
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+save_
+
+save_pd_meas.intensity_total
+
+    _definition.id                '_pd_meas.intensity_total'
+    _alias.definition_id          '_pd_meas_intensity_total'
+    _definition.update            2022-12-30
+    _description.text
+;
+    Intensity recorded at each measurement point as a function of
+    angle, time, channel, or some other variable (see
+    _pd_meas.2theta_* etc.). These intensities are measured from
+    the specimen, with background, specimen mounting, and/or container
+    scattering included.
+
+    Use these entries for measurements where intensity
+    values are not counts (use _pd_meas.counts_* for event-counting
+    measurements where the standard uncertainty is
+    estimated as the square root of the number of counts).
+
+    Corrections for background, detector dead time etc.,
+    should not have been made to these values. Instead use
+    _pd_proc.intensity_* for corrected diffractograms.
+
+    _pd_meas.units_of_intensity should be used to specify
+    the units of the intensity measurements.
+;
+    _name.category_id             pd_meas
+    _name.object_id               intensity_total
+    _type.purpose                 Measurand
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Real
+    _units.code                   none
+
+save_
+
+save_pd_meas.intensity_total_su
+
+    _definition.id                '_pd_meas.intensity_total_su'
+    _definition.update            2022-09-28
+    _description.text
+;
+    Standard uncertainty of _pd_meas.intensity_total.
+;
+    _name.category_id             pd_meas
+    _name.object_id               intensity_total_su
+    _name.linked_item_id          '_pd_meas.intensity_total'
+    _units.code                   none
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+save_
+
+save_pd_meas.point_id
+
+    _definition.id                '_pd_meas.point_id'
+    _alias.definition_id          '_pd_meas_point_id'
+    _definition.update            2022-12-04
+    _description.text
+;
+    Arbitrary label identifying a measured data point. Used to
+    identify a specific entry in a list of measured intensities.
+    The role of this identifier may be adopted by
+    _pd_data.point_id if measured, processed, and/or calculated
+    intensity values are combined in a single list.
+;
+    _name.category_id             pd_meas
+    _name.object_id               point_id
+    _name.linked_item_id          '_pd_data.point_id'
+    _type.purpose                 Link
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Code
+
+save_
+
+save_pd_meas.position
+
+    _definition.id                '_pd_meas.position'
+    _alias.definition_id          '_pd_meas_position'
+    _definition.update            2022-10-11
+    _description.text
+;
+    A linear distance in millimetres corresponding to the
+    location where an intensity measurement is made.
+    Used for detectors where a distance measurement is made
+    as a direct observable, such as from a microdensitometer
+    trace from film or a strip chart recorder. This is an
+    alternative to _pd_meas.2theta_scan, which should only be
+    used for instruments that record intensities directly
+    against 2θ. For instruments where the position scale
+    is nonlinear, the data item _pd_meas.detector_id should
+    be used to record positions.
+
+    Calibration information, such as angle offsets or a
+    function to convert this distance to a 2θ angle
+    or d-space, should be supplied with items from PD_CALIB.
+
+    Do not confuse this with the instrument geometry
+    descriptions given by _pd_instr.dist_*.
+;
+    _name.category_id             pd_meas
+    _name.object_id               position
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _units.code                   millimetres
+
+save_
+
+save_pd_meas.position_su
+
+    _definition.id                '_pd_meas.position_su'
+    _definition.update            2022-10-27
+    _description.text
+;
+    Standard uncertainty of _pd_meas.position.
+;
+    _name.category_id             pd_meas
+    _name.object_id               position_su
+    _name.linked_item_id          '_pd_meas.position'
+    _units.code                   millimetres
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+save_
+
+save_pd_meas.step_count_time
+
+    _definition.id                '_pd_meas.step_count_time'
+    _alias.definition_id          '_pd_meas_step_count_time'
+    _definition.update            2023-01-06
+    _description.text
+;
+    The count time in seconds for each intensity measurement.
+;
+    _name.category_id             pd_meas
+    _name.object_id               step_count_time
+    _type.purpose                 Measurand
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   seconds
+
+save_
+
+save_pd_meas.step_count_time_su
+
+    _definition.id                '_pd_meas.step_count_time_su'
+    _definition.update            2022-10-27
+    _description.text
+;
+    Standard uncertainty of _pd_meas.step_count_time.
+;
+    _name.category_id             pd_meas
+    _name.object_id               step_count_time_su
+    _name.linked_item_id          '_pd_meas.step_count_time'
+    _units.code                   seconds
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+save_
+
+save_pd_meas.time_of_flight
+
+    _definition.id                '_pd_meas.time_of_flight'
+    _alias.definition_id          '_pd_meas_time_of_flight'
+    _definition.update            2023-01-06
+    _description.text
+;
+    Measured time in microseconds for time-of-flight neutron
+    measurements. Note that the flight distance may be
+    specified using _pd_instr.dist_* values.
+;
+    _name.category_id             pd_meas
+    _name.object_id               time_of_flight
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   microseconds
+
+save_
+
+save_pd_meas.time_of_flight_su
+
+    _definition.id                '_pd_meas.time_of_flight_su'
+    _definition.update            2022-10-27
+    _description.text
+;
+    Standard uncertainty of _pd_meas.time_of_flight.
+;
+    _name.category_id             pd_meas
+    _name.object_id               time_of_flight_su
+    _name.linked_item_id          '_pd_meas.time_of_flight'
+    _units.code                   microseconds
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+save_
+
+save_PD_PROC
+
+    _definition.id                PD_PROC
+    _definition.scope             Category
+    _definition.class             Loop
+    _definition.update            2025-04-18
+    _description.text
+;
+    This section contains the diffraction data set after processing
+    and application of correction terms. If the data set is
+    reprocessed, this section may be replaced.
+;
+    _name.category_id             PD_DATA
+    _name.object_id               PD_PROC
+
+    loop_
+      _category_key.name
+         '_pd_proc.point_id'
+         '_pd_proc.diffractogram_id'
+
+save_
+
+save_pd_proc.2theta_corrected
+
+    _definition.id                '_pd_proc.2theta_corrected'
+    _alias.definition_id          '_pd_proc_2theta_corrected'
+    _definition.update            2022-10-11
+    _description.text
+;
+    The 2θ diffraction angle in degrees of an intensity
+    measurement where 2θ is not constant. Used if
+    corrections such as for nonlinearity, zero offset etc.
+    have been applied to the _pd_meas.2theta_* values or if
+    2θ values are computed. If the 2θ values
+    are evenly spaced, _pd_proc.2theta_range_min,
+    _pd_proc.2theta_range_max and _pd_proc.2theta_range_inc
+    may be used to specify the 2θ values.
+;
+    _name.category_id             pd_proc
+    _name.object_id               2theta_corrected
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            -180.0:180.0
+    _units.code                   degrees
+
+save_
+
+save_pd_proc.2theta_corrected_su
+
+    _definition.id                '_pd_proc.2theta_corrected_su'
+    _definition.update            2022-10-27
+    _description.text
+;
+    Standard uncertainty of _pd_proc.2theta_corrected.
+;
+    _name.category_id             pd_proc
+    _name.object_id               2theta_corrected_su
+    _name.linked_item_id          '_pd_proc.2theta_corrected'
+    _units.code                   degrees
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+save_
+
+save_pd_proc.d_spacing
+
+    _definition.id                '_pd_proc.d_spacing'
+    _alias.definition_id          '_pd_proc_d_spacing'
+    _definition.update            2022-10-11
+    _description.text
+;
+    d-spacing corresponding to an intensity point
+    from Bragg's law, d = λ/(2 sinθ), in units of angstroms.
+;
+    _name.category_id             pd_proc
+    _name.object_id               d_spacing
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   angstroms
+
+save_
+
+save_pd_proc.d_spacing_su
+
+    _definition.id                '_pd_proc.d_spacing_su'
+    _definition.update            2022-10-27
+    _description.text
+;
+    Standard uncertainty of _pd_proc.d_spacing.
+;
+    _name.category_id             pd_proc
+    _name.object_id               d_spacing_su
+    _name.linked_item_id          '_pd_proc.d_spacing'
+    _units.code                   angstroms
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+save_
+
+save_pd_proc.diffractogram_id
+
+    _definition.id                '_pd_proc.diffractogram_id'
+    _definition.update            2023-06-23
+    _description.text
+;
+    Label identifying the diffraction measurement that the
+    data tabulated in the PD_PROC category belong to. This
+    may be omitted in the usual case that only one diffraction
+    measurement is present in a data block.
+;
+    _name.category_id             pd_proc
+    _name.object_id               diffractogram_id
+    _name.linked_item_id          '_pd_data.diffractogram_id'
+    _type.purpose                 Link
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_pd_proc.energy_detection
+
+    _definition.id                '_pd_proc.energy_detection'
+    _alias.definition_id          '_pd_proc_energy_detection'
+    _definition.update            2022-10-11
+    _description.text
+;
+    Detection energy in electronvolts selected by the analyser,
+    if not the same as the incident energy (triple-axis or
+    energy-dispersive data). This may be a single value or may
+    vary for each data point (triple-axis and time-of-flight data).
+;
+    _name.category_id             pd_proc
+    _name.object_id               energy_detection
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   electron_volts
+
+save_
+
+save_pd_proc.energy_detection_su
+
+    _definition.id                '_pd_proc.energy_detection_su'
+    _definition.update            2022-10-27
+    _description.text
+;
+    Standard uncertainty of _pd_proc.energy_detection.
+;
+    _name.category_id             pd_proc
+    _name.object_id               energy_detection_su
+    _name.linked_item_id          '_pd_proc.energy_detection'
+    _units.code                   electron_volts
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+save_
+
+save_pd_proc.energy_incident
+
+    _definition.id                '_pd_proc.energy_incident'
+    _alias.definition_id          '_pd_proc_energy_incident'
+    _definition.update            2022-10-11
+    _description.text
+;
+    Incident energy in electronvolts of the source computed
+    from secondary calibration information (time-of-flight
+    and synchrotron data).
+;
+    _name.category_id             pd_proc
+    _name.object_id               energy_incident
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   electron_volts
+
+save_
+
+save_pd_proc.energy_incident_su
+
+    _definition.id                '_pd_proc.energy_incident_su'
+    _definition.update            2022-10-27
+    _description.text
+;
+    Standard uncertainty of _pd_proc.energy_incident.
+;
+    _name.category_id             pd_proc
+    _name.object_id               energy_incident_su
+    _name.linked_item_id          '_pd_proc.energy_incident'
+    _units.code                   electron_volts
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+save_
+
+save_pd_proc.intensity_bkg_calc
+
+    _definition.id                '_pd_proc.intensity_bkg_calc'
+    _alias.definition_id          '_pd_proc_intensity_bkg_calc'
+    _definition.update            2014-06-20
+    _description.text
+;
+    Inclusion of s.u.'s for these values is strongly recommended.
+
+    _pd_proc.intensity_bkg_calc is intended to contain the
+    background intensity for every data point where the
+    background function has been fitted or estimated (for example, in
+    all Rietveld and profile fits).
+;
+    _name.category_id             pd_proc
+    _name.object_id               intensity_bkg_calc
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   none
+
+save_
+
+save_pd_proc.intensity_bkg_calc_su
+
+    _definition.id                '_pd_proc.intensity_bkg_calc_su'
+    _definition.update            2022-09-28
+    _description.text
+;
+    Standard uncertainty of _pd_proc.intensity_bkg_calc.
+;
+    _name.category_id             pd_proc
+    _name.object_id               intensity_bkg_calc_su
+    _name.linked_item_id          '_pd_proc.intensity_bkg_calc'
+    _units.code                   none
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+save_
+
+save_pd_proc.intensity_bkg_fix
+
+    _definition.id                '_pd_proc.intensity_bkg_fix'
+    _alias.definition_id          '_pd_proc_intensity_bkg_fix'
+    _definition.update            2014-06-20
+    _description.text
+;
+    Inclusion of s.u.'s for these values is strongly recommended.
+
+    If the background is estimated for a limited number of points
+    and the calculated background is then extrapolated from
+    these fixed points, indicate the background values for
+    these points with _pd_proc.intensity_bkg_fix. Use a value
+    of '.' for data points where a fixed background has not
+    been defined. The extrapolated background at every point
+    may be specified using _pd_proc.intensity_bkg_calc.
+
+    Background values should be on the same scale as the
+    _pd_proc.intensity_net values. Thus normalization and
+    correction factors should be applied before
+    background subtraction (or should be applied to the
+    background values equally).
+
+    The other normalization factors applied to the data set (for
+    example, Lp corrections, compensation for variation in
+    counting time) may be specified in _pd_proc.intensity_norm.
+    The function should be specified as the one used to divide the
+    measured intensities.
+;
+    _name.category_id             pd_proc
+    _name.object_id               intensity_bkg_fix
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   none
+
+save_
+
+save_pd_proc.intensity_bkg_fix_su
+
+    _definition.id                '_pd_proc.intensity_bkg_fix_su'
+    _definition.update            2022-09-28
+    _description.text
+;
+    Standard uncertainty of _pd_proc.intensity_bkg_fix.
+;
+    _name.category_id             pd_proc
+    _name.object_id               intensity_bkg_fix_su
+    _name.linked_item_id          '_pd_proc.intensity_bkg_fix'
+    _units.code                   none
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+save_
+
+save_pd_proc.intensity_incident
+
+    _definition.id                '_pd_proc.intensity_incident'
+    _alias.definition_id          '_pd_proc_intensity_incident'
+    _definition.update            2014-06-20
+    _description.text
+;
+    Inclusion of s.u.'s for these values is strongly recommended.
+
+    If the intensities have been corrected for a variation of the
+    incident intensity as a function of a data-collection
+    variable (examples: source fluctuations in synchrotrons,
+    θ-compensated slits in conventional diffractometers,
+    spectral corrections for white-beam experiments), the
+    correction function should be specified as
+    _pd_proc.intensity_incident. The normalization should be
+    specified in _pd_proc.intensity_incident as a value to be
+    used to divide the measured intensities to obtain the
+    normalised diffractogram. Thus, the
+    _pd_proc.intensity_incident values should increase as the
+    incident flux is increased.
+;
+    _name.category_id             pd_proc
+    _name.object_id               intensity_incident
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   none
+
+save_
+
+save_pd_proc.intensity_incident_su
+
+    _definition.id                '_pd_proc.intensity_incident_su'
+    _definition.update            2022-09-28
+    _description.text
+;
+    Standard uncertainty of _pd_proc.intensity_incident.
+;
+    _name.category_id             pd_proc
+    _name.object_id               intensity_incident_su
+    _name.linked_item_id          '_pd_proc.intensity_incident'
+    _units.code                   none
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+save_
+
+save_pd_proc.intensity_net
+
+    _definition.id                '_pd_proc.intensity_net'
+    _alias.definition_id          '_pd_proc_intensity_net'
+    _definition.update            2022-12-30
+    _description.text
+;
+    Inclusion of s.u.'s for these values is strongly recommended.
+
+    Intensity values for the processed diffractogram for
+    each data point (see _pd_proc.2theta_*, _pd_proc.wavelength
+    etc.) after background subtraction, normalization, and other
+    correction factors have been applied (in contrast to
+    _pd_meas.counts_* or _pd_meas.intensity_* values, which are
+    uncorrected).
+;
+    _name.category_id             pd_proc
+    _name.object_id               intensity_net
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _units.code                   none
+
+save_
+
+save_pd_proc.intensity_net_su
+
+    _definition.id                '_pd_proc.intensity_net_su'
+    _definition.update            2022-09-28
+    _description.text
+;
+    Standard uncertainty of _pd_proc.intensity_net.
+;
+    _name.category_id             pd_proc
+    _name.object_id               intensity_net_su
+    _name.linked_item_id          '_pd_proc.intensity_net'
+    _units.code                   none
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+save_
+
+save_pd_proc.intensity_norm
+
+    _definition.id                '_pd_proc.intensity_norm'
+    _alias.definition_id          '_pd_proc_intensity_norm'
+    _definition.update            2014-06-20
+    _description.text
+;
+    Inclusion of s.u.'s for these values is strongly recommended.
+
+    Values in this data item are normalisation-corrected and contain
+    a background component.
+
+    Background values (for example, given by _pd_proc.intensity_bkg_calc)
+    should be on the same scale as the _pd_proc.intensity_net values.
+    Thus normalization and correction factors should be applied before
+    background subtraction (or should be applied to the background values
+    equally).
+
+    Normalization factors applied to the data set (for
+    example, Lp corrections, compensation for variation in
+    counting time) may be specified in _pd_proc.intensity_norm.
+    The function should be specified as the one used to divide the
+    measured intensities.
+
+    Note that if the intensities have been corrected for a variation
+    of the incident intensity as a function of a data-collection
+    variable, the correction function should be specified separately
+    as _pd_proc.intensity_incident.
+;
+    _name.category_id             pd_proc
+    _name.object_id               intensity_norm
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   none
+
+save_
+
+save_pd_proc.intensity_norm_su
+
+    _definition.id                '_pd_proc.intensity_norm_su'
+    _definition.update            2022-09-28
+    _description.text
+;
+    Standard uncertainty of _pd_proc.intensity_norm.
+;
+    _name.category_id             pd_proc
+    _name.object_id               intensity_norm_su
+    _name.linked_item_id          '_pd_proc.intensity_norm'
+    _units.code                   none
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+save_
+
+save_pd_proc.intensity_total
+
+    _definition.id                '_pd_proc.intensity_total'
+    _alias.definition_id          '_pd_proc_intensity_total'
+    _definition.update            2014-06-20
+    _description.text
+;
+    Inclusion of s.u.'s for these values is strongly recommended.
+
+    Intensity values for the processed diffractogram at each data
+    point as a function of angle, time, channel, or some other
+    variable (see _pd_meas.2theta_* etc.), where background, normalization,
+    or other corrections have not been applied.
+;
+    _name.category_id             pd_proc
+    _name.object_id               intensity_total
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   none
+
+save_
+
+save_pd_proc.intensity_total_su
+
+    _definition.id                '_pd_proc.intensity_total_su'
+    _definition.update            2022-09-28
+    _description.text
+;
+    Standard uncertainty of _pd_proc.intensity_total.
+;
+    _name.category_id             pd_proc
+    _name.object_id               intensity_total_su
+    _name.linked_item_id          '_pd_proc.intensity_total'
+    _units.code                   none
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+save_
+
+save_pd_proc.ls_weight
+
+    _definition.id                '_pd_proc.ls_weight'
+    _alias.definition_id          '_pd_proc_ls_weight'
+    _definition.update            2023-07-05
+    _description.text
+;
+    Weight applied to each profile point. These values
+    may be omitted if the weights are 1/u^2^, where
+    u is the s.u. for the _pd_proc.intensity_net values.
+
+    A weight value of zero is used to indicate a data
+    point not used for refinement (see
+    _pd_proc.info_excluded_regions).
+;
+    _name.category_id             pd_proc
+    _name.object_id               ls_weight
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   none
+
+save_
+
+save_pd_proc.point_id
+
+    _definition.id                '_pd_proc.point_id'
+    _alias.definition_id          '_pd_proc_point_id'
+    _definition.update            2014-06-20
+    _description.text
+;
+    Arbitrary label identifying a processed data point. Used to
+    identify a specific entry in a list of processed intensities.
+    The role of this identifier may be adopted by
+    _pd_data.point_id if measured, processed and calculated
+    intensity values are combined in a single list, or by
+    _pd_meas.point_id if measured and processed lists are
+    combined.
+;
+    _name.category_id             pd_proc
+    _name.object_id               point_id
+    _name.linked_item_id          '_pd_data.point_id'
+    _type.purpose                 Link
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Code
+
+save_
+
+save_pd_proc.recip_len_q
+
+    _definition.id                '_pd_proc.recip_len_Q'
+    _alias.definition_id          '_pd_proc_recip_len_Q'
+    _definition.update            2022-10-11
+    _description.text
+;
+    Length in reciprocal space (|Q|= 2π/d) corresponding to
+    an intensity point. Units are inverse angstroms.
+;
+    _name.category_id             pd_proc
+    _name.object_id               recip_len_Q
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   reciprocal_angstroms
+
+save_
+
+save_pd_proc.recip_len_q_su
+
+    _definition.id                '_pd_proc.recip_len_Q_su'
+    _definition.update            2022-10-27
+    _description.text
+;
+    Standard uncertainty of _pd_proc.recip_len_Q.
+;
+    _name.category_id             pd_proc
+    _name.object_id               recip_len_Q_su
+    _name.linked_item_id          '_pd_proc.recip_len_Q'
+    _units.code                   reciprocal_angstroms
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+save_
+
+save_pd_proc.wavelength
+
+    _definition.id                '_pd_proc.wavelength'
+    _alias.definition_id          '_pd_proc_wavelength'
+    _definition.update            2023-01-22
+    _description.text
+;
+    Wavelength in angstroms for the incident radiation as
+    computed from secondary calibration information. This will
+    be most appropriate for measurements where the wavelength varies
+    for each data point and must be looped with the intensity values,
+    such as time-of-flight, or energy-dispersive measurements.
+
+    For measurements where the incident radiation can be considered to
+    be monochromatic and has been estimated or refined, for instance,
+    from instrumental parameters or a reference material, please record
+    the wavelength with _diffrn_radiation_wavelength.value and
+    _diffrn_radiation_wavelength.determination.
+;
+    _name.category_id             pd_proc
+    _name.object_id               wavelength
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   angstroms
+
+save_
+
+save_pd_proc.wavelength_su
+
+    _definition.id                '_pd_proc.wavelength_su'
+    _definition.update            2022-10-27
+    _description.text
+;
+    Standard uncertainty of _pd_proc.wavelength.
+;
+    _name.category_id             pd_proc
+    _name.object_id               wavelength_su
+    _name.linked_item_id          '_pd_proc.wavelength'
+    _units.code                   angstroms
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+save_
+
+save_PD_DIFFRACTOGRAM
+
+    _definition.id                PD_DIFFRACTOGRAM
+    _definition.scope             Category
+    _definition.class             Set
+    _definition.update            2022-10-11
+    _description.text
+;
+    This category includes data names relating to a diffractogram
+    as a whole.
+;
+    _name.category_id             PD_GROUP
+    _name.object_id               PD_DIFFRACTOGRAM
+    _category_key.name            '_pd_diffractogram.id'
+
+save_
+
+save_pd_diffractogram.id
+
+    _definition.id                '_pd_diffractogram.id'
+    _definition.update            2025-04-18
+    _description.text
+;
+    Arbitrary label identifying a powder diffraction measurement.
+;
+    _name.category_id             pd_diffractogram
+    _name.object_id               id
+    _type.purpose                 Key
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_pd_diffractogram.spec_id
+
+    _definition.id                '_pd_diffractogram.spec_id'
+    _definition.update            2023-03-25
+    _description.text
+;
+    The specimen (see _pd_spec.id) from which the diffractogram was collected.
+;
+    _name.category_id             pd_diffractogram
+    _name.object_id               spec_id
+    _name.linked_item_id          '_pd_spec.id'
+    _type.purpose                 Link
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_PD_INSTR
+
+    _definition.id                PD_INSTR
+    _definition.scope             Category
+    _definition.class             Set
+    _definition.update            2023-01-12
+    _description.text
+;
+    This section contains information relevant to the instrument
+    used for the diffraction measurement. For most laboratories,
+    very little of this information will change, so a standard file
+    may be prepared and included with each data set.
+
+    Note that several definitions in the core CIF dictionary
+    are relevant here. For example, use:
+      _diffrn_radiation_wavelength.value for the source wavelength,
+      _diffrn_radiation_wavelength.type for the X-ray wavelength type,
+      _diffrn_source.device and _diffrn_source.details for the radiation source,
+      _diffrn_radiation.polarisn_ratio for the source polarization,
+      _diffrn_radiation.probe for the radiation type.
+    For data sets measured with partially monochromatized radiation,
+    for example, where both Kα~1~ and Kα~2~ are present, it is
+    important that all wavelengths present are included in a
+    loop_ using _diffrn_radiation_wavelength.value to define the
+    wavelength and _diffrn_radiation_wavelength.wt to define the
+    relative intensity of that wavelength. It is required that
+    _diffrn_radiation_wavelength.id also be present in the
+    wavelength loop. It may also be useful to
+    create a "dummy" ID to use for labelling
+    peaks/reflections where the Kα~1~ and Kα~2~ wavelengths are
+    not resolved. Set _diffrn_radiation_wavelength.wt to be 0 for
+    such a dummy ID.
+
+    In the PD_INSTR definitions, the term monochromator refers
+    to a primary beam (pre-specimen) monochromator and the term
+    analyser refers to post-diffraction (post-specimen)
+    monochromator. The analyser may be fixed for specific
+    wavelength or may be capable of being scanned.
+
+    It is strongly recommended that the core dictionary term
+    _diffrn_radiation.probe (specifying the nature of the radiation
+    used) is employed for all data sets.
+;
+    _name.category_id             PD_GROUP
+    _name.object_id               PD_INSTR
+    _category_key.name            '_pd_instr.id'
+
+save_
+
+save_pd_instr.2theta_monochr_pre
+
+    _definition.id                '_pd_instr.2theta_monochr_pre'
+    _alias.definition_id          '_pd_instr_2theta_monochr_pre'
+    _definition.update            2016-10-20
+    _description.text
+;
+    The 2θ angle for a pre-specimen monochromator (see also
+    _pd_instr.monochr_pre_spec).
+;
+    _name.category_id             pd_instr
+    _name.object_id               2theta_monochr_pre
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            -180.0:180.0
+    _units.code                   degrees
+
+save_
+
+save_pd_instr.beam_size_ax
+
+    _definition.id                '_pd_instr.beam_size_ax'
+    _alias.definition_id          '_pd_instr_beam_size_ax'
+    _definition.update            2014-06-20
+    _description.text
+;
+    Axial dimension of the radiation beam
+    at the specimen position (in millimetres).
+    The perpendicular to the plane containing the incident
+    and scattered beam is the axial (*_ax) direction.
+;
+    _name.category_id             pd_instr
+    _name.object_id               size_ax
+    _type.purpose                 Number
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   millimetres
+
+save_
+
+save_pd_instr.beam_size_eq
+
+    _definition.id                '_pd_instr.beam_size_eq'
+    _alias.definition_id          '_pd_instr_beam_size_eq'
+    _definition.update            2014-06-20
+    _description.text
+;
+    Equatorial dimensions of the radiation beam
+    at the specimen position (in millimetres).
+    The equatorial dimension is in the plane of scattering.
+;
+    _name.category_id             pd_instr
+    _name.object_id               size_eq
+    _type.purpose                 Number
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   millimetres
+
+save_
+
+save_pd_instr.cons_illum_flag
+
+    _definition.id                '_pd_instr.cons_illum_flag'
+    _alias.definition_id          '_pd_instr_cons_illum_flag'
+    _definition.update            2014-06-20
+    _description.text
+;
+    Use 'yes' for instruments where the divergence slit is
+    θ-compensated to yield a constant illumination length
+    (also see _pd_instr.cons_illum_len).
+
+    For other flat-plate instruments, where the illumination
+    length changes with 2θ, specify 'no'. Note that
+    if the length is known, it may be specified using
+    _pd_instr.var_illum_len.
+;
+    _name.category_id             pd_instr
+    _name.object_id               cons_illum_flag
+    _type.purpose                 State
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Code
+
+    loop_
+      _enumeration_set.state
+         yes
+         no
+
+save_
+
+save_pd_instr.cons_illum_len
+
+    _definition.id                '_pd_instr.cons_illum_len'
+    _alias.definition_id          '_pd_instr_cons_illum_len'
+    _definition.update            2023-01-22
+    _description.text
+;
+    Use _pd_instr.cons_illum_len for instruments where the length of
+    specimen illuminated does not vary with 2θ, usually achieved by
+    adjustment of the divergence slits (sometimes known as
+    θ-compensated slits).
+;
+    _name.category_id             pd_instr
+    _name.object_id               cons_illum_len
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   millimetres
+
+save_
+
+save_pd_instr.detector_circle_radius
+
+    _definition.id                '_pd_instr.detector_circle_radius'
+    _definition.update            2022-12-04
+    _description.text
+;
+    The radius of the detector circle (also called the 'goniometer circle'
+    or 'diffractometer circle').
+
+    The detector circle is defined either by the centre of the active window
+    of a stationary detector, or, in most cases, by a detector moving around
+    the specimen. The radius is the distance from the specimen to the
+    detector.
+
+    In this construction, the detector radius is constant for all measurement
+    points. For geometries where this is not the case, see
+    _pd_instr.dist_vsrc_spec and _pd_instr.dist_spec_vdetc.
+
+    Where the specimen-detector distance is difficult to define, for example,
+    for a large, flat, area detector, the distance refers to the closest
+    approach of the detector to the specimen.
+
+    See the discussion on 'detector circle' or 'goniometer circle' in
+    International Tables Vol H, S2.1.4.1 for further information.
+;
+    _name.category_id             pd_instr
+    _name.object_id               detector_circle_radius
+    _type.purpose                 Number
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   millimetres
+
+save_
+
+save_pd_instr.dist_mono_spec
+
+    _definition.id                '_pd_instr.dist_mono_spec'
+    _alias.definition_id          '_pd_instr_dist_mono/spec'
+    _definition.update            2014-06-20
+    _description.text
+;
+    Specifies distances in millimetres from the monochromator to the specimen.
+    Note that *_src_spec is used in place of *_src_mono and
+    *_mono_spec if there is no monochromator in use.
+;
+    _name.category_id             pd_instr
+    _name.object_id               dist_mono_spec
+    _type.purpose                 Number
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   millimetres
+
+save_
+
+save_pd_instr.dist_src_mono
+
+    _definition.id                '_pd_instr.dist_src_mono'
+    _alias.definition_id          '_pd_instr_dist_src/mono'
+    _definition.update            2023-01-06
+    _description.text
+;
+    Specifies distance in millimetres from the radiation source to
+    the monochromator. Note that *_src_spec is used in place of
+    *_src_mono and *_mono_spec if there is no monochromator in use.
+;
+    _name.category_id             pd_instr
+    _name.object_id               dist_src_mono
+    _type.purpose                 Number
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   millimetres
+
+save_
+
+save_pd_instr.dist_src_spec
+
+    _definition.id                '_pd_instr.dist_src_spec'
+    _alias.definition_id          '_pd_instr_dist_src/spec'
+    _definition.update            2023-01-06
+    _description.text
+;
+    Specifies distances in millimetres from the radiation source to
+    the specimen. Note that *_src_spec is used in place of
+    *_src_mono and *_mono_spec if there is no monochromator in use
+;
+    _name.category_id             pd_instr
+    _name.object_id               dist_src_spec
+    _type.purpose                 Number
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   millimetres
+
+save_
+
+save_pd_instr.divg_ax_mono_spec
+
+    _definition.id                '_pd_instr.divg_ax_mono_spec'
+    _alias.definition_id          '_pd_instr_divg_ax_mono/spec'
+    _definition.update            2016-10-20
+    _description.text
+;
+    Describes collimation in the axial direction
+    (perpendicular to the plane containing the incident
+    and diffracted beams) between the monochromator and the specimen.
+    Values are the maximum divergence angles in
+    degrees, as limited by slits or beamline optics
+    other than Soller slits (see _pd_instr.soller_ax_*).
+    Note that *_src_spec is used in place of *_src_mono and
+    *_mono_spec if there is no monochromator in use.
+;
+    _name.category_id             pd_instr
+    _name.object_id               divg_ax_mono_spec
+    _type.purpose                 Number
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   degrees
+
+save_
+
+save_pd_instr.divg_ax_src_mono
+
+    _definition.id                '_pd_instr.divg_ax_src_mono'
+    _alias.definition_id          '_pd_instr_divg_ax_src/mono'
+    _definition.update            2023-01-06
+    _description.text
+;
+    Describes collimation in the axial direction (perpendicular to
+    the plane containing the incident and diffracted beams) between
+    the radiation source and monochromator. Values are the maximum
+    divergence angles in degrees, as limited by slits or beamline
+    optics other than Soller slits (see _pd_instr.soller_ax_*). Note
+    that *_src_spec is used in place of *_src_mono and *_mono_spec
+    if there is no monochromator in use.
+;
+    _name.category_id             pd_instr
+    _name.object_id               divg_ax_src_mono
+    _type.purpose                 Number
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   degrees
+
+save_
+
+save_pd_instr.divg_ax_src_spec
+
+    _definition.id                '_pd_instr.divg_ax_src_spec'
+    _alias.definition_id          '_pd_instr_divg_ax_src/spec'
+    _definition.update            2016-10-20
+    _description.text
+;
+    Describes collimation in the axial direction
+    (perpendicular to the plane containing the incident
+    and diffracted beams)  between the radiation source and specimen.
+    Values are the maximum divergence angles in
+    degrees, as limited by slits or beamline optics
+    other than Soller slits (see _pd_instr.soller_ax_*).
+    Note that *_src_spec is used in place of *_src_mono and
+    *_mono_spec if there is no monochromator in use
+;
+    _name.category_id             pd_instr
+    _name.object_id               divg_ax_src_spec
+    _type.purpose                 Number
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   degrees
+
+save_
+
+save_pd_instr.divg_eq_mono_spec
+
+    _definition.id                '_pd_instr.divg_eq_mono_spec'
+    _alias.definition_id          '_pd_instr_divg_eq_mono/spec'
+    _definition.update            2016-10-20
+    _description.text
+;
+    Describes collimation in the equatorial plane (the plane
+    containing the incident and diffracted beams) between the monochromator and
+    the specimen Values are the maximum divergence angles in
+    degrees, as limited by slits or beamline optics
+    other than Soller slits (see _pd_instr.soller_eq_*).
+    Note that *_src_spec is used in place of *_src_mono and
+    *_mono_spec if there is no monochromator in use.
+;
+    _name.category_id             pd_instr
+    _name.object_id               divg_eq_mono_spec
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   degrees
+
+save_
+
+save_pd_instr.divg_eq_src_mono
+
+    _definition.id                '_pd_instr.divg_eq_src_mono'
+    _alias.definition_id          '_pd_instr_divg_eq_src/mono'
+    _definition.update            2023-01-06
+    _description.text
+;
+    Describes collimation in the equatorial plane (the plane
+    containing the incident and diffracted beams) between the radiation source
+    and monochromator. Values are the maximum divergence angles in
+    degrees, as limited by slits or beamline optics
+    other than Soller slits (see _pd_instr.soller_eq_*).
+    Note that *_src_spec is used in place of *_src_mono and
+    *_mono_spec if there is no monochromator in use.
+;
+    _name.category_id             pd_instr
+    _name.object_id               divg_eq_src_mono
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   degrees
+
+save_
+
+save_pd_instr.divg_eq_src_spec
+
+    _definition.id                '_pd_instr.divg_eq_src_spec'
+    _alias.definition_id          '_pd_instr_divg_eq_src/spec'
+    _definition.update            2023-01-06
+    _description.text
+;
+    Describes collimation in the equatorial plane (the plane
+    containing the incident and diffracted beams) between the
+    radiation source and specimen. Values are the maximum
+    divergence angles in degrees, as limited by slits or beamline
+    optics other than Soller slits (see _pd_instr.soller_eq_*). Note
+    that *_src_spec is used in place of *_src_mono and *_mono_spec
+    if there is no monochromator in use.
+;
+    _name.category_id             pd_instr
+    _name.object_id               divg_eq_src_spec
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   degrees
+
+save_
+
+save_pd_instr.geometry
+
+    _definition.id                '_pd_instr.geometry'
+    _alias.definition_id          '_pd_instr_geometry'
+    _definition.update            2014-06-20
+    _description.text
+;
+    A description of the diffractometer type or geometry.
+;
+    _name.category_id             pd_instr
+    _name.object_id               geometry
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+
+    loop_
+      _description_example.case
+;
+       Bragg-Brentano
+;
+;
+       Guinier
+;
+;
+       Parallel-beam non-focusing optics with channel-cut
+        monochromator and linear position-sensitive detector
+;
+
+save_
+
+save_pd_instr.id
+
+    _definition.id                '_pd_instr.id'
+    _definition.update            2023-03-25
+    _description.text
+;
+    Arbitrary label identifying a powder diffraction instrument.
+;
+    _name.category_id             pd_instr
+    _name.object_id               id
+    _type.purpose                 Key
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_pd_instr.location
+
+    _definition.id                '_pd_instr.location'
+    _alias.definition_id          '_pd_instr_location'
+    _definition.update            2014-06-20
+    _description.text
+;
+    The name and location of the instrument where measurements
+    were made. This is used primarily to identify data sets
+    measured away from the author's home facility, at shared
+    resources such as a reactor or spallation source.
+;
+    _name.category_id             pd_instr
+    _name.object_id               location
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+    _description_example.case
+        'SEPD diffractometer, IPNS, Argonne National Lab (USA)'
+
+save_
+
+save_pd_instr.monochr_pre_spec
+
+    _definition.id                '_pd_instr.monochr_pre_spec'
+    _alias.definition_id          '_pd_instr_monochr_pre_spec'
+    _definition.update            2014-06-20
+    _description.text
+;
+    Indicates the method used to obtain monochromatic radiation.
+    Use _pd_instr.monochr_pre_spec to describe the primary beam
+    monochromator (pre-specimen monochromation). Use
+    _pd_instr.monochr_post_spec to specify the
+    post-diffraction analyser (post-specimen monochromation).
+
+    When a monochromator crystal is used, the material and the
+    indices of the Bragg reflection are specified.
+
+    Note that monochromators may have either 'parallel' or
+    'antiparallel' orientation. It is assumed that the
+    geometry is parallel unless specified otherwise.
+    In a parallel geometry, the position of the monochromator
+    allows the incident beam and the final post-specimen
+    and post-monochromator beam to be as close to parallel
+    as possible. In a parallel geometry, the diffracting
+    planes in the specimen and monochromator will be parallel
+    when 2θ~monochromator~ is equal to 2θ~specimen~.
+    For further discussion see R. Jenkins & R. Snyder (1996).
+    Introduction to X-ray Powder Diffraction,
+    pp. 164-165. New York: Wiley.
+;
+    _name.category_id             pd_instr
+    _name.object_id               monochr_pre_spec
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+
+    loop_
+      _description_example.case
+         'Zr filter'
+         'Ge 220'
+         'none'
+         'equatorial mounted graphite (0001)'
+         'Si (111), antiparallel'
+
+save_
+
+save_pd_instr.slit_ax_mono_spec
+
+    _definition.id                '_pd_instr.slit_ax_mono_spec'
+    _alias.definition_id          '_pd_instr_slit_ax_mono/spec'
+    _definition.update            2016-10-20
+    _description.text
+;
+    Describes collimation in the axial direction
+    (perpendicular to the plane containing the incident
+    and diffracted beams) for the instrument as a slit width
+    (as opposed to a divergence angle).
+    Values are the width of the slit (in millimetres) defining
+    collimation between the monochromator and the specimen.
+    Note that *_src_spec is used in place of *_src_mono and
+    *_mono_spec if there is no monochromator in use.
+;
+    _name.category_id             pd_instr
+    _name.object_id               slit_ax_mono_spec
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   millimetres
+
+save_
+
+save_pd_instr.slit_ax_src_mono
+
+    _definition.id                '_pd_instr.slit_ax_src_mono'
+    _alias.definition_id          '_pd_instr_slit_ax_src/mono'
+    _definition.update            2023-01-06
+    _description.text
+;
+    Describes collimation in the axial direction (perpendicular to
+    the plane containing the incident and diffracted beams) for the
+    instrument as a slit width (as opposed to a divergence angle).
+    Values are the width of the slit (in millimetres) defining
+    collimation between the radiation source and monochromator.
+    Note that *_src_spec is used in place of *_src_mono and
+    *_mono_spec if there is no monochromator in use.
+;
+    _name.category_id             pd_instr
+    _name.object_id               slit_ax_src_mono
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   millimetres
+
+save_
+
+save_pd_instr.slit_ax_src_spec
+
+    _definition.id                '_pd_instr.slit_ax_src_spec'
+    _alias.definition_id          '_pd_instr_slit_ax_src/spec'
+    _definition.update            2023-01-06
+    _description.text
+;
+    Describes collimation in the axial direction (perpendicular to
+    the plane containing the incident and diffracted beams) for the
+    instrument as a slit width (as opposed to a divergence angle).
+    Values are the width of the slit (in millimetres) defining
+    collimation between the radiation source and the specimen. Note
+    that *_src_spec is used in place of *_src_mono and *_mono_spec
+    if there is no monochromator in use.
+;
+    _name.category_id             pd_instr
+    _name.object_id               slit_ax_src_spec
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   millimetres
+
+save_
+
+save_pd_instr.slit_eq_mono_spec
+
+    _definition.id                '_pd_instr.slit_eq_mono_spec'
+    _alias.definition_id          '_pd_instr_slit_eq_mono/spec'
+    _definition.update            2023-01-06
+    _description.text
+;
+    Describes collimation in the equatorial plane (the plane
+    containing the incident and diffracted beams) for the
+    instrument as a slit width (as opposed to a divergence angle).
+    Values are the width of the slit (in millimetres) defining
+    collimation between the monochromator and the specimen.
+    Note that *_src_spec is used in place of *_src_mono and
+    *_mono_spec if there is no monochromator in use.
+;
+    _name.category_id             pd_instr
+    _name.object_id               slit_eq_mono_spec
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   millimetres
+
+save_
+
+save_pd_instr.slit_eq_src_mono
+
+    _definition.id                '_pd_instr.slit_eq_src_mono'
+    _alias.definition_id          '_pd_instr_slit_eq_src/mono'
+    _definition.update            2023-01-06
+    _description.text
+;
+    Describes collimation in the equatorial plane (the plane
+    containing the incident and diffracted beams) for the
+    instrument as a slit width (as opposed to a divergence angle).
+    Values are the width of the slit (in millimetres) defining
+    collimation between the radiation source and monochromator.
+    Note that *_src_spec is used in place of *_src_mono and
+    *_mono_spec if there is no monochromator in use.
+;
+    _name.category_id             pd_instr
+    _name.object_id               slit_eq_src_mono
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   millimetres
+
+save_
+
+save_pd_instr.slit_eq_src_spec
+
+    _definition.id                '_pd_instr.slit_eq_src_spec'
+    _alias.definition_id          '_pd_instr_slit_eq_src/spec'
+    _definition.update            2023-01-06
+    _description.text
+;
+    Describes collimation in the equatorial plane (the plane
+    containing the incident and diffracted beams) for the
+    instrument as a slit width (as opposed to a divergence angle).
+    Values are the width of the slit (in millimetres) defining
+    collimation between the radiation source and the specimen.
+    Note that *_src_spec is used in place of *_src_mono and
+    *_mono_spec if there is no monochromator in use.
+;
+    _name.category_id             pd_instr
+    _name.object_id               slit_eq_src_spec
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   millimetres
+
+save_
+
+save_pd_instr.soller_ax_mono_spec
+
+    _definition.id                '_pd_instr.soller_ax_mono_spec'
+    _alias.definition_id          '_pd_instr_soller_ax_mono/spec'
+    _definition.update            2023-01-06
+    _description.text
+;
+    Describes collimation in the axial direction (perpendicular to
+    the plane containing the incident and diffracted beams) for the
+    instrument. Values are the maximum divergence angles in
+    degrees, as limited by Soller slits located between the
+    monochromator and specimen. Note that *_src_spec is used in
+    place of *_src_mono and *_mono_spec if there is no monochromator
+    in use.
+;
+    _name.category_id             pd_instr
+    _name.object_id               soller_ax_mono_spec
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   degrees
+
+save_
+
+save_pd_instr.soller_ax_src_mono
+
+    _definition.id                '_pd_instr.soller_ax_src_mono'
+    _alias.definition_id          '_pd_instr_soller_ax_src/mono'
+    _definition.update            2014-06-20
+    _description.text
+;
+    Describes collimation in the axial direction
+    (perpendicular to the plane containing the incident
+    and diffracted beams) for the instrument.
+    Values are the maximum divergence angles in
+    degrees, as limited by Soller slits located thus:
+    Collimation between the radiation source and monochromator;
+    Note that *_src_spec is used in place of *_src_mono and
+    *_mono_spec if there is no monochromator in use, and
+    *_spec_detc is used in place of *_spec_anal and
+    *_anal_detc if there is no analyser in use.
+;
+    _name.category_id             pd_instr
+    _name.object_id               soller_ax_src_mono
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   degrees
+
+save_
+
+save_pd_instr.soller_ax_src_spec
+
+    _definition.id                '_pd_instr.soller_ax_src_spec'
+    _alias.definition_id          '_pd_instr_soller_ax_src/spec'
+    _definition.update            2023-01-06
+    _description.text
+;
+    Describes collimation in the axial direction (perpendicular to
+    the plane containing the incident and diffracted beams) for the
+    instrument. Values are the maximum divergence angles in
+    degrees, as limited by Soller slits located between the
+    radiation source and specimen. Note that *_src_spec is used in
+    place of *_src_mono and *_mono_spec if there is no monochromator
+    in use.
+;
+    _name.category_id             pd_instr
+    _name.object_id               soller_ax_src_spec
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   degrees
+
+save_
+
+save_pd_instr.soller_eq_mono_spec
+
+    _definition.id                '_pd_instr.soller_eq_mono_spec'
+    _alias.definition_id          '_pd_instr_soller_eq_mono/spec'
+    _definition.update            2016-10-20
+    _description.text
+;
+    Describes collimation in the equatorial plane (the plane
+    containing the incident and diffracted beams) for
+    the instrument. Values are the maximum divergence angles in
+    degrees, as limited by Soller slits located between the monochromator and
+    the specimen. Note that *_src_spec is used in place of *_src_mono and
+    *_mono_spec if there is no monochromator in use.
+;
+    _name.category_id             pd_instr
+    _name.object_id               soller_eq_mono_spec
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   degrees
+
+save_
+
+save_pd_instr.soller_eq_src_mono
+
+    _definition.id                '_pd_instr.soller_eq_src_mono'
+    _alias.definition_id          '_pd_instr_soller_eq_src/mono'
+    _definition.update            2014-06-20
+    _description.text
+;
+    Describes collimation in the equatorial plane (the plane
+    containing the incident and diffracted beams) for
+    the instrument. Values are the maximum divergence angles in
+    degrees, as limited by Soller slits located thus:
+    Collimation between the radiation source and monochromator;
+    Note that *_src_spec is used in place of *_src_mono and
+    *_mono_spec if there is no monochromator in use, and
+    *_spec_detc is used in place of *_spec_anal and
+    *_anal_detc if there is no analyser in use.
+;
+    _name.category_id             pd_instr
+    _name.object_id               soller_eq_src_mono
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   degrees
+
+save_
+
+save_pd_instr.soller_eq_src_spec
+
+    _definition.id                '_pd_instr.soller_eq_src_spec'
+    _alias.definition_id          '_pd_instr_soller_eq_src/spec'
+    _definition.update            2023-01-06
+    _description.text
+;
+    Describes collimation in the equatorial plane (the plane
+    containing the incident and diffracted beams) for the
+    instrument. Values are the maximum divergence angles in degrees,
+    as limited by Soller slits located between the radiation source
+    and monochromator. Note that *_src_spec is used in place of
+    *_src_mono and *_mono_spec if there is no monochromator in use.
+;
+    _name.category_id             pd_instr
+    _name.object_id               soller_eq_src_spec
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   degrees
+
+save_
+
+save_pd_instr.source_size_ax
+
+    _definition.id                '_pd_instr.source_size_ax'
+    _alias.definition_id          '_pd_instr_source_size_ax'
+    _definition.update            2023-01-06
+    _description.text
+;
+    Axial intrinsic dimension of the radiation source (in
+    millimetres). The perpendicular to the plane containing the
+    incident and scattered beam is the axial (*_ax) direction.
+;
+    _name.category_id             pd_instr
+    _name.object_id               source_size_ax
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   millimetres
+
+save_
+
+save_pd_instr.source_size_eq
+
+    _definition.id                '_pd_instr.source_size_eq'
+    _alias.definition_id          '_pd_instr_source_size_eq'
+    _definition.update            2023-01-06
+    _description.text
+;
+    Equatorial intrinsic dimension of the radiation source (in
+    millimetres). The equatorial direction is in the plane
+    containing the incident and scattered beam.
+;
+    _name.category_id             pd_instr
+    _name.object_id               source_size_eq
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   millimetres
+
+save_
+
+save_pd_instr.special_details
+
+    _definition.id                '_pd_instr.special_details'
+    _alias.definition_id          '_pd_instr_special_details'
+    _definition.update            2014-06-20
+    _description.text
+;
+    A brief description of the instrument giving
+    details that cannot be given in other
+    PD_INSTR entries.
+;
+    _name.category_id             pd_instr
+    _name.object_id               special_details
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_PD_INSTR_DETECTOR
+
+    _definition.id                PD_INSTR_DETECTOR
+    _definition.scope             Category
+    _definition.class             Loop
+    _definition.update            2023-01-06
+    _description.text
+;
+    This section contains information relevant to the detector
+    geometry used for the diffraction measurement. For most laboratories,
+    very little of this information will change, so a standard file
+    may be prepared and included with each data set.
+
+    The term analyser refers to post-diffraction (post-specimen)
+    monochromator. The analyser may be fixed for specific
+    wavelength or may be capable of being scanned.
+
+    For multiple-detector instruments it may be necessary to loop the
+    *_anal_detc or *_spec_detc values (for  _pd_instr.dist_*,
+    _pd_instr.divg_*, _pd_instr.slit_* and  _pd_instr.soller_*) with
+    the detector ID's (_pd_instr_detector.id).
+;
+    _name.category_id             PD_GROUP
+    _name.object_id               PD_INSTR_DETECTOR
+    _category_key.name            '_pd_instr_detector.id'
+
+save_
+
+save_pd_instr.2theta_monochr_post
+
+    _definition.id                '_pd_instr.2theta_monochr_post'
+    _alias.definition_id          '_pd_instr_2theta_monochr_post'
+    _definition.update            2023-01-06
+    _description.text
+;
+    The 2θ angle for a post-specimen
+    monochromator (also called an analyser)
+    (see also _pd_instr.monochr_post_spec).
+;
+    _name.category_id             pd_instr_detector
+    _name.object_id               2theta_monochr_post
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            -180.0:180.0
+    _units.code                   degrees
+
+save_
+
+save_pd_instr.dist_anal_detc
+
+    _definition.id                '_pd_instr.dist_anal_detc'
+    _alias.definition_id          '_pd_instr_dist_anal/detc'
+    _definition.update            2016-10-20
+    _description.text
+;
+    Specifies the distance in millimetres from the analyser to the detector.
+    Note that *_spec_detc is used in place of *_anal_detc
+    if there is no analyser in use.
+;
+    _name.category_id             pd_instr_detector
+    _name.object_id               dist_anal_detc
+    _type.purpose                 Number
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   millimetres
+
+save_
+
+save_pd_instr.dist_spec_anal
+
+    _definition.id                '_pd_instr.dist_spec_anal'
+    _alias.definition_id          '_pd_instr_dist_spec/anal'
+    _definition.update            2023-01-06
+    _description.text
+;
+    Specifies distances in millimetres from the specimen to the
+    analyser. Note that *_spec_detc is used in place of *_spec_anal
+    if there is no analyser in use.
+;
+    _name.category_id             pd_instr_detector
+    _name.object_id               dist_spec_anal
+    _type.purpose                 Number
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   millimetres
+
+save_
+
+save_pd_instr.dist_spec_detc
+
+    _definition.id                '_pd_instr.dist_spec_detc'
+    _alias.definition_id          '_pd_instr_dist_spec/detc'
+    _definition.update            2023-01-06
+    _description.text
+;
+    Specifies distance in millimetres from the specimen to the
+    detector. Note that *_spec_anal and *_anal_detc are used
+    instead of *_spec_detc if there is an analyser in use.
+;
+    _name.category_id             pd_instr_detector
+    _name.object_id               dist_spec_detc
+    _type.purpose                 Number
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   millimetres
+
+save_
+
+save_pd_instr.divg_ax_anal_detc
+
+    _definition.id                '_pd_instr.divg_ax_anal_detc'
+    _alias.definition_id          '_pd_instr_divg_ax_anal/detc'
+    _definition.update            2023-01-06
+    _description.text
+;
+    Describes collimation in the axial direction (perpendicular to
+    the plane containing the incident and diffracted beams) between
+    the analyser and the detector. Values are the maximum divergence
+    angles in degrees, as limited by slits or beamline optics other
+    than Soller slits (see _pd_instr.soller_ax_*). Note that
+    *_spec_detc is used in place of *_spec_anal and *_anal_detc if
+    there is no analyser in use.
+;
+    _name.category_id             pd_instr_detector
+    _name.object_id               divg_ax_anal_detc
+    _type.purpose                 Number
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   degrees
+
+save_
+
+save_pd_instr.divg_ax_spec_anal
+
+    _definition.id                '_pd_instr.divg_ax_spec_anal'
+    _alias.definition_id          '_pd_instr_divg_ax_spec/anal'
+    _definition.update            2023-01-06
+    _description.text
+;
+    Describes collimation in the axial direction
+    (perpendicular to the plane containing the incident
+    and diffracted beams) between the specimen and the analyser.
+    Values are the maximum divergence angles in
+    degrees, as limited by slits or beamline optics
+    other than Soller slits (see _pd_instr.soller_ax_*).
+    Note that *_spec_detc is used in place of *_spec_anal and *_anal_detc
+    if there is no analyser in use.
+;
+    _name.category_id             pd_instr_detector
+    _name.object_id               divg_ax_spec_anal
+    _type.purpose                 Number
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   degrees
+
+save_
+
+save_pd_instr.divg_ax_spec_detc
+
+    _definition.id                '_pd_instr.divg_ax_spec_detc'
+    _alias.definition_id          '_pd_instr_divg_ax_spec/detc'
+    _definition.update            2023-01-06
+    _description.text
+;
+    Describes collimation in the axial direction
+    (perpendicular to the plane containing the incident
+    and diffracted beams) between the specimen and the detector.
+    Values are the maximum divergence angles in
+    degrees, as limited by slits or beamline optics
+    other than Soller slits (see _pd_instr.soller_ax_*). Note that
+    *_spec_detc is used in place of *_spec_anal and *_anal_detc
+    if there is no analyser in use.
+;
+    _name.category_id             pd_instr_detector
+    _name.object_id               divg_ax_spec_detc
+    _type.purpose                 Number
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   degrees
+
+save_
+
+save_pd_instr.divg_eq_anal_detc
+
+    _definition.id                '_pd_instr.divg_eq_anal_detc'
+    _alias.definition_id          '_pd_instr_divg_eq_anal/detc'
+    _definition.update            2023-01-06
+    _description.text
+;
+    Describes collimation in the equatorial plane (the plane
+    containing the incident and diffracted beams) between the
+    analyser and the detector. Values are the maximum divergence
+    angles in degrees, as limited by slits or beamline optics other
+    than Soller slits (see _pd_instr.soller_eq_*). Note that
+    *_spec_detc is used in place of *_spec_anal and *_anal_detc if
+    there is no analyser in use.
+;
+    _name.category_id             pd_instr_detector
+    _name.object_id               divg_eq_anal_detc
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   degrees
+
+save_
+
+save_pd_instr.divg_eq_spec_anal
+
+    _definition.id                '_pd_instr.divg_eq_spec_anal'
+    _alias.definition_id          '_pd_instr_divg_eq_spec/anal'
+    _definition.update            2023-01-06
+    _description.text
+;
+    Describes collimation in the equatorial plane (the plane
+    containing the incident and diffracted beams) between the
+    specimen and the analyser. Values are the maximum divergence
+    angles in degrees, as limited by slits or beamline optics other
+    than Soller slits (see _pd_instr.soller_eq_*). Note that
+    *_spec_detc is used in place of *_spec_anal and *_anal_detc if
+    there is no analyser in use.
+;
+    _name.category_id             pd_instr_detector
+    _name.object_id               divg_eq_spec_anal
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   degrees
+
+save_
+
+save_pd_instr.divg_eq_spec_detc
+
+    _definition.id                '_pd_instr.divg_eq_spec_detc'
+    _alias.definition_id          '_pd_instr_divg_eq_spec/detc'
+    _definition.update            2023-01-06
+    _description.text
+;
+    Describes collimation in the equatorial plane (the plane
+    containing the incident and diffracted beams) between the
+    specimen and the detector. Values are the maximum divergence
+    angles in degrees, as limited by slits or beamline optics other
+    than Soller slits (see _pd_instr.soller_eq_*). Note that
+    *_spec_detc is used in place of *_spec_anal and *_anal_detc if
+    there is no analyser in use.
+;
+    _name.category_id             pd_instr_detector
+    _name.object_id               divg_eq_spec_detc
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   degrees
+
+save_
+
+save_pd_instr.monochr_post_spec
+
+    _definition.id                '_pd_instr.monochr_post_spec'
+    _alias.definition_id          '_pd_instr_monochr_post_spec'
+    _definition.update            2014-10-20
+    _description.text
+;
+    Indicates the method used to obtain monochromatic radiation.
+    Use _pd_instr.monochr_pre_spec to describe the primary beam
+    monochromator (pre-specimen monochromation). Use
+    _pd_instr.monochr_post_spec to specify the
+    post-diffraction analyser (post-specimen monochromation).
+
+    When a monochromator crystal is used, the material and the
+    indices of the Bragg reflection are specified.
+
+    Note that monochromators may have either 'parallel' or
+    'antiparallel' orientation. It is assumed that the
+    geometry is parallel unless specified otherwise.
+    In a parallel geometry, the position of the monochromator
+    allows the incident beam and the final post-specimen
+    and post-monochromator beam to be as close to parallel
+    as possible. In a parallel geometry, the diffracting
+    planes in the specimen and monochromator will be parallel
+    when 2θ~monochromator~ is equal to 2θ~specimen~.
+    For further discussion see R. Jenkins & R. Snyder (1996).
+    Introduction to X-ray Powder Diffraction,
+    pp. 164-165. New York: Wiley.
+;
+    _name.category_id             pd_instr_detector
+    _name.object_id               monochr_post_spec
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+
+    loop_
+      _description_example.case
+         'Zr filter'
+         'Ge 220'
+         'none'
+         'equatorial mounted graphite (0001)'
+         'Si (111), antiparallel'
+
+save_
+
+save_pd_instr.slit_ax_anal_detc
+
+    _definition.id                '_pd_instr.slit_ax_anal_detc'
+    _alias.definition_id          '_pd_instr_slit_ax_anal/detc'
+    _definition.update            2023-01-06
+    _description.text
+;
+    Describes collimation in the axial direction (perpendicular to
+    the plane containing the incident and diffracted beams) for the
+    instrument as a slit width (as opposed to a divergence angle).
+    Values are the width of the slit (in millimetres) defining
+    collimation between the analyser and the detector. Note that
+    *_spec_detc is used in place of *_spec_anal and *_anal_detc if
+    there is no analyser in use.
+;
+    _name.category_id             pd_instr_detector
+    _name.object_id               slit_ax_anal_detc
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   millimetres
+
+save_
+
+save_pd_instr.slit_ax_spec_anal
+
+    _definition.id                '_pd_instr.slit_ax_spec_anal'
+    _alias.definition_id          '_pd_instr_slit_ax_spec/anal'
+    _definition.update            2023-01-06
+    _description.text
+;
+    Describes collimation in the axial direction (perpendicular to
+    the plane containing the incident and diffracted beams) for the
+    instrument as a slit width (as opposed to a divergence angle).
+    Values are the width of the slit (in millimetres) defining
+    collimation between the specimen and the analyser. Note that
+    *_spec_detc is used in place of *_spec_anal and *_anal_detc if
+    there is no analyser in use.
+;
+    _name.category_id             pd_instr_detector
+    _name.object_id               slit_ax_spec_anal
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   millimetres
+
+save_
+
+save_pd_instr.slit_ax_spec_detc
+
+    _definition.id                '_pd_instr.slit_ax_spec_detc'
+    _alias.definition_id          '_pd_instr_slit_ax_spec/detc'
+    _definition.update            2023-01-06
+    _description.text
+;
+    Describes collimation in the axial direction (perpendicular to
+    the plane containing the incident and diffracted beams) for the
+    instrument as a slit width (as opposed to a divergence angle).
+    Values are the width of the slit (in millimetres) defining
+    collimation between the specimen and the detector. Note that
+    *_spec_detc is used in place of *_spec_anal and *_anal_detc if
+    there is no analyser in use.
+;
+    _name.category_id             pd_instr_detector
+    _name.object_id               slit_ax_spec_detc
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   millimetres
+
+save_
+
+save_pd_instr.slit_eq_anal_detc
+
+    _definition.id                '_pd_instr.slit_eq_anal_detc'
+    _alias.definition_id          '_pd_instr_slit_eq_anal/detc'
+    _definition.update            2023-01-06
+    _description.text
+;
+    Describes collimation in the equatorial plane (the plane
+    containing the incident and diffracted beams) for the instrument
+    as a slit width (as opposed to a divergence angle). Values are
+    the width of the slit (in millimetres) defining collimation
+    between the analyser and the detector. Note that *_spec_detc is
+    used in place of *_spec_anal and *_anal_detc if there is no
+    analyser in use.
+;
+    _name.category_id             pd_instr_detector
+    _name.object_id               slit_eq_anal_detc
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   millimetres
+
+save_
+
+save_pd_instr.slit_eq_spec_anal
+
+    _definition.id                '_pd_instr.slit_eq_spec_anal'
+    _alias.definition_id          '_pd_instr_slit_eq_spec/anal'
+    _definition.update            2023-01-06
+    _description.text
+;
+    Describes collimation in the equatorial plane (the plane
+    containing the incident and diffracted beams) for the instrument
+    as a slit width (as opposed to a divergence angle). Values are
+    the width of the slit (in millimetres) defining collimation
+    between the specimen and the analyser. Note that *_spec_detc is
+    used in place of *_spec_anal and *_anal_detc if there is no
+    analyser in use.
+;
+    _name.category_id             pd_instr_detector
+    _name.object_id               slit_eq_spec_anal
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   millimetres
+
+save_
+
+save_pd_instr.slit_eq_spec_detc
+
+    _definition.id                '_pd_instr.slit_eq_spec_detc'
+    _alias.definition_id          '_pd_instr_slit_eq_spec/detc'
+    _definition.update            2023-01-06
+    _description.text
+;
+    Describes collimation in the equatorial plane (the plane
+    containing the incident and diffracted beams) for the instrument
+    as a slit width (as opposed to a divergence angle). Values are
+    the width of the slit (in millimetres) defining collimation
+    between the specimen and the detector. Note that *_spec_detc is
+    used in place of *_spec_anal and *_anal_detc if there is no
+    analyser in use.
+;
+    _name.category_id             pd_instr_detector
+    _name.object_id               slit_eq_spec_detc
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   millimetres
+
+save_
+
+save_pd_instr.soller_ax_anal_detc
+
+    _definition.id                '_pd_instr.soller_ax_anal_detc'
+    _alias.definition_id          '_pd_instr_soller_ax_anal/detc'
+    _definition.update            2023-01-06
+    _description.text
+;
+    Describes collimation in the axial direction (perpendicular to
+    the plane containing the incident and diffracted beams) for the
+    instrument. Values are the maximum divergence angles in
+    degrees, as limited by Soller slits located between the analyser
+    and the detector. Note that *_spec_detc is used in place of
+    *_spec_anal and *_anal_detc if there is no analyser in use.
+;
+    _name.category_id             pd_instr_detector
+    _name.object_id               soller_ax_anal_detc
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   degrees
+
+save_
+
+save_pd_instr.soller_ax_spec_anal
+
+    _definition.id                '_pd_instr.soller_ax_spec_anal'
+    _alias.definition_id          '_pd_instr_soller_ax_spec/anal'
+    _definition.update            2023-01-06
+    _description.text
+;
+    Describes collimation in the axial direction (perpendicular to
+    the plane containing the incident and diffracted beams) for the
+    instrument. Values are the maximum divergence angles in
+    degrees, as limited by Soller slits located between the specimen
+    and the analyser. Note that *_spec_detc is used in place of
+    *_spec_anal and *_anal_detc if there is no analyser in use.
+;
+    _name.category_id             pd_instr_detector
+    _name.object_id               soller_ax_spec_anal
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   degrees
+
+save_
+
+save_pd_instr.soller_ax_spec_detc
+
+    _definition.id                '_pd_instr.soller_ax_spec_detc'
+    _alias.definition_id          '_pd_instr_soller_ax_spec/detc'
+    _definition.update            2023-01-06
+    _description.text
+;
+    Describes collimation in the axial direction (perpendicular to
+    the plane containing the incident and diffracted beams) for the
+    instrument. Values are the maximum divergence angles in
+    degrees, as limited by Soller slits located between the specimen
+    and the detector. Note that *_spec_detc is used in place of
+    *_spec_anal and *_anal_detc if there is no analyser in use.
+;
+    _name.category_id             pd_instr_detector
+    _name.object_id               soller_ax_spec_detc
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   degrees
+
+save_
+
+save_pd_instr.soller_eq_anal_detc
+
+    _definition.id                '_pd_instr.soller_eq_anal_detc'
+    _alias.definition_id          '_pd_instr_soller_eq_anal/detc'
+    _definition.update            2023-01-06
+    _description.text
+;
+    Describes collimation in the equatorial plane (the plane
+    containing the incident and diffracted beams) for the
+    instrument. Values are the maximum divergence angles in degrees,
+    as limited by Soller slits located between the analyser and the
+    detector. Note that *_spec_detc is used in place of *_spec_anal
+    and *_anal_detc if there is no analyser in use.
+;
+    _name.category_id             pd_instr_detector
+    _name.object_id               soller_eq_anal_detc
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   degrees
+
+save_
+
+save_pd_instr.soller_eq_spec_anal
+
+    _definition.id                '_pd_instr.soller_eq_spec_anal'
+    _alias.definition_id          '_pd_instr_soller_eq_spec/anal'
+    _definition.update            2023-01-06
+    _description.text
+;
+    Describes collimation in the equatorial plane (the plane
+    containing the incident and diffracted beams) for the
+    instrument. Values are the maximum divergence angles in degrees,
+    as limited by Soller slits located between the specimen and the
+    analyser. Note that *_spec_detc is used in place of *_spec_anal
+    and *_anal_detc if there is no analyser in use.
+;
+    _name.category_id             pd_instr_detector
+    _name.object_id               soller_eq_spec_anal
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   degrees
+
+save_
+
+save_pd_instr.soller_eq_spec_detc
+
+    _definition.id                '_pd_instr.soller_eq_spec_detc'
+    _alias.definition_id          '_pd_instr_soller_eq_spec/detc'
+    _definition.update            2023-01-06
+    _description.text
+;
+    Describes collimation in the equatorial plane (the plane
+    containing the incident and diffracted beams) for the
+    instrument. Values are the maximum divergence angles in degrees,
+    as limited by Soller slits located between the specimen and the
+    detector in use. Note that *_spec_detc is used in place of
+    *_spec_anal and *_anal_detc if there is no analyser in use.
+;
+    _name.category_id             pd_instr_detector
+    _name.object_id               soller_eq_spec_detc
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   degrees
+
+save_
+
+save_pd_instr_detector.id
+
+    _definition.id                '_pd_instr_detector.id'
+    _definition.update            2023-06-09
+    _description.text
+;
+    A code which identifies the detector or channel number in a
+    position-sensitive, energy-dispersive or other multiple-detector
+    instrument for which the individual instrument geometry is being
+    defined. Where a single detector is used, this may be omitted.
+;
+    _name.category_id             pd_instr_detector
+    _name.object_id               id
+    _type.purpose                 Key
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Code
+
+save_
+
+save_PD_MEAS_INFO_AUTHOR
+
+    _definition.id                PD_MEAS_INFO_AUTHOR
+    _definition.scope             Category
+    _definition.class             Loop
+    _definition.update            2023-06-05
+    _description.text
+;
+    This category is deprecated. Please see AUDIT_AUTHOR and AUDIT_AUTHOR_ROLE.
+
+    This section contains information about the person(s)
+    who conducted the measurement.
+;
+    _name.category_id             PD_GROUP
+    _name.object_id               PD_MEAS_INFO_AUTHOR
+    _category_key.name            '_pd_meas_info_author.name'
+
+save_
+
+save_pd_meas_info_author.address
+
+    _definition.id                '_pd_meas_info_author.address'
+
+    loop_
+      _definition_replaced.id
+      _definition_replaced.by
+         1                        '_audit_author.address'
+         2                        '_audit_author_role.role'
+
+    _alias.definition_id          '_pd_meas_info_author_address'
+    _definition.update            2023-06-05
+    _description.text
+;
+    This item is deprecated. Please see _audit_author.address and
+    _audit_author_role.role.
+
+    The address of the person who measured the data set. If there
+    is more than one person, this will be looped with
+    _pd_meas_info_author.name.
+;
+    _name.category_id             pd_meas_info_author
+    _name.object_id               address
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_pd_meas_info_author.email
+
+    _definition.id                '_pd_meas_info_author.email'
+
+    loop_
+      _definition_replaced.id
+      _definition_replaced.by
+         1                        '_audit_author.email'
+         2                        '_audit_author_role.role'
+
+    _alias.definition_id          '_pd_meas_info_author_email'
+    _definition.update            2023-06-05
+    _description.text
+;
+    This item is deprecated. Please see _audit_author.email and
+    _audit_author_role.role.
+
+    The e-mail address of the person who measured the data set. If
+    there is more than one person, this will be looped with
+    _pd_meas_info_author.name.
+;
+    _name.category_id             pd_meas_info_author
+    _name.object_id               email
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_pd_meas_info_author.fax
+
+    _definition.id                '_pd_meas_info_author.fax'
+
+    loop_
+      _definition_replaced.id
+      _definition_replaced.by
+         1                        '_audit_author.fax'
+         2                        '_audit_author_role.role'
+
+    _alias.definition_id          '_pd_meas_info_author_fax'
+    _definition.update            2023-06-05
+    _description.text
+;
+    This item is deprecated. Please see _audit_author.fax and
+    _audit_author_role.role.
+
+    The fax number of the person who measured the data set. If
+    there is more than one person, this will be looped with
+    _pd_meas_info_author.name. The recommended style is
+    the international dialing prefix, followed by the area code in
+    parentheses, followed by the local number with no spaces.
+;
+    _name.category_id             pd_meas_info_author
+    _name.object_id               fax
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_pd_meas_info_author.name
+
+    _definition.id                '_pd_meas_info_author.name'
+
+    loop_
+      _definition_replaced.id
+      _definition_replaced.by
+         1                        '_audit_author.name'
+         2                        '_audit_author_role.role'
+
+    _alias.definition_id          '_pd_meas_info_author_name'
+    _definition.update            2023-06-05
+    _description.text
+;
+    This item is deprecated. Please see _audit_author.name and
+    _audit_author_role.role.
+
+    The name of the person who measured the data set. The family
+    name(s), followed by a comma and including any dynastic
+    components, precedes the first name(s) or initial(s).
+    For more than one person use a loop to specify multiple values.
+;
+    _name.category_id             pd_meas_info_author
+    _name.object_id               name
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_pd_meas_info_author.phone
+
+    _definition.id                '_pd_meas_info_author.phone'
+
+    loop_
+      _definition_replaced.id
+      _definition_replaced.by
+         1                        '_audit_author.phone'
+         2                        '_audit_author_role.role'
+
+    _alias.definition_id          '_pd_meas_info_author_phone'
+    _definition.update            2023-06-05
+    _description.text
+;
+    This item is deprecated. Please see _audit_author.phone and
+    _audit_author_role.role.
+
+    The telephone number of the person who measured the data set.
+    If there is more than one person, this will be looped with
+    _pd_meas_info_author.name. The recommended style is
+    the international dialing prefix, followed by the area code in
+    parentheses, followed by the local number with no spaces.
+;
+    _name.category_id             pd_meas_info_author
+    _name.object_id               phone
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_PD_MEAS_OVERALL
+
+    _definition.id                PD_MEAS_OVERALL
+    _definition.scope             Category
+    _definition.class             Set
+    _definition.update            2025-04-18
+    _description.text
+;
+    This section contains information about the conditions used for
+    the measurement of the diffraction data set, prior to processing
+    and application of correction terms. While additional
+    information may be added to the CIF as data are processed and
+    transported between laboratories, the information in this section of
+    the CIF will rarely be changed once data collection is complete.
+;
+    _name.category_id             PD_GROUP
+    _name.object_id               PD_MEAS_OVERALL
+    _category_key.name            '_pd_meas_overall.diffractogram_id'
+
+save_
+
+save_pd_meas.2theta_fixed
+
+    _definition.id                '_pd_meas.2theta_fixed'
+    _alias.definition_id          '_pd_meas_2theta_fixed'
+    _definition.update            2022-10-11
+    _description.text
+;
+    The 2θ diffraction angle in degrees for measurements
+    in a white-beam fixed-angle experiment. For measurements
+    where 2θ is scanned, see _pd_meas.2theta_scan or
+    _pd_meas.2theta_range_*.
+;
+    _name.category_id             pd_meas_overall
+    _name.object_id               2theta_fixed
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            -180.0:360.0
+    _units.code                   degrees
+
+save_
+
+save_pd_meas.2theta_fixed_su
+
+    _definition.id                '_pd_meas.2theta_fixed_su'
+    _definition.update            2022-10-27
+    _description.text
+;
+    Standard uncertainty of _pd_meas.2theta_fixed.
+;
+    _name.category_id             pd_meas_overall
+    _name.object_id               2theta_fixed_su
+    _name.linked_item_id          '_pd_meas.2theta_fixed'
+    _units.code                   degrees
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+save_
+
+save_pd_meas.2theta_range_inc
+
+    _definition.id                '_pd_meas.2theta_range_inc'
+    _alias.definition_id          '_pd_meas_2theta_range_inc'
+    _definition.update            2022-09-28
+    _description.text
+;
+    2θ diffraction angle increment in degrees used for the
+    measurement of intensities. These may be used in place of the
+    _pd_meas.2theta_scan values for data sets measured with a
+    constant step size.
+;
+    _name.category_id             pd_meas_overall
+    _name.object_id               2theta_range_inc
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            -180.0:360.0
+    _units.code                   degrees
+
+save_
+
+save_pd_meas.2theta_range_max
+
+    _definition.id                '_pd_meas.2theta_range_max'
+    _alias.definition_id          '_pd_meas_2theta_range_max'
+    _definition.update            2014-06-20
+    _description.text
+;
+    Maximum 2θ diffraction angle in degrees used for the
+    measurement of intensities. These may be used in place of the
+    _pd_meas.2theta_scan values for data sets measured with a
+    constant step size.
+;
+    _name.category_id             pd_meas_overall
+    _name.object_id               2theta_range_max
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            -180.0:360.0
+    _units.code                   degrees
+
+save_
+
+save_pd_meas.2theta_range_min
+
+    _definition.id                '_pd_meas.2theta_range_min'
+    _alias.definition_id          '_pd_meas_2theta_range_min'
+    _definition.update            2014-06-20
+    _description.text
+;
+    Minimum 2θ diffraction angle in degrees used for the
+    measurement of intensities. These may be used in place of the
+    _pd_meas.2theta_scan values for data sets measured with a
+    constant step size.
+;
+    _name.category_id             pd_meas_overall
+    _name.object_id               2theta_range_min
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            -180.0:360.0
+    _units.code                   degrees
+
+save_
+
+save_pd_meas.angle_chi
+
+    _definition.id                '_pd_meas.angle_chi'
+    _alias.definition_id          '_pd_meas_angle_chi'
+    _definition.update            2022-10-11
+    _description.text
+;
+    The diffractometer angle in degrees for an instrument with an
+    Euler circle. The definitions for these angles follow the
+    convention of International Tables for X-ray Crystallography
+    (1974), Vol. IV, p. 276.
+;
+    _name.category_id             pd_meas_overall
+    _name.object_id               angle_chi
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            -180.0:360.0
+    _units.code                   degrees
+
+save_
+
+save_pd_meas.angle_chi_su
+
+    _definition.id                '_pd_meas.angle_chi_su'
+    _definition.update            2022-10-27
+    _description.text
+;
+    Standard uncertainty of _pd_meas.angle_chi.
+;
+    _name.category_id             pd_meas_overall
+    _name.object_id               angle_chi_su
+    _name.linked_item_id          '_pd_meas.angle_chi'
+    _units.code                   degrees
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+save_
+
+save_pd_meas.angle_omega
+
+    _definition.id                '_pd_meas.angle_omega'
+    _alias.definition_id          '_pd_meas_angle_omega'
+    _definition.update            2022-10-11
+    _description.text
+;
+    The diffractometer angle in degrees for an instrument with an
+    Euler circle. The definitions for these angles follow the
+    convention of International Tables for X-ray Crystallography
+    (1974), Vol. IV, p. 276.
+;
+    _name.category_id             pd_meas_overall
+    _name.object_id               angle_omega
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            -180.0:360.0
+    _units.code                   degrees
+
+save_
+
+save_pd_meas.angle_omega_su
+
+    _definition.id                '_pd_meas.angle_omega_su'
+    _definition.update            2022-10-27
+    _description.text
+;
+    Standard uncertainty of _pd_meas.angle_omega.
+;
+    _name.category_id             pd_meas_overall
+    _name.object_id               angle_omega_su
+    _name.linked_item_id          '_pd_meas.angle_omega'
+    _units.code                   degrees
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+save_
+
+save_pd_meas.angle_phi
+
+    _definition.id                '_pd_meas.angle_phi'
+    _alias.definition_id          '_pd_meas_angle_phi'
+    _definition.update            2022-10-11
+    _description.text
+;
+    The diffractometer angle in degrees for an instrument with an
+    Euler circle. The definitions for these angles follow the
+    convention of International Tables for X-ray Crystallography
+    (1974), Vol. IV, p. 276.
+;
+    _name.category_id             pd_meas_overall
+    _name.object_id               angle_phi
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            -180.0:360.0
+    _units.code                   degrees
+
+save_
+
+save_pd_meas.angle_phi_su
+
+    _definition.id                '_pd_meas.angle_phi_su'
+    _definition.update            2022-10-27
+    _description.text
+;
+    Standard uncertainty of _pd_meas.angle_phi.
+;
+    _name.category_id             pd_meas_overall
+    _name.object_id               angle_phi_su
+    _name.linked_item_id          '_pd_meas.angle_phi'
+    _units.code                   degrees
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+save_
+
+save_pd_meas.datetime_initiated
+
+    _definition.id                '_pd_meas.datetime_initiated'
+    _alias.definition_id          '_pd_meas_datetime_initiated'
+    _definition.update            2022-09-30
+    _description.text
+;
+    The date and time of the data-set measurement.
+    Entries should follow the standard RFC 3339 ABNF format
+    'yyyy-mm-ddThh:mm:ss{Z|[+-]zz:zz}'. Where possible, give
+    the time when the measurement was started, rather than
+    when it was completed.
+;
+    _name.category_id             pd_meas_overall
+    _name.object_id               datetime_initiated
+    _type.purpose                 Encode
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                DateTime
+
+    loop_
+      _description_example.case
+         1990-07-13T14:40:00Z
+         2042-12-13T02:37:23Z
+         2005-03-03T12:02:09.17+09:30
+         2015-10-30T22:45:00-02:00
+         1912-02-03T11:47:00Z
+         1979-09-01T12:00:00Z
+
+save_
+
+save_pd_meas.number_of_points
+
+    _definition.id                '_pd_meas.number_of_points'
+    _alias.definition_id          '_pd_meas_number_of_points'
+    _definition.update            2019-09-25
+    _description.text
+;
+    Total number of points in the measured diffractogram.
+;
+    _name.category_id             pd_meas_overall
+    _name.object_id               number_of_points
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Integer
+    _enumeration.range            1:
+    _units.code                   none
+
+save_
+
+save_pd_meas.rocking_angle
+
+    _definition.id                '_pd_meas.rocking_angle'
+    _alias.definition_id          '_pd_meas_rocking_angle'
+    _definition.update            2023-07-05
+    _description.text
+;
+    The total angular range, in degrees, through which a specimen is rotated or
+    oscillated during a measurement step (see _pd_meas.rocking_axis).
+
+    Where the rocking axis aligns with a measurement axis, and the rotation
+    range relates to the point being measured, the total angular range is
+    assumed to be centred on the measurement point.
+;
+    _name.category_id             pd_meas_overall
+    _name.object_id               rocking_angle
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:360.0
+    _units.code                   degrees
+
+save_
+
+save_pd_meas.rocking_angle_su
+
+    _definition.id                '_pd_meas.rocking_angle_su'
+    _definition.update            2022-10-27
+    _description.text
+;
+    Standard uncertainty of _pd_meas.rocking_angle.
+;
+    _name.category_id             pd_meas_overall
+    _name.object_id               rocking_angle_su
+    _name.linked_item_id          '_pd_meas.rocking_angle'
+    _units.code                   degrees
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+save_
+
+save_pd_meas.rocking_axis
+
+    _definition.id                '_pd_meas.rocking_axis'
+    _alias.definition_id          '_pd_meas_rocking_axis'
+    _definition.update            2014-06-20
+    _description.text
+;
+    The axis (or axes) used to rotate or rock the
+    specimen for better randomization of crystallites
+    (see _pd_meas.rocking_angle).
+;
+    _name.category_id             pd_meas_overall
+    _name.object_id               rocking_axis
+    _type.purpose                 State
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Code
+
+    loop_
+      _enumeration_set.state
+         chi
+         omega
+         phi
+
+save_
+
+save_pd_meas.scan_method
+
+    _definition.id                '_pd_meas.scan_method'
+    _alias.definition_id          '_pd_meas_scan_method'
+    _definition.update            2014-06-20
+    _description.text
+;
+    Code identifying the method for scanning reciprocal space.
+    The designation `fixed' should be used for measurements where
+    film, a stationary position-sensitive or area detector
+    or other non-moving detection mechanism is used to
+    measure diffraction intensities.
+;
+    _name.category_id             pd_meas_overall
+    _name.object_id               scan_method
+    _type.purpose                 State
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Code
+
+    loop_
+      _enumeration_set.state
+      _enumeration_set.detail
+         step                     'Step scan.'
+         cont                     'Continuous scan.'
+         tof                      'Time of flight.'
+         disp                     'Energy dispersive.'
+         fixed                    'Stationary detector.'
+
+save_
+
+save_pd_meas.special_details
+
+    _definition.id                '_pd_meas.special_details'
+    _alias.definition_id          '_pd_meas_special_details'
+    _definition.update            2014-06-20
+    _description.text
+;
+    Special details of the diffraction measurement process.
+    Include information about source instability, degradation etc.
+    However, this item should not be used to record information
+    that can be specified in other PD_MEAS entries.
+;
+    _name.category_id             pd_meas_overall
+    _name.object_id               special_details
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_pd_meas.units_of_intensity
+
+    _definition.id                '_pd_meas.units_of_intensity'
+    _alias.definition_id          '_pd_meas_units_of_intensity'
+    _definition.update            2014-06-20
+    _description.text
+;
+    Units for intensity measurements when _pd_meas.intensity_*
+    is used. Note that use of 'counts' or 'counts per second'
+    here is strongly discouraged: convert the intensity
+    measurements to counts and use _pd_meas.counts_* and
+    _pd_meas.step_count_time instead of _pd_meas.intensity_*.
+;
+    _name.category_id             pd_meas_overall
+    _name.object_id               units_of_intensity
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+
+    loop_
+      _description_example.case
+         'estimated from strip chart'
+         'arbitrary, from film density'
+         'counts, with automatic dead-time correction applied'
+
+save_
+
+save_pd_meas_overall.diffractogram_id
+
+    _definition.id                '_pd_meas_overall.diffractogram_id'
+    _definition.update            2023-01-12
+    _description.text
+;
+    The diffractogram (see _pd_diffractogram.id) to which the measurement
+    conditions relate.
+;
+    _name.category_id             pd_meas_overall
+    _name.object_id               diffractogram_id
+    _name.linked_item_id          '_pd_diffractogram.id'
+    _type.purpose                 Link
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_PD_PEAK
+
+    _definition.id                PD_PEAK
+    _definition.scope             Category
+    _definition.class             Loop
+    _definition.update            2023-06-10
+    _description.text
+;
+    This section contains peak information extracted from the
+    measured or, if present, the processed diffractogram. Each
+    peak in this table will have a unique label (see _pd_peak.id).
+    The reflections and phases associated with each peak will be
+    specified in other sections (see REFLN and PD_PHASE).
+
+    Note that peak positions are customarily determined from the
+    processed diffractogram and thus corrections for position
+    and intensity will have been previously applied.
+;
+    _name.category_id             PD_GROUP
+    _name.object_id               PD_PEAK
+
+    loop_
+      _category_key.name
+         '_pd_peak.diffractogram_id'
+         '_pd_peak.id'
+
+save_
+
+save_pd_peak.2theta_centroid
+
+    _definition.id                '_pd_peak.2theta_centroid'
+    _alias.definition_id          '_pd_peak_2theta_centroid'
+    _definition.update            2022-10-11
+    _description.text
+;
+    Position of the centroid of a peak as a 2θ angle.
+;
+    _name.category_id             pd_peak
+    _name.object_id               2theta_centroid
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:180.0
+    _units.code                   degrees
+
+save_
+
+save_pd_peak.2theta_centroid_su
+
+    _definition.id                '_pd_peak.2theta_centroid_su'
+    _definition.update            2022-10-27
+    _description.text
+;
+    Standard uncertainty of _pd_peak.2theta_centroid.
+;
+    _name.category_id             pd_peak
+    _name.object_id               2theta_centroid_su
+    _name.linked_item_id          '_pd_peak.2theta_centroid'
+    _units.code                   degrees
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+save_
+
+save_pd_peak.2theta_maximum
+
+    _definition.id                '_pd_peak.2theta_maximum'
+    _alias.definition_id          '_pd_peak_2theta_maximum'
+    _definition.update            2022-10-11
+    _description.text
+;
+    Position of the maximum of a peak as a 2θ angle.
+;
+    _name.category_id             pd_peak
+    _name.object_id               2theta_maximum
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:180.0
+    _units.code                   degrees
+
+save_
+
+save_pd_peak.2theta_maximum_su
+
+    _definition.id                '_pd_peak.2theta_maximum_su'
+    _definition.update            2022-10-27
+    _description.text
+;
+    Standard uncertainty of _pd_peak.2theta_maximum.
+;
+    _name.category_id             pd_peak
+    _name.object_id               2theta_maximum_su
+    _name.linked_item_id          '_pd_peak.2theta_maximum'
+    _units.code                   degrees
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+save_
+
+save_pd_peak.d_spacing
+
+    _definition.id                '_pd_peak.d_spacing'
+    _alias.definition_id          '_pd_peak_d_spacing'
+    _definition.update            2022-10-11
+    _description.text
+;
+    Peak position as a d-spacing in angstroms.
+;
+    _name.category_id             pd_peak
+    _name.object_id               d_spacing
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   angstroms
+
+save_
+
+save_pd_peak.d_spacing_su
+
+    _definition.id                '_pd_peak.d_spacing_su'
+    _definition.update            2022-10-27
+    _description.text
+;
+    Standard uncertainty of _pd_peak.d_spacing.
+;
+    _name.category_id             pd_peak
+    _name.object_id               d_spacing_su
+    _name.linked_item_id          '_pd_peak.d_spacing'
+    _units.code                   angstroms
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+save_
+
+save_pd_peak.diffractogram_id
+
+    _definition.id                '_pd_peak.diffractogram_id'
+    _definition.update            2023-06-10
+    _description.text
+;
+    The diffractogram (see _pd_diffractogram.id) to which the peak information
+    relates.
+;
+    _name.category_id             pd_peak
+    _name.object_id               diffractogram_id
+    _name.linked_item_id          '_pd_diffractogram.id'
+    _type.purpose                 Link
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_pd_peak.id
+
+    _definition.id                '_pd_peak.id'
+    _alias.definition_id          '_pd_peak_id'
+    _definition.update            2014-06-20
+    _description.text
+;
+    An arbitrary code is assigned to each peak. Used to link with
+    _pd_refln.peak_id so that multiple hkl and/or phase
+    identifications can be assigned to a single peak.
+    Each peak will have a unique code. In cases
+    where two peaks are severely overlapped, it may be
+    desirable to list them as a single peak.
+
+    A peak ID must be included for every peak.
+;
+    _name.category_id             pd_peak
+    _name.object_id               id
+    _type.purpose                 Key
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Code
+
+save_
+
+save_pd_peak.intensity
+
+    _definition.id                '_pd_peak.intensity'
+    _alias.definition_id          '_pd_peak_intensity'
+    _definition.update            2014-06-20
+    _description.text
+;
+    Integrated area for the peak, with the same scaling as
+    the _pd_proc.intensity_* values. It is good practice to
+    include s.u.'s for these values.
+;
+    _name.category_id             pd_peak
+    _name.object_id               intensity
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   none
+
+save_
+
+save_pd_peak.intensity_su
+
+    _definition.id                '_pd_peak.intensity_su'
+    _definition.update            2022-09-28
+    _description.text
+;
+    Standard uncertainty of _pd_peak.intensity.
+;
+    _name.category_id             pd_peak
+    _name.object_id               intensity_su
+    _name.linked_item_id          '_pd_peak.intensity'
+    _units.code                   none
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+save_
+
+save_pd_peak.pk_height
+
+    _definition.id                '_pd_peak.pk_height'
+    _alias.definition_id          '_pd_peak_pk_height'
+    _definition.update            2014-06-20
+    _description.text
+;
+    The maximum intensity of the peak, either extrapolated
+    or the highest observed intensity value. The same
+    scaling is used for the _pd_proc.intensity_* values.
+    It is good practice to include s.u.'s for these values.
+;
+    _name.category_id             pd_peak
+    _name.object_id               pk_height
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   none
+
+save_
+
+save_pd_peak.pk_height_su
+
+    _definition.id                '_pd_peak.pk_height_su'
+    _definition.update            2022-09-28
+    _description.text
+;
+    Standard uncertainty of _pd_peak.pk_height.
+;
+    _name.category_id             pd_peak
+    _name.object_id               pk_height_su
+    _name.linked_item_id          '_pd_peak.pk_height'
+    _units.code                   none
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+save_
+
+save_pd_peak.wavelength_id
+
+    _definition.id                '_pd_peak.wavelength_id'
+    _alias.definition_id          '_pd_peak_wavelength_id'
+    _definition.update            2014-06-20
+    _description.text
+;
+    Code identifying the wavelength appropriate for this peak
+    from the wavelengths in the _diffrn_radiation_ list.
+    (See _diffrn_radiation_wavelength.id.) Most commonly used
+    to distinguish Kα~1~ peaks from Kα~2~ or to designate
+    where Kα~1~ and Kα~2~ peaks cannot be resolved. For
+    complex peak tables with multiple superimposed peaks,
+    specify wavelengths in the reflection table using
+    _refln.wavelength_id rather than identifying peaks by
+    wavelength.
+;
+    _name.category_id             pd_peak
+    _name.object_id               wavelength_id
+    _name.linked_item_id          '_diffrn_radiation_wavelength.id'
+    _type.purpose                 Link
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Word
+
+save_
+
+save_pd_peak.width_2theta
+
+    _definition.id                '_pd_peak.width_2theta'
+    _alias.definition_id          '_pd_peak_width_2theta'
+    _definition.update            2022-10-11
+    _description.text
+;
+    Peak width as full-width at half-maximum expressed as
+    a 2θ value in degrees.
+;
+    _name.category_id             pd_peak
+    _name.object_id               width_2theta
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:180.0
+    _units.code                   degrees
+
+save_
+
+save_pd_peak.width_2theta_su
+
+    _definition.id                '_pd_peak.width_2theta_su'
+    _definition.update            2022-10-27
+    _description.text
+;
+    Standard uncertainty of _pd_peak.width_2theta.
+;
+    _name.category_id             pd_peak
+    _name.object_id               width_2theta_su
+    _name.linked_item_id          '_pd_peak.width_2theta'
+    _units.code                   degrees
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+save_
+
+save_pd_peak.width_d_spacing
+
+    _definition.id                '_pd_peak.width_d_spacing'
+    _alias.definition_id          '_pd_peak_width_d_spacing'
+    _definition.update            2022-10-11
+    _description.text
+;
+    Peak width as full-width at half-maximum expressed as
+    a d-spacing in angstroms.
+;
+    _name.category_id             pd_peak
+    _name.object_id               width_d_spacing
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   angstroms
+
+save_
+
+save_pd_peak.width_d_spacing_su
+
+    _definition.id                '_pd_peak.width_d_spacing_su'
+    _definition.update            2022-10-27
+    _description.text
+;
+    Standard uncertainty of _pd_peak.width_d_spacing.
+;
+    _name.category_id             pd_peak
+    _name.object_id               width_d_spacing_su
+    _name.linked_item_id          '_pd_peak.width_d_spacing'
+    _units.code                   angstroms
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+save_
+
+save_PD_PEAK_OVERALL
+
+    _definition.id                PD_PEAK_OVERALL
+    _definition.scope             Category
+    _definition.class             Set
+    _definition.update            2023-06-10
+    _description.text
+;
+    This category describes general aspects of the peak extraction
+    process.
+;
+    _name.category_id             PD_GROUP
+    _name.object_id               PD_PEAK_OVERALL
+
+    loop_
+      _category_key.name
+         '_pd_peak_overall.diffractogram_id'
+         '_pd_peak_overall.id'
+
+save_
+
+save_pd_peak.special_details
+
+    _definition.id                '_pd_peak.special_details'
+    _alias.definition_id          '_pd_peak_special_details'
+    _definition.update            2014-06-20
+    _description.text
+;
+    Detailed description of any non-routine processing steps
+    used for peak determination or other comments
+    related to the peak table that cannot be given elsewhere.
+;
+    _name.category_id             pd_peak_overall
+    _name.object_id               special_details
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_pd_peak_overall.diffractogram_id
+
+    _definition.id                '_pd_peak_overall.diffractogram_id'
+    _definition.update            2023-06-10
+    _description.text
+;
+    The diffractogram (see _pd_diffractogram.id) to which the overall peak
+    information relates.
+;
+    _name.category_id             pd_peak_overall
+    _name.object_id               diffractogram_id
+    _name.linked_item_id          '_pd_diffractogram.id'
+    _type.purpose                 Link
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_pd_peak_overall.id
+
+    _definition.id                '_pd_peak_overall.id'
+    _definition.update            2023-03-26
+    _description.text
+;
+    An arbitrary code identifying the overall peak description.
+;
+    _name.category_id             pd_peak_overall
+    _name.object_id               id
+    _type.purpose                 Key
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Code
+
+save_
+
+save_PD_PHASE
+
+    _definition.id                PD_PHASE
+    _definition.scope             Category
+    _definition.class             Set
+    _definition.update            2025-04-18
+    _description.text
+;
+    This category allows for the description of the phases contributing to the
+    powder diffraction data set. Note that if multiple-phase Rietveld or other
+    structural analysis is performed, the structural results will be placed in
+    different data blocks, using CIF entries from the core CIF dictionary.
+;
+    _name.category_id             PD_GROUP
+    _name.object_id               PD_PHASE
+    _category_key.name            '_pd_phase.id'
+
+save_
+
+save_pd_phase.id
+
+    _definition.id                '_pd_phase.id'
+    _definition.update            2025-04-18
+    _description.text
+;
+    Unique label identifying a phase.
+;
+    _name.category_id             pd_phase
+    _name.object_id               id
+    _type.purpose                 Key
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_pd_phase.name
+
+    _definition.id                '_pd_phase.name'
+    _alias.definition_id          '_pd_phase_name'
+    _definition.update            2023-01-18
+    _description.text
+;
+    The name of the phase. It may be designated as unknown, or by a mineral
+    name, structure type, chemical formula, or other identifier.
+;
+    _name.category_id             pd_phase
+    _name.object_id               name
+    _type.purpose                 Describe
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Text
+
+    loop_
+      _description_example.case
+         'NIST 640e Silicon standard'
+         'Al2O3'
+         'malachite'
+         'Calcium sulphate hemihydrate. ACME Chemicals, batch #12090.'
+         'Olivine#Mg2SiO4'
+
+save_
+
+save_PD_PHASE_BLOCK
+
+    _definition.id                PD_PHASE_BLOCK
+    _definition.scope             Category
+    _definition.class             Loop
+    _definition.update            2022-12-03
+    _description.text
+;
+    **DEPRECATED**
+    Use _pd_phase.id, as necessary.
+
+    A table of phases relevant to the current data
+    block. Each phase is identified by the block identifier
+    of the data block containing the phase information,
+    and the _pd_phase.id of the phase contained within
+    that block.
+;
+    _name.category_id             PD_GROUP
+    _name.object_id               PD_PHASE_BLOCK
+    _category_key.name            '_pd_phase_block.id'
+
+save_
+
+save_pd_phase_block.id
+
+    _definition.id                '_pd_phase_block.id'
+    _definition_replaced.id       1
+    _definition_replaced.by       '_pd_phase.id'
+    _alias.definition_id          '_pd_phase_block_id'
+    _definition.update            2025-04-18
+    _description.text
+;
+    **DEPRECATED**
+    Use _pd_phase.id, as necessary.
+
+    A block ID code identifying a block containing phase information.
+;
+    _name.category_id             pd_phase_block
+    _name.object_id               id
+    _name.linked_item_id          '_pd_block.id'
+    _type.purpose                 Link
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_PD_PHASE_MASS
+
+    _definition.id                PD_PHASE_MASS
+    _definition.scope             Category
+    _definition.class             Loop
+    _definition.update            2022-12-03
+    _description.text
+;
+    This category describes the percent composition by mass of
+    phases in a specimen. Values are derived from modelling a
+    particular diffraction measurement on a specimen and should
+    not be used where the mass composition has been determined
+    by other means.
+;
+    _name.category_id             PD_GROUP
+    _name.object_id               PD_PHASE_MASS
+
+    loop_
+      _category_key.name
+         '_pd_phase_mass.diffractogram_id'
+         '_pd_phase_mass.phase_id'
+
+    loop_
+      _description_example.case
+      _description_example.detail
+;
+         _audit.schema         Custom
+
+         loop_
+         _pd_phase_mass.diffractogram_id
+         _pd_phase_mass.phase_id
+         _pd_phase_mass.percent
+         _pd_phase_mass.percent_su
+         A_DIFFRACTOGRAM   PHASE_1   45.45   0.42
+         A_DIFFRACTOGRAM   PHASE_2   37.42   0.63
+         A_DIFFRACTOGRAM   PHASE_3   17.13   0.53
+;
+;
+         Tabulation of quantitative phase analysis data. The phase masses,
+         expressed as percentages of the entire specimen are given, along with
+         their associated standard uncertainties. The values are associated with
+         one diffractogram and three phases.
+
+         Blocks containing information about more than one phase must set a
+         non-default value for _audit.schema.
+;
+
+;
+         _audit.schema            Custom
+
+         loop_
+         _pd_phase_mass.phase_id
+         _pd_phase_mass.percent
+         _pd_phase_mass.percent_su
+         PHASE_1   45.45   0.42
+         PHASE_2   37.42   0.63
+         PHASE_3   17.13   0.53
+;
+;
+         Tabulation of quantitative phase analysis data. The phase masses,
+         expressed as percentages of the entire specimen are given, along with
+         their associated standard uncertainties. The values are associated with
+         three phases.
+
+         The method of presentation given here would be associated with being
+         present in a block which already contains a _pd_diffractogram.id
+         data item; the value of _pd_phase_mass.diffractogram_id is linked to
+         that value.
+
+         When information about more than one phase is contained in a single
+         data block, _audit.schema should have a non-default value.
+;
+
+save_
+
+save_pd_phase_mass.diffractogram_id
+
+    _definition.id                '_pd_phase_mass.diffractogram_id'
+    _definition.update            2022-12-03
+    _description.text
+;
+    A diffractogram id to which the phase mass percent value
+    relates.
+;
+    _name.category_id             pd_phase_mass
+    _name.object_id               diffractogram_id
+    _name.linked_item_id          '_pd_diffractogram.id'
+    _type.purpose                 Link
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_pd_phase_mass.percent
+
+    _definition.id                '_pd_phase_mass.percent'
+    _alias.definition_id          '_pd_phase_mass_%'
+    _definition.update            2023-01-23
+    _description.text
+;
+    Total mass of the phase expressed as a percentage of the total
+    mass of the specimen.
+
+    If _pd_qpa_internal_std.mass_percent or _pd_qpa_external_std.k_factor
+    is present, the values given are assumed to be in absolute terms.
+
+    The value of the mass percent given to the internal standard
+    represents the total crystalline contribution of that standard.
+    That is, if 1 g of a 90% crystalline internal standard is added
+    to 3 g of sample, the value of _pd_phase_mass.percent for the
+    standard is 22.5%.
+;
+    _name.category_id             pd_phase_mass
+    _name.object_id               percent
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:100.0
+    _units.code                   none
+
+save_
+
+save_pd_phase_mass.percent_su
+
+    _definition.id                '_pd_phase_mass.percent_su'
+    _definition.update            2022-12-03
+    _description.text
+;
+    Standard uncertainty of _pd_phase_mass.percent.
+;
+    _name.category_id             pd_phase_mass
+    _name.object_id               percent_su
+    _name.linked_item_id          '_pd_phase_mass.percent'
+    _units.code                   none
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+save_
+
+save_pd_phase_mass.phase_id
+
+    _definition.id                '_pd_phase_mass.phase_id'
+    _definition.update            2022-12-03
+    _description.text
+;
+    The phase (see _pd_phase.id) to which the percent mass relates.
+;
+    _name.category_id             pd_phase_mass
+    _name.object_id               phase_id
+    _name.linked_item_id          '_pd_phase.id'
+    _type.purpose                 Link
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_PD_PREF_ORIENT
+
+    _definition.id                PD_PREF_ORIENT
+    _definition.scope             Category
+    _definition.class             Set
+    _definition.update            2023-01-12
+    _description.text
+;
+    This section contains a description of preferred-orientation
+    corrections applied to a phase when modelling its contribution
+    to a histogram.
+
+    March-Dollase and spherical harmonics corrections can be given explicitly.
+    For other methods, use the _pd_pref_orient.special_details.
+
+    See Dollase, W. A. (1986). J. Appl. Cryst. 19, 267-272 and
+    Jarvinen, M. (1993). J. Appl. Cryst. 26, 525-531 for
+    further information.
+;
+    _name.category_id             PD_GROUP
+    _name.object_id               PD_PREF_ORIENT
+
+    loop_
+      _category_key.name
+         '_pd_pref_orient.diffractogram_id'
+         '_pd_pref_orient.phase_id'
+
+save_
+
+save_pd_pref_orient.diffractogram_id
+
+    _definition.id                '_pd_pref_orient.diffractogram_id'
+    _definition.update            2023-01-12
+    _description.text
+;
+    The diffractogram (see _pd_diffractogram.id) to which the preferred-
+    orientation correction relates.
+;
+    _name.category_id             pd_pref_orient
+    _name.object_id               diffractogram_id
+    _name.linked_item_id          '_pd_diffractogram.id'
+    _type.purpose                 Link
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_pd_pref_orient.phase_id
+
+    _definition.id                '_pd_pref_orient.phase_id'
+    _definition.update            2023-01-12
+    _description.text
+;
+    The phase (see _pd_phase.id) to which the preferred-orientation
+    correction relates.
+;
+    _name.category_id             pd_pref_orient
+    _name.object_id               phase_id
+    _name.linked_item_id          '_pd_phase.id'
+    _type.purpose                 Link
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_pd_pref_orient.special_details
+
+    _definition.id                '_pd_pref_orient.special_details'
+    _definition.update            2023-01-06
+    _description.text
+;
+    Description of the preferred-orientation correction if
+    such a correction is used, and it cannot be described
+    as a March-Dollase or spherical harmonics correction.
+
+    or
+
+    Additional information relevant to non-routine steps
+    used in the application of a preferred-orientation model
+    that cannot be specified elsewhere.
+
+    If the correction can be described as a March-Dollase
+    or spherical harmonics correction, use
+    _pd_pref_orient_March_Dollase.* or
+    _pd_pref_orient_spherical_harmonics.*, as
+    appropriate.
+
+    Omitting _pd_pref_orient* implies that no preferred-
+    orientation correction has been used. If a non-standard
+    function form is used, it is recommended that the actual
+    equation in TeX, or a programming language, is used to
+    specify the function as well as a giving a description.
+    Include the value(s) used for the correction with s.u.'s.
+;
+    _name.category_id             pd_pref_orient
+    _name.object_id               special_details
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_PD_PREF_ORIENT_MARCH_DOLLASE
+
+    _definition.id                PD_PREF_ORIENT_MARCH_DOLLASE
+    _definition.scope             Category
+    _definition.class             Loop
+    _definition.update            2023-01-06
+    _description.text
+;
+    This section contains a description of March-Dollase
+    preferred-orientation corrections applied to a phase
+    when modelling its contribution to a histogram.
+
+    For spherical harmonics corrections, see
+    PD_PREF_ORIENT_SPHERICAL_HARMONICS. For other methods,
+    use _pd_pref_orient.special_details.
+
+    See Dollase, W. A. (1986). J. Appl. Cryst. 19, 267-272 for
+    further information.
+;
+    _name.category_id             PD_GROUP
+    _name.object_id               PD_PREF_ORIENT_MARCH_DOLLASE
+
+    loop_
+      _category_key.name
+         '_pd_pref_orient_March_Dollase.diffractogram_id'
+         '_pd_pref_orient_March_Dollase.id'
+         '_pd_pref_orient_March_Dollase.phase_id'
+
+    loop_
+      _description_example.case
+      _description_example.detail
+;
+         _audit.schema                Custom
+
+         loop_
+         _pd_pref_orient_March_Dollase.id
+         _pd_pref_orient_March_Dollase.diffractogram_id
+         _pd_pref_orient_March_Dollase.phase_id
+         _pd_pref_orient_March_Dollase.hkl
+         _pd_pref_orient_March_Dollase.fract
+         _pd_pref_orient_March_Dollase.fract_su
+         1   DIFFPAT_1   PHASE_1   [1 0 4]   0.79   0.12
+         2   DIFFPAT_1   PHASE_2   [0 0 1]   0.66   0.15
+;
+;
+         Showing a fully qualified reporting of the preferred-orientation
+         corrections for a phase with a _pd_phase.id of 'PHASE_1' a phase
+         with a _pd_phase.id of 'PHASE_2', both belonging to a diffractogram
+         with a _pd_diffractogram.id of 'DIFFPAT_1.
+
+         The first phase has the preferred-orientation direction of 104, with a
+         March r parameter value of 0.79 with a standard uncertainty of 0.12.
+
+         The second phase has the preferred-orientation direction of 001, with a
+         March r parameter value of 0.66 with a standard uncertainty of 0.15.
+
+         As information about more than one phase is present in the data block
+         _audit.schema takes a non-default value.
+;
+;
+         _pd_diffractogram.id   DIFFPAT_A
+         _pd_phase.id           PHASE_A
+
+         loop_
+         _pd_pref_orient_March_Dollase.id
+         _pd_pref_orient_March_Dollase.index_h
+         _pd_pref_orient_March_Dollase.index_k
+         _pd_pref_orient_March_Dollase.index_l
+         _pd_pref_orient_March_Dollase.fract
+         _pd_pref_orient_March_Dollase.r
+         a   1 0 0   0.63   0.79
+         b   0 1 0   0.37   0.66
+;
+;
+         Reporting of the preferred-orientation corrections for a phase with the
+         _pd_phase.id of 'PHASE_A' for diffractogram DIFFPAT_A.
+
+         There are two preferred-orientation corrections being applied to the
+         same phase. The first is in the 100 direction, with a March r parameter
+         value of 0.79. This individual correction contributes 63% to the total
+         correction. The second is in the 010 direction, with a March r
+         parameter value of 0.66. This individual correction contributes 37% to
+         the total correction.
+;
+
+save_
+
+save_pd_pref_orient_march_dollase.diffractogram_id
+
+    _definition.id
+        '_pd_pref_orient_March_Dollase.diffractogram_id'
+    _definition.update            2023-01-06
+    _description.text
+;
+    A diffractogram id to which the preferred-orientation correction
+    relates.
+;
+    _name.category_id             pd_pref_orient_March_Dollase
+    _name.object_id               diffractogram_id
+    _name.linked_item_id          '_pd_diffractogram.id'
+    _type.purpose                 Link
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_pd_pref_orient_march_dollase.fract
+
+    _definition.id                '_pd_pref_orient_March_Dollase.fract'
+    _definition.update            2023-01-06
+    _description.text
+;
+    In the case of multiple March-Dollase preferred-orientation
+    directions for a single phase, this denotes the fractional
+    amount of preferred orientation in each direction.
+
+    The sum of all values for a given phase and diffractogram
+    should be 1.
+;
+    _name.category_id             pd_pref_orient_March_Dollase
+    _name.object_id               fract
+    _type.purpose                 Measurand
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Real
+    _units.code                   none
+
+save_
+
+save_pd_pref_orient_march_dollase.fract_su
+
+    _definition.id                '_pd_pref_orient_March_Dollase.fract_su'
+    _definition.update            2022-11-17
+    _description.text
+;
+    Standard uncertainty of _pd_pref_orient_March_Dollase.fract.
+;
+    _name.category_id             pd_pref_orient_March_Dollase
+    _name.object_id               fract_su
+    _name.linked_item_id          '_pd_pref_orient_March_Dollase.fract'
+    _units.code                   none
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+save_
+
+save_pd_pref_orient_march_dollase.geom
+
+    _definition.id                '_pd_pref_orient_March_Dollase.geom'
+    _definition.update            2023-01-06
+    _description.text
+;
+    Code identifying the geometry of the preferred-orientation
+    correction, as distinct from the geometry of data collection.
+
+    The functional form of the March-Dollase correction depends
+    on whether the data were collected in symmetric or asymmetric
+    reflection or transmission, or capillary geometries. See
+    Section 3, Rowles & Buckley (2017) J. Appl. Cryst. (2017).
+    50, 240-251, for further discussion.
+
+    In most Rietveld software, 'symmetric reflection' is the
+    default implementation.
+
+;
+    _name.category_id             pd_pref_orient_March_Dollase
+    _name.object_id               geom
+    _type.purpose                 State
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Code
+
+    loop_
+      _enumeration_set.state
+      _enumeration_set.detail
+         srefln                   'Symmetric reflection.'
+         arefln                   'Asymmetric reflection.'
+         strans                   'Symmetric transmission.'
+         atrans                   'Asymmetric transmission.'
+         cap                      'Capillary (Debye-Scherrer).'
+    _enumeration.default          srefln
+
+save_
+
+save_pd_pref_orient_march_dollase.hkl
+
+    _definition.id                '_pd_pref_orient_March_Dollase.hkl'
+    _definition.update            2023-01-06
+    _description.text
+;
+    Miller indices of the March-Dollase preferred-orientation
+    direction.
+;
+    _name.category_id             pd_pref_orient_March_Dollase
+    _name.object_id               hkl
+    _type.purpose                 Number
+    _type.source                  Assigned
+    _type.container               Matrix
+    _type.dimension               '[3]'
+    _type.contents                Integer
+    _units.code                   none
+    _method.purpose               Evaluation
+    _method.expression
+;
+    With po as pd_pref_orient_March_Dollase
+
+           po.hkl =  [po.index_h,
+                      po.index_k,
+                      po.index_l]
+;
+
+save_
+
+save_pd_pref_orient_march_dollase.id
+
+    _definition.id                '_pd_pref_orient_March_Dollase.id'
+    _definition.update            2023-01-06
+    _description.text
+;
+    A code to uniquely identify each March-Dollase
+    preferred-orientation correction.
+;
+    _name.category_id             pd_pref_orient_March_Dollase
+    _name.object_id               id
+    _type.purpose                 Encode
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Text
+    _enumeration.default          .
+
+save_
+
+save_pd_pref_orient_march_dollase.index_h
+
+    _definition.id                '_pd_pref_orient_March_Dollase.index_h'
+    _definition.update            2023-01-06
+    _description.text
+;
+    The h Miller index of the March-Dollase preferred-orientation
+    direction.
+;
+    _name.category_id             pd_pref_orient_March_Dollase
+    _name.object_id               index_h
+    _type.purpose                 Number
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Integer
+    _units.code                   none
+
+save_
+
+save_pd_pref_orient_march_dollase.index_k
+
+    _definition.id                '_pd_pref_orient_March_Dollase.index_k'
+    _definition.update            2023-01-06
+    _description.text
+;
+    The k Miller index of the March-Dollase preferred-orientation
+    direction.
+;
+    _name.category_id             pd_pref_orient_March_Dollase
+    _name.object_id               index_k
+    _type.purpose                 Number
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Integer
+    _units.code                   none
+
+save_
+
+save_pd_pref_orient_march_dollase.index_l
+
+    _definition.id                '_pd_pref_orient_March_Dollase.index_l'
+    _definition.update            2023-01-06
+    _description.text
+;
+    The l Miller index of the March-Dollase preferred-orientation
+    direction.
+;
+    _name.category_id             pd_pref_orient_March_Dollase
+    _name.object_id               index_l
+    _type.purpose                 Number
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Integer
+    _units.code                   none
+
+save_
+
+save_pd_pref_orient_march_dollase.phase_id
+
+    _definition.id                '_pd_pref_orient_March_Dollase.phase_id'
+    _definition.update            2023-01-06
+    _description.text
+;
+    A phase id to which the preferred-orientation correction
+    relates.
+;
+    _name.category_id             pd_pref_orient_March_Dollase
+    _name.object_id               phase_id
+    _name.linked_item_id          '_pd_phase.id'
+    _type.purpose                 Link
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_pd_pref_orient_march_dollase.r
+
+    _definition.id                '_pd_pref_orient_March_Dollase.r'
+    _definition.update            2022-11-17
+    _description.text
+;
+    March distribution parameter describing the degree of
+    preferred-orientation in a given phase and diffractogram.
+    In general, a value of 1 describes an unoriented phase.
+    r in the range (1, ∞) describes orientation of disk-like
+    particles, and r in the range (0,1) describes orientation
+    of needle-like particles.
+
+    The direction of the correction must also be given using
+    _pd_pref_orient_March_Dollase.index_h, _k, and _l. If
+    more than one orientation direction is used, the fractional
+    contribution of each direction must be specified with
+    _pd_pref_orient_March_Dollase.fract.
+
+    Omitting _pd_pref_orient.* implies that no preferred-
+    orientation correction has been used.
+
+    See Dollase, W. A. (1986). J. Appl. Cryst. 19, 267-272 for
+    further information.
+;
+    _name.category_id             pd_pref_orient_March_Dollase
+    _name.object_id               r
+    _type.purpose                 Measurand
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   none
+
+save_
+
+save_pd_pref_orient_march_dollase.r_su
+
+    _definition.id                '_pd_pref_orient_March_Dollase.r_su'
+    _definition.update            2022-11-17
+    _description.text
+;
+    Standard uncertainty of _pd_pref_orient_March_Dollase.r.
+;
+    _name.category_id             pd_pref_orient_March_Dollase
+    _name.object_id               r_su
+    _name.linked_item_id          '_pd_pref_orient_March_Dollase.r'
+    _units.code                   none
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+save_
+
+save_PD_PREF_ORIENT_SPHERICAL_HARMONICS
+
+    _definition.id                PD_PREF_ORIENT_SPHERICAL_HARMONICS
+    _definition.scope             Category
+    _definition.class             Loop
+    _definition.update            2023-01-06
+    _description.text
+;
+    This section contains a description of spherical
+    harmonics preferred-orientation corrections applied
+    to a phase when modelling its contribution to a
+    histogram.
+
+    For March-Dollase corrections, see
+    PD_PREF_ORIENT_MARCH_DOLLASE. For other methods,
+    use _pd_pref_orient.special_details.
+
+    See Jarvinen, M. (1993). J. Appl. Cryst. 26, 525-531 for
+    further information.
+;
+    _name.category_id             PD_GROUP
+    _name.object_id               PD_PREF_ORIENT_SPHERICAL_HARMONICS
+
+    loop_
+      _category_key.name
+         '_pd_pref_orient_spherical_harmonics.diffractogram_id'
+         '_pd_pref_orient_spherical_harmonics.id'
+         '_pd_pref_orient_spherical_harmonics.phase_id'
+
+    loop_
+      _description_example.case
+      _description_example.detail
+;
+         _audit.schema          Custom
+
+         loop_
+         _pd_pref_orient_spherical_harmonics.id
+         _pd_pref_orient_spherical_harmonics.phase_id
+         _pd_pref_orient_spherical_harmonics.diffractogram_id
+         _pd_pref_orient_spherical_harmonics.y_ij
+         _pd_pref_orient_spherical_harmonics.c_ij
+         _pd_pref_orient_spherical_harmonics.c_ij_su
+         a   PHASE_A DIFFPAT_A   [0 0]   1.0     .
+         b   PHASE_A DIFFPAT_A   [2 0]   1.538   0.013
+         c   PHASE_B DIFFPAT_A   [0 0]   1.0     .
+         d   PHASE_B DIFFPAT_A   [4 1]  -0.066   0.010
+         e   PHASE_A DIFFPAT_B   [0 0]   1.0     .
+         f   PHASE_A DIFFPAT_B   [2 0]   1.630   0.014
+;
+;
+         Showing a fully qualified reporting of the preferred-orientation
+         corrections for phases with the _pd_phase.id of 'PHASE_A' and 'PHASE_B'
+         present in the diffractograms with the _pd_diffractogram.id of
+         'DIFFPAT_A' and 'DIFFPAT_B'.
+
+         In diffractogram 'DIFFPAT_A', both 'PHASE_A' and 'PHASE_B' have
+         corrections applied, with the non-(0,0) order/term pairs taking the
+         values (2,0) and (4,1), with coefficients of 1.538(13) and -0.066(10),
+         respectively.
+
+         In diffractogram 'DIFFPAT_B', only 'PHASE_A' has corrections applied,
+         with the non-(0,0) order/term pair taking the value (2,0), with a
+         coefficient of 1.630(14).
+
+         As information for more than one phase is contained in the data block,
+         _audit.schema has non-default value 'Custom'.
+;
+;
+         _pd_phase.id   PHASE_A
+
+         loop_
+         _pd_pref_orient_spherical_harmonics.id
+         _pd_pref_orient_spherical_harmonics.diffractogram_id
+         _pd_pref_orient_spherical_harmonics.y_i
+         _pd_pref_orient_spherical_harmonics.y_j
+         _pd_pref_orient_spherical_harmonics.c_ij
+         _pd_pref_orient_spherical_harmonics.c_ij_su
+         a   DIFFPAT_A   0   0   1.0     .
+         b   DIFFPAT_A   2   0   1.538   0.013
+         c   DIFFPAT_A   4   0   0.913   0.016
+         d   DIFFPAT_A   4  -3  -0.166   0.010
+         1   DIFFPAT_B   0   0   1.0     .
+         2   DIFFPAT_B   2   0   1.630   0.014
+;
+;
+         Reporting of the preferred-orientation corrections for a phase with the
+         _pd_phase.id of 'PHASE_A'.
+
+         This table is reporting preferred-orientation values pertinent to this
+         phase, as seen in two diffractograms: 'DIFFPAT_A' and 'DIFFPAT_B'.
+         There are four corrections applied in 'DIFFPAT_A' corresponding to
+         order/term pairs of (0,0), (2,0), (4,0), and (4, -3), and their
+         magnitudes and standard uncertainties are 1.0, 1.538(13), 0.913(16),
+         and -0.166(10), respectively. There are two corrections applied in
+         'DIFFPAT_B' corresponding to order/term pairs of (0,0) and (2,0), and
+         their magnitudes and standard uncertainties are 1.0 and 1.630(14),
+         respectively.
+;
+
+save_
+
+save_pd_pref_orient_spherical_harmonics.c_ij
+
+    _definition.id                '_pd_pref_orient_spherical_harmonics.c_ij'
+    _definition.update            2022-11-17
+    _description.text
+;
+    The value of the coefficient scaling the spherical
+    harmonic, ij, as given by _pd_pref_orient_spherical_harmonics.y_ij.
+;
+    _name.category_id             pd_pref_orient_spherical_harmonics
+    _name.object_id               c_ij
+    _type.purpose                 Measurand
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Real
+    _units.code                   none
+
+save_
+
+save_pd_pref_orient_spherical_harmonics.c_ij_su
+
+    _definition.id                '_pd_pref_orient_spherical_harmonics.c_ij_su'
+    _definition.update            2022-11-17
+    _description.text
+;
+    Standard uncertainty of _pd_pref_orient_spherical_harmonics.c_ij.
+;
+    _name.category_id             pd_pref_orient_spherical_harmonics
+    _name.object_id               c_ij_su
+    _name.linked_item_id          '_pd_pref_orient_spherical_harmonics.c_ij'
+    _units.code                   none
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+save_
+
+save_pd_pref_orient_spherical_harmonics.diffractogram_id
+
+    _definition.id
+        '_pd_pref_orient_spherical_harmonics.diffractogram_id'
+    _definition.update            2023-01-06
+    _description.text
+;
+    A diffractogram id to which the preferred-orientation correction
+    relates.
+;
+    _name.category_id             pd_pref_orient_spherical_harmonics
+    _name.object_id               diffractogram_id
+    _name.linked_item_id          '_pd_diffractogram.id'
+    _type.purpose                 Link
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_pd_pref_orient_spherical_harmonics.geom
+
+    _definition.id                '_pd_pref_orient_spherical_harmonics.geom'
+    _definition.update            2023-01-06
+    _description.text
+;
+    Code identifying the geometry of the preferred-orientation
+    correction, as distinct from the geometry of data collection.
+
+    The functional form of the spherical harmonics correction depends
+    on whether the data were collected in symmetric or asymmetric
+    reflection or transmission, or capillary geometries. See
+    Section 3, Rowles & Buckley (2017) J. Appl. Cryst. (2017).
+    50, 240-251, for further discussion.
+
+    In most Rietveld software, 'symmetric reflection' is the
+    default implementation.
+
+;
+    _name.category_id             pd_pref_orient_spherical_harmonics
+    _name.object_id               geom
+    _type.purpose                 State
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Code
+
+    loop_
+      _enumeration_set.state
+      _enumeration_set.detail
+         srefln                   'Symmetric reflection.'
+         arefln                   'Asymmetric reflection.'
+         strans                   'Symmetric transmission.'
+         atrans                   'Asymmetric transmission.'
+         cap                      'Capillary (Debye-Scherrer).'
+    _enumeration.default          srefln
+
+save_
+
+save_pd_pref_orient_spherical_harmonics.id
+
+    _definition.id                '_pd_pref_orient_spherical_harmonics.id'
+    _definition.update            2022-11-17
+    _description.text
+;
+    A code to uniquely identify each spherical harmonic
+    preferred-orientation correction.
+;
+    _name.category_id             pd_pref_orient_spherical_harmonics
+    _name.object_id               id
+    _type.purpose                 Encode
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Code
+    _enumeration.default          .
+
+save_
+
+save_pd_pref_orient_spherical_harmonics.phase_id
+
+    _definition.id                '_pd_pref_orient_spherical_harmonics.phase_id'
+    _definition.update            2023-01-06
+    _description.text
+;
+    A phase id to which the preferred-orientation correction
+    relates.
+;
+    _name.category_id             pd_pref_orient_spherical_harmonics
+    _name.object_id               phase_id
+    _name.linked_item_id          '_pd_phase.id'
+    _type.purpose                 Link
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_pd_pref_orient_spherical_harmonics.texture_index
+
+    _definition.id
+        '_pd_pref_orient_spherical_harmonics.texture_index'
+    _definition.update            2023-01-06
+    _description.text
+;
+    The texture index, as described by equation 4.212
+    in Bunge, as T = sum_{i,j} [c_{i,j)^2 / (2i+1)].
+
+    It gives the value [1, ∞), where 1 is a random powder
+    and ∞ is an ideal single crystal.
+
+    Bunge, H.J., (2015) "Texture Analysis in Materials Science:
+    Mathematical Methods", Helga and Hans-Peter Bunge,
+    Wolfratshausen.
+;
+    _name.category_id             pd_pref_orient_spherical_harmonics
+    _name.object_id               texture_index
+    _type.purpose                 Measurand
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            1.0:
+    _units.code                   none
+    _method.purpose               Evaluation
+    _method.expression
+;
+    t = 0.0
+
+    Loop po as pd_pref_orient_spherical_harmonics  {
+        t += po.c_ij ** 2 / (2 * po.y_i + 1)
+    }
+    _pd_pref_orient_spherical_harmonics.texture_index = t
+
+;
+
+save_
+
+save_pd_pref_orient_spherical_harmonics.texture_index_su
+
+    _definition.id
+        '_pd_pref_orient_spherical_harmonics.texture_index_su'
+    _definition.update            2022-11-17
+    _description.text
+;
+    Standard uncertainty of _pd_pref_orient_spherical_harmonics.texture_index.
+;
+    _name.category_id             pd_pref_orient_spherical_harmonics
+    _name.object_id               texture_index_su
+    _name.linked_item_id
+        '_pd_pref_orient_spherical_harmonics.texture_index'
+    _units.code                   none
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+save_
+
+save_pd_pref_orient_spherical_harmonics.y_i
+
+    _definition.id                '_pd_pref_orient_spherical_harmonics.y_i'
+    _definition.update            2022-11-17
+    _description.text
+;
+    The order of the spherical harmonics preferred-orientation
+    correction. Valid values are positive, even integers.
+;
+    _name.category_id             pd_pref_orient_spherical_harmonics
+    _name.object_id               y_i
+    _type.purpose                 Number
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Integer
+    _enumeration.range            0:
+    _units.code                   none
+
+save_
+
+save_pd_pref_orient_spherical_harmonics.y_ij
+
+    _definition.id                '_pd_pref_orient_spherical_harmonics.y_ij'
+    _definition.update            2023-06-13
+    _description.text
+;
+    The order (i) and term (j) of the spherical harmonic
+    preferred-orientation correction. Spherical
+    harmonics are functions that obey the point-symmetry
+    operations of the phase, and can be used to model
+    deviations in peak intensity due to preferred-orientation
+    or texture.
+
+    In the application of spherical harmonics corrections,
+    valid orders are positive, even integers, and possible
+    terms are in the range -i:i. Valid terms are restricted
+    by space-group symmetry. The parity of the term is given
+    by its sign; odd parity is negative, even is positive.
+
+    Omitting _pd_pref_orient.* implies that no preferred-
+    orientation correction has been used.
+
+    See Jarvinen, M. (1993). J. Appl. Cryst. 26, 525-531 for
+    further information.
+;
+    _name.category_id             pd_pref_orient_spherical_harmonics
+    _name.object_id               y_ij
+    _type.purpose                 Number
+    _type.source                  Assigned
+    _type.container               List
+    _type.dimension               '[2]'
+    _type.contents                Integer
+    _units.code                   none
+    _method.purpose               Evaluation
+    _method.expression
+;
+    With po as pd_pref_orient_spherical_harmonics
+
+      po.y_ij = [po.y_i, po.y_j]
+;
+
+save_
+
+save_pd_pref_orient_spherical_harmonics.y_j
+
+    _definition.id                '_pd_pref_orient_spherical_harmonics.y_j'
+    _definition.update            2023-01-06
+    _description.text
+;
+    The term (j) of the given order (i) of the spherical harmonics
+    preferred-orientation correction. The parity of the term
+    is given by its sign; odd parity is negative, even is positive.
+
+    In general, possible values are in the range -i:i. Valid values
+    are dependent on the space-group of the phase.
+;
+    _name.category_id             pd_pref_orient_spherical_harmonics
+    _name.object_id               y_j
+    _type.purpose                 Number
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Integer
+    _units.code                   none
+    _method.purpose               Definition
+    _method.expression
+;
+     With po as pd_pref_orient_spherical_harmonics
+
+    _enumeration.range = -po.y_i:po.y_i
+;
+
+save_
+
+save_PD_PREP
+
+    _definition.id                PD_PREP
+    _definition.scope             Category
+    _definition.class             Set
+    _definition.update            2023-06-04
+    _description.text
+;
+    This section contains descriptive information about how the sample, from
+    which the specimen was created, was prepared.
+
+    The 'specimen' is the artefact placed into the beam. The specimen is made
+    from the 'sample'. Information about the sample is specified in PD_PREP.
+
+    'Specimen', 'sample', and 'material' have specific meanings, and sometimes
+    cannot be specifically deliniated. The 'specimen' is the artefact placed
+    into the beam from which the diffraction measurement is taken, and is
+    described in PD_SPEC. The specimen is made from the 'sample', which can have
+    information specified in PD_PREP. The sample is drawn from a 'material',
+    which may exist in an actual or idealised sense, which can have information
+    specified in PD_CHAR. For example: the material might be BaTiO3, the
+    sample might be a specific batch from a specific manufacturer, and the
+    specimen is the material taken from the bottle and placed in the instrument.
+;
+    _name.category_id             PD_GROUP
+    _name.object_id               PD_PREP
+
+    loop_
+      _category_key.name
+         '_pd_prep.char_id'
+         '_pd_prep.id'
+
+save_
+
+save_pd_prep.char_id
+
+    _definition.id                '_pd_prep.char_id'
+    _definition.update            2023-06-04
+    _description.text
+;
+    The identifier for the material from which this sample was prepared
+;
+    _name.category_id             pd_prep
+    _name.object_id               char_id
+    _name.linked_item_id          '_pd_char.id'
+    _type.purpose                 Link
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_pd_prep.conditions
+
+    _definition.id                '_pd_prep.conditions'
+    _alias.definition_id          '_pd_prep_conditions'
+    _definition.update            2023-01-22
+    _description.text
+;
+    A description of how the sample was prepared
+    (reaction conditions etc.)
+;
+    _name.category_id             pd_prep
+    _name.object_id               conditions
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_pd_prep.cool_rate
+
+    _definition.id                '_pd_prep.cool_rate'
+    _alias.definition_id          '_pd_prep_cool_rate'
+    _definition.update            2022-10-11
+    _description.text
+;
+    Cooling rate in kelvins per minute for samples prepared
+    at high temperatures. If the cooling rate is not linear
+    or is unknown (e.g. quenched samples), it should be
+    described in _pd_prep.conditions instead.
+;
+    _name.category_id             pd_prep
+    _name.object_id               cool_rate
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   kelvins_per_minute
+
+save_
+
+save_pd_prep.cool_rate_su
+
+    _definition.id                '_pd_prep.cool_rate_su'
+    _definition.update            2022-10-27
+    _description.text
+;
+    Standard uncertainty of _pd_prep.cool_rate.
+;
+    _name.category_id             pd_prep
+    _name.object_id               cool_rate_su
+    _name.linked_item_id          '_pd_prep.cool_rate'
+    _units.code                   kelvins_per_minute
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+save_
+
+save_pd_prep.id
+
+    _definition.id                '_pd_prep.id'
+    _definition.update            2023-06-04
+    _description.text
+;
+    Arbitrary label identifying a sample.
+;
+    _name.category_id             pd_prep
+    _name.object_id               id
+    _type.purpose                 Key
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_pd_prep.pressure
+
+    _definition.id                '_pd_prep.pressure'
+    _alias.definition_id          '_pd_prep_pressure'
+    _definition.update            2022-10-11
+    _description.text
+;
+    Preparation pressure of the sample in kilopascals. This
+    is particularly important for materials which are metastable
+    at the measurement pressure, _diffrn_ambient_pressure.
+;
+    _name.category_id             pd_prep
+    _name.object_id               pressure
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   kilopascals
+
+save_
+
+save_pd_prep.pressure_su
+
+    _definition.id                '_pd_prep.pressure_su'
+    _definition.update            2022-10-27
+    _description.text
+;
+    Standard uncertainty of _pd_prep.pressure.
+;
+    _name.category_id             pd_prep
+    _name.object_id               pressure_su
+    _name.linked_item_id          '_pd_prep.pressure'
+    _units.code                   kilopascals
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+save_
+
+save_pd_prep.special_details
+
+    _definition.id                '_pd_prep.special_details'
+    _definition.update            2023-06-04
+    _description.text
+;
+    Descriptive information about the sample that cannot be included in other
+    data items.
+;
+    _name.category_id             pd_prep
+    _name.object_id               special_details
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_pd_prep.temperature
+
+    _definition.id                '_pd_prep.temperature'
+    _alias.definition_id          '_pd_prep_temperature'
+    _definition.update            2022-10-11
+    _description.text
+;
+    Preparation temperature of the sample in kelvins. This is
+    particularly important for materials which are metastable
+    at the measurement temperature, _diffrn.ambient_temperature.
+;
+    _name.category_id             pd_prep
+    _name.object_id               temperature
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   kelvins
+
+save_
+
+save_pd_prep.temperature_su
+
+    _definition.id                '_pd_prep.temperature_su'
+    _definition.update            2022-10-27
+    _description.text
+;
+    Standard uncertainty of _pd_prep.temperature.
+;
+    _name.category_id             pd_prep
+    _name.object_id               temperature_su
+    _name.linked_item_id          '_pd_prep.temperature'
+    _units.code                   kelvins
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+save_
+
+save_PD_PROC_INFO_AUTHOR
+
+    _definition.id                PD_PROC_INFO_AUTHOR
+    _definition.scope             Category
+    _definition.class             Loop
+    _definition.update            2023-06-05
+    _description.text
+;
+    This category is deprecated. Please see AUDIT_AUTHOR and AUDIT_AUTHOR_ROLE.
+
+    This section contains information about the person(s)
+    who processed the data.
+;
+    _name.category_id             PD_GROUP
+    _name.object_id               PD_PROC_INFO_AUTHOR
+    _category_key.name            '_pd_proc_info_author.name'
+
+save_
+
+save_pd_proc_info_author.address
+
+    _definition.id                '_pd_proc_info_author.address'
+
+    loop_
+      _definition_replaced.id
+      _definition_replaced.by
+         1                        '_audit_author.address'
+         2                        '_audit_author_role.role'
+
+    _alias.definition_id          '_pd_proc_info_author_address'
+    _definition.update            2023-06-05
+    _description.text
+;
+    This item is deprecated. Please see _audit_author.address and
+    _audit_author_role.role.
+
+    The address of the person who processed the data.
+    If there is more than one person, this will be looped with
+    _pd_proc_info_author.name.
+;
+    _name.category_id             pd_proc_info_author
+    _name.object_id               address
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_pd_proc_info_author.email
+
+    _definition.id                '_pd_proc_info_author.email'
+
+    loop_
+      _definition_replaced.id
+      _definition_replaced.by
+         1                        '_audit_author.email'
+         2                        '_audit_author_role.role'
+
+    _alias.definition_id          '_pd_proc_info_author_email'
+    _definition.update            2023-06-05
+    _description.text
+;
+    This item is deprecated. Please see _audit_author.email and
+    _audit_author_role.role.
+
+    The e-mail address of the person who processed the
+    data. If there is more than one person, this will be looped
+    with _pd_proc_info_author.name.
+;
+    _name.category_id             pd_proc_info_author
+    _name.object_id               email
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_pd_proc_info_author.fax
+
+    _definition.id                '_pd_proc_info_author.fax'
+
+    loop_
+      _definition_replaced.id
+      _definition_replaced.by
+         1                        '_audit_author.fax'
+         2                        '_audit_author_role.role'
+
+    _alias.definition_id          '_pd_proc_info_author_fax'
+    _definition.update            2023-05-06
+    _description.text
+;
+    This item is deprecated. Please see _audit_author.fax and
+    _audit_author_role.role.
+
+    The fax number of the person who processed the data.
+    If there is more than one person, this will be looped with
+    _pd_proc_info_author.name. The recommended style is
+    the international dialing prefix, followed by the area code in
+    parentheses, followed by the local number with no spaces.
+;
+    _name.category_id             pd_proc_info_author
+    _name.object_id               fax
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_pd_proc_info_author.name
+
+    _definition.id                '_pd_proc_info_author.name'
+
+    loop_
+      _definition_replaced.id
+      _definition_replaced.by
+         1                        '_audit_author.name'
+         2                        '_audit_author_role.role'
+
+    _alias.definition_id          '_pd_proc_info_author_name'
+    _definition.update            2023-06-05
+    _description.text
+;
+    This item is deprecated. Please see _audit_author.name and
+    _audit_author_role.role.
+
+    The name of the person who processed the data, if different
+    from the person(s) who measured the data set. The family
+    name(s), followed by a comma and including any dynastic
+    components, precedes the first name(s) or initial(s). For
+    more than one person use a loop to specify multiple values.
+;
+    _name.category_id             pd_proc_info_author
+    _name.object_id               name
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_pd_proc_info_author.phone
+
+    _definition.id                '_pd_proc_info_author.phone'
+
+    loop_
+      _definition_replaced.id
+      _definition_replaced.by
+         1                        '_audit_author.phone'
+         2                        '_audit_author_role.role'
+
+    _alias.definition_id          '_pd_proc_info_author_phone'
+    _definition.update            2023-06-05
+    _description.text
+;
+    This item is deprecated. Please see _audit_author.phone and
+    _audit_author_role.role.
+
+    The telephone number of the person who processed the data.
+    If there is more than one person, this will be looped
+    with _pd_proc_info_author.name. The recommended style is
+    the international dialing prefix, followed by the area code in
+    parentheses, followed by the local number with no spaces.
+;
+    _name.category_id             pd_proc_info_author
+    _name.object_id               phone
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_PD_PROC_LS
+
+    _definition.id                PD_PROC_LS
+    _definition.scope             Category
+    _definition.class             Set
+    _definition.update            2014-06-20
+    _description.text
+;
+    This section is used to define parameters relevant to a
+    least-squares fit to a powder diffractogram, using a Rietveld
+    or other full-profile (e.g. Pawley or Le Bail methods) fit.
+
+    Note that values in this section refer to full-pattern fitting.
+    Use the appropriate items for single-crystal analyses from the
+    core CIF dictionary for structure refinements using diffraction
+    intensities estimated from a powder diffractogram by
+    pattern-decomposition methods. Also note that many entries in
+    the core _refine_ls_ entries may also be useful (for example
+    _refine_ls_shift/su_*).
+;
+    _name.category_id             PD_GROUP
+    _name.object_id               PD_PROC_LS
+    _category_key.name            '_pd_proc_ls.diffractogram_id'
+
+save_
+
+save_pd_proc_ls.background_function
+
+    _definition.id                '_pd_proc_ls.background_function'
+    _alias.definition_id          '_pd_proc_ls_background_function'
+    _definition.update            2014-06-20
+    _description.text
+;
+    Description of the background treatment mechanism used to
+    fit the data set.
+
+    For refinements where the background is computed as a
+    function that is fitted to minimize the difference between
+    the observed and calculated patterns, it is
+    recommended that in addition to a description of the
+    function (e.g. Chebychev polynomial), the actual equation(s)
+    used are included in TeX, or a programming language such
+    as Fortran or C. Include also the values used for the
+    coefficients used in the background function with their
+    s.u.'s. The background values for each data point
+    computed from the function should be specified in
+    _pd_proc.intensity_bkg_calc.
+
+    If background correction is performed using extrapolation
+    from a set of points at fixed locations, these points
+    should be defined using _pd_proc.intensity_bkg_fix, and
+    _pd_proc_ls.background_function should indicate the
+    extrapolation method (linear extrapolation, spline etc.).
+    _pd_proc_ls.background_function should also indicate how the
+    points were determined (automatically, by visual estimation
+    etc.) and whether the values were refined to improve the
+    agreement. The extrapolated background intensity value for
+    each data point should be specified in
+    _pd_proc.intensity_bkg_calc.
+;
+    _name.category_id             pd_proc_ls
+    _name.object_id               background_function
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_pd_proc_ls.diffractogram_id
+
+    _definition.id                '_pd_proc_ls.diffractogram_id'
+    _definition.update            2023-03-26
+    _description.text
+;
+    The diffractogram (see _pd_diffractogram.id) to which the least squares
+    information relates.
+;
+    _name.category_id             pd_proc_ls
+    _name.object_id               diffractogram_id
+    _name.linked_item_id          '_pd_diffractogram.id'
+    _type.purpose                 Link
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_pd_proc_ls.peak_cutoff
+
+    _definition.id                '_pd_proc_ls.peak_cutoff'
+    _alias.definition_id          '_pd_proc_ls_peak_cutoff'
+    _definition.update            2014-06-20
+    _description.text
+;
+    Describes where peak-intensity computation is
+    discontinued as a fraction of the intensity of the
+    peak at maximum. Thus for a value of 0.005, the
+    tails of a diffraction peak are neglected
+    after the intensity has dropped below 0.5% of the
+    diffraction intensity at the maximum.
+;
+    _name.category_id             pd_proc_ls
+    _name.object_id               peak_cutoff
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_pd_proc_ls.pref_orient_corr
+
+    _definition.id                '_pd_proc_ls.pref_orient_corr'
+    _definition_replaced.id       1
+    _definition_replaced.by       '_pd_pref_orient.special_details'
+    _alias.definition_id          '_pd_proc_ls_pref_orient_corr'
+    _definition.update            2023-01-06
+    _description.text
+;
+    DEPRECATED. Use _pd_pref_orient.special_details, or if
+    the correction can be described as a March-Dollase
+    or spherical harmonics correction, use
+    _pd_pref_orient_March_Dollase.* or
+    _pd_pref_orient_spherical_harmonics.*, as
+    appropriate.
+
+    Description of the preferred-orientation correction if
+    such a correction is used. Omitting this entry
+    implies that no preferred-orientation correction
+    has been used. If a function form is used, it is
+    recommended that the actual equation in TeX, or a
+    programming language, is used to specify the function as
+    well as a giving a description. Include the value(s) used
+    for the correction with s.u.'s.
+;
+    _name.category_id             pd_proc_ls
+    _name.object_id               pref_orient_corr
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_pd_proc_ls.prof_r_factor
+
+    _definition.id                '_pd_proc_ls.prof_R_factor'
+    _alias.definition_id          '_pd_proc_ls_prof_R_factor'
+    _definition.update            2022-09-28
+    _description.text
+;
+    _pd_proc_ls.prof_R_factor, often called R~p~, is an
+      unweighted fitness metric for the agreement between the
+      observed and computed diffraction patterns.
+         R~p~ = sum~i~ | I~obs~(i) - I~calc~(i) |
+                / sum~i~ ( I~obs~(i) )
+      Note that in the above equations,
+         w(i) is the weight for the ith data point (see
+              _pd_proc.ls_weight).
+         I~obs~(i) is the observed intensity for the ith data
+              point, sometimes referred to as y~i~(obs) or
+              y~oi~. (See _pd_meas.counts_total,
+              _pd_meas.intensity_total or _pd_proc.intensity_total.)
+         I~calc~(i) is the computed intensity for the ith data
+              point with background and other corrections
+              applied to match the scale of the observed data set,
+              sometimes referred to as y~i~(calc) or
+              y~ci~. (See _pd_calc.intensity_total.)
+         n is the total number of data points (see
+              _pd_proc.number_of_points) less the number of
+              data points excluded from the refinement.
+         p is the total number of refined parameters.
+;
+    _name.category_id             pd_proc_ls
+    _name.object_id               pd_proc_ls_prof_R_factor
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   none
+
+save_
+
+save_pd_proc_ls.prof_wr_expected
+
+    _definition.id                '_pd_proc_ls.prof_wR_expected'
+    _alias.definition_id          '_pd_proc_ls_prof_wR_expected'
+    _definition.update            2022-09-28
+    _description.text
+;
+    _pd_proc_ls.prof_wR_expected, sometimes called the
+      theoretical R~wp~ or R~exp~, is a weighted fitness metric for
+      the statistical precision of the data set. For an idealised fit,
+      where all deviations between the observed intensities and
+      those computed from the model are due to statistical
+      fluctuations, the observed R~wp~ should match the expected
+      R factor. In reality, R~wp~ will always be higher than
+      R~exp~.
+        R~exp~ = SQRT { (n - p)  / sum~i~ ( w(i) [I~obs~(i)]^2^ ) }
+
+      Note that in the above equations,
+         w(i) is the weight for the ith data point (see
+              _pd_proc.ls_weight).
+         I~obs~(i) is the observed intensity for the ith data
+              point, sometimes referred to as y~i~(obs) or
+              y~oi~. (See _pd_meas.counts_total,
+              _pd_meas.intensity_total or _pd_proc.intensity_total.)
+         I~calc~(i) is the computed intensity for the ith data
+              point with background and other corrections
+              applied to match the scale of the observed data set,
+              sometimes referred to as y~i~(calc) or
+              y~ci~. (See _pd_calc.intensity_total.)
+         n is the total number of data points (see
+              _pd_proc.number_of_points) less the number of
+              data points excluded from the refinement.
+         p is the total number of refined parameters.
+;
+    _name.category_id             pd_proc_ls
+    _name.object_id               pd_proc_ls_prof_wR_expected
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   none
+
+save_
+
+save_pd_proc_ls.prof_wr_factor
+
+    _definition.id                '_pd_proc_ls.prof_wR_factor'
+    _alias.definition_id          '_pd_proc_ls_prof_wR_factor'
+    _definition.update            2022-09-28
+    _description.text
+;
+    _pd_proc_ls.prof_wR_factor, often called R~wp~, is a
+      weighted fitness metric for the agreement between the
+      observed and computed diffraction patterns.
+        R~wp~ = SQRT {
+                 sum~i~ ( w(i) [ I~obs~(i) - I~calc~(i) ]^2^ )
+                 / sum~i~ ( w(i) [I~obs~(i)]^2^ )
+                }
+
+      Note that in the above equations,
+         w(i) is the weight for the ith data point (see
+              _pd_proc.ls_weight).
+         I~obs~(i) is the observed intensity for the ith data
+              point, sometimes referred to as y~i~(obs) or
+              y~oi~. (See _pd_meas.counts_total,
+              _pd_meas.intensity_total or _pd_proc.intensity_total.)
+         I~calc~(i) is the computed intensity for the ith data
+              point with background and other corrections
+              applied to match the scale of the observed data set,
+              sometimes referred to as y~i~(calc) or
+              y~ci~. (See _pd_calc.intensity_total.)
+         n is the total number of data points (see
+              _pd_proc.number_of_points) less the number of
+              data points excluded from the refinement.
+         p is the total number of refined parameters.
+;
+    _name.category_id             pd_proc_ls
+    _name.object_id               pd_proc_ls_prof_wR_factor
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   none
+
+save_
+
+save_pd_proc_ls.profile_function
+
+    _definition.id                '_pd_proc_ls.profile_function'
+    _alias.definition_id          '_pd_proc_ls_profile_function'
+    _definition.update            2014-06-20
+    _description.text
+;
+    Description of the profile function used to
+    fit the data set. If a function form is used, it is
+    recommended that the actual equation in TeX, or a
+    programming language, is used to specify the function as
+    well as giving a description. Include the values used
+    for the profile-function coefficients and their s.u.'s.
+;
+    _name.category_id             pd_proc_ls
+    _name.object_id               profile_function
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_pd_proc_ls.special_details
+
+    _definition.id                '_pd_proc_ls.special_details'
+    _alias.definition_id          '_pd_proc_ls_special_details'
+    _definition.update            2014-06-20
+    _description.text
+;
+    Additional characterization information relevant to
+    non-routine steps used for refinement of a structural model
+    that cannot be specified elsewhere.
+;
+    _name.category_id             pd_proc_ls
+    _name.object_id               special_details
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_PD_PROC_OVERALL
+
+    _definition.id                PD_PROC_OVERALL
+    _definition.scope             Category
+    _definition.class             Set
+    _definition.update            2025-04-18
+    _description.text
+;
+    This section contains overall information about the diffraction
+    data set after processing and application of correction
+    terms. If the data set is reprocessed, this section may be
+    replaced.
+;
+    _name.category_id             PD_GROUP
+    _name.object_id               PD_PROC_OVERALL
+    _category_key.name            '_pd_proc_overall.diffractogram_id'
+
+save_
+
+save_pd_proc.2theta_range_inc
+
+    _definition.id                '_pd_proc.2theta_range_inc'
+    _alias.definition_id          '_pd_proc_2theta_range_inc'
+    _definition.update            2021-11-12
+    _description.text
+;
+    The increment in 2θ diffraction angles in degrees for the
+    measurement of intensities. These may be used in place of the
+    _pd_proc.2theta_corrected values, or in the case of white-beam
+    experiments it will define the fixed 2θ value.
+;
+    _name.category_id             pd_proc_overall
+    _name.object_id               2theta_range_inc
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            -180.0:180.0
+    _units.code                   degrees
+
+save_
+
+save_pd_proc.2theta_range_max
+
+    _definition.id                '_pd_proc.2theta_range_max'
+    _alias.definition_id          '_pd_proc_2theta_range_max'
+    _definition.update            2014-06-20
+    _description.text
+;
+    The maximum 2θ diffraction angle in degrees for the
+    measurement of intensities. This may be used in place of the
+    _pd_proc.2theta_corrected values, or in the case of white-beam
+    experiments it will define the fixed 2θ value together with
+    _pd_proc.2theta_range_min.
+;
+    _name.category_id             pd_proc_overall
+    _name.object_id               2theta_range_max
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            -180.0:180.0
+    _units.code                   degrees
+
+save_
+
+save_pd_proc.2theta_range_min
+
+    _definition.id                '_pd_proc.2theta_range_min'
+    _alias.definition_id          '_pd_proc_2theta_range_min'
+    _definition.update            2014-06-20
+    _description.text
+;
+    The minimum 2θ diffraction angle in degrees for the
+    measurement of intensities. This may be used in place of the
+    _pd_proc.2theta_corrected values, or in the case of white-beam
+    experiments they will define the fixed 2θ value together with
+    _pd_proc.2theta_range_max.
+;
+    _name.category_id             pd_proc_overall
+    _name.object_id               2theta_range_min
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            -180.0:180.0
+    _units.code                   degrees
+
+save_
+
+save_pd_proc.info_data_reduction
+
+    _definition.id                '_pd_proc.info_data_reduction'
+    _alias.definition_id          '_pd_proc_info_data_reduction'
+    _definition.update            2014-06-20
+    _description.text
+;
+    Description of the processing steps applied in the data-reduction
+    process (background subtraction, α-2 stripping, smoothing
+    etc.). Include details of the program(s) used etc.
+;
+    _name.category_id             pd_proc_overall
+    _name.object_id               info_data_reduction
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_pd_proc.info_datetime
+
+    _definition.id                '_pd_proc.info_datetime'
+    _alias.definition_id          '_pd_proc_info_datetime'
+    _definition.update            2023-01-16
+    _description.text
+;
+    Date and time when the data set was most recently processed.
+
+    Entries should follow the standard RFC 3339 ABNF format
+    'yyyy-mm-ddThh:mm:ss{Z|[+-]zz:zz}'.
+;
+    _name.category_id             pd_proc_overall
+    _name.object_id               info_datetime
+    _type.purpose                 Encode
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                DateTime
+
+    loop_
+      _description_example.case
+         1990-07-13T14:40:00Z
+         2042-12-13T02:37:23Z
+         2005-03-03T12:02:09.17+09:30
+         2015-10-30T22:45:00-02:00
+         1912-02-03T11:47:00Z
+         1979-09-01
+
+save_
+
+save_pd_proc.info_excluded_regions
+
+    _definition.id                '_pd_proc.info_excluded_regions'
+    _alias.definition_id          '_pd_proc_info_excluded_regions'
+    _definition.update            2014-06-20
+    _description.text
+;
+    Description of regions in the diffractogram excluded
+    from processing along with a justification of why the
+    data points were not used.
+;
+    _name.category_id             pd_proc_overall
+    _name.object_id               info_excluded_regions
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+    _description_example.case     '20 to 21 degrees unreliable due to beam dump'
+
+save_
+
+save_pd_proc.info_special_details
+
+    _definition.id                '_pd_proc.info_special_details'
+    _alias.definition_id          '_pd_proc_info_special_details'
+    _definition.update            2014-06-20
+    _description.text
+;
+    Detailed description of any non-routine processing steps
+    applied due to any irregularities in this particular data set.
+;
+    _name.category_id             pd_proc_overall
+    _name.object_id               info_special_details
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_pd_proc.number_of_points
+
+    _definition.id                '_pd_proc.number_of_points'
+    _alias.definition_id          '_pd_proc_number_of_points'
+    _definition.update            2019-09-25
+    _description.text
+;
+    The total number of data points in the processed diffractogram.
+;
+    _name.category_id             pd_proc_overall
+    _name.object_id               number_of_points
+    _type.purpose                 Number
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Integer
+    _enumeration.range            1:
+    _units.code                   none
+
+save_
+
+save_pd_proc_overall.diffractogram_id
+
+    _definition.id                '_pd_proc_overall.diffractogram_id'
+    _definition.update            2023-01-12
+    _description.text
+;
+    The diffractogram (see _pd_diffractogram.id) to which the overall
+    processing attributes relate.
+;
+    _name.category_id             pd_proc_overall
+    _name.object_id               diffractogram_id
+    _name.linked_item_id          '_pd_diffractogram.id'
+    _type.purpose                 Link
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_PD_QPA_CALIB_FACTOR
+
+    _definition.id                PD_QPA_CALIB_FACTOR
+    _definition.scope             Category
+    _definition.class             Set
+    _definition.update            2023-01-15
+    _description.text
+;
+    This category gives the value of the calibration constant by which the
+    calculated intensity or scale factor associated with the given phase is
+    divided by in order to allow quantitative phase analysis to be undertaken.
+    Further normalisation may be necessary, and can be indicated.
+
+    For a description of the quantification methodologies below, and a review on
+    quantitative phase analysis in general, see Chapter 3.9 of International
+    Tables, Vol. H, and references therein.
+;
+    _name.category_id             PD_GROUP
+    _name.object_id               PD_QPA_CALIB_FACTOR
+    _category_key.name            '_pd_qpa_calib_factor.phase_id'
+
+save_
+
+save_pd_qpa_calib_factor.absorption_diffraction
+
+    _definition.id                '_pd_qpa_calib_factor.absorption_diffraction'
+    _definition.update            2023-01-22
+    _description.text
+;
+    A absorption-diffraction calibration value associated with the given phase
+    which allows quantitative phase analysis to be undertaken.
+
+    A description of the associated quantification procedure can be found in
+    the equivalent enumeration in _pd_qpa_overall.method.
+;
+    _name.category_id             pd_qpa_calib_factor
+    _name.object_id               absorption_diffraction
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _units.code                   none
+
+save_
+
+save_pd_qpa_calib_factor.absorption_diffraction_su
+
+    _definition.id
+        '_pd_qpa_calib_factor.absorption_diffraction_su'
+    _definition.update            2023-01-22
+    _description.text
+;
+    Standard uncertainty of _pd_qpa_calib_factor.absorption_diffraction.
+;
+    _name.category_id             pd_qpa_calib_factor
+    _name.object_id               absorption_diffraction_su
+    _name.linked_item_id          '_pd_qpa_calib_factor.absorption_diffraction'
+    _units.code                   none
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+save_
+
+save_pd_qpa_calib_factor.ddm
+
+    _definition.id                '_pd_qpa_calib_factor.DDM'
+    _definition.update            2023-01-22
+    _description.text
+;
+    A Direct-Derivation Methodology (DDM) calibration value associated with the
+    given phase which allows quantitative phase analysis to be undertaken.
+
+    A description of the associated quantification procedure can be found in
+    the equivalent enumeration in _pd_qpa_overall.method.
+;
+    _name.category_id             pd_qpa_calib_factor
+    _name.object_id               DDM
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _units.code                   none
+
+save_
+
+save_pd_qpa_calib_factor.ddm_su
+
+    _definition.id                '_pd_qpa_calib_factor.DDM_su'
+    _definition.update            2023-01-22
+    _description.text
+;
+    Standard uncertainty of _pd_qpa_calib_factor.DDM.
+;
+    _name.category_id             pd_qpa_calib_factor
+    _name.object_id               DDM_su
+    _name.linked_item_id          '_pd_qpa_calib_factor.DDM'
+    _units.code                   none
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+save_
+
+save_pd_qpa_calib_factor.external_standard
+
+    _definition.id                '_pd_qpa_calib_factor.external_standard'
+    _definition.update            2023-01-22
+    _description.text
+;
+    A external standard calibration value associated with the given phase which
+    allows quantitative phase analysis to be undertaken.
+
+    If the external standard approach is used, the use of PD_QPA_EXTERNAL_STD
+    data items is preferred.
+
+    A description of the associated quantification procedure can be found in
+    the equivalent enumeration in _pd_qpa_overall.method.
+;
+    _name.category_id             pd_qpa_calib_factor
+    _name.object_id               external_standard
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _units.code                   none
+
+save_
+
+save_pd_qpa_calib_factor.external_standard_su
+
+    _definition.id                '_pd_qpa_calib_factor.external_standard_su'
+    _definition.update            2023-01-22
+    _description.text
+;
+    Standard uncertainty of _pd_qpa_calib_factor.external_standard.
+;
+    _name.category_id             pd_qpa_calib_factor
+    _name.object_id               external_standard_su
+    _name.linked_item_id          '_pd_qpa_calib_factor.external_standard'
+    _units.code                   none
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+save_
+
+save_pd_qpa_calib_factor.i_over_ic
+
+    _definition.id                '_pd_qpa_calib_factor.I_over_Ic'
+    _definition.update            2023-01-22
+    _description.text
+;
+    A Reference Intensity Ratio (RIR) calibration value associated with the
+    given phase which allows quantitative phase analysis to be undertaken.
+
+    This ratio must have been calculated with respect to corundum; for other
+    reference materials, please use _pd_qpa_calib_factor.RIR.
+
+    A description of the associated quantification procedure can be found in
+    the equivalent enumeration in _pd_qpa_overall.method.
+;
+    _name.category_id             pd_qpa_calib_factor
+    _name.object_id               I_over_Ic
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _units.code                   none
+
+save_
+
+save_pd_qpa_calib_factor.i_over_ic_su
+
+    _definition.id                '_pd_qpa_calib_factor.I_over_Ic_su'
+    _definition.update            2023-01-22
+    _description.text
+;
+    Standard uncertainty of _pd_qpa_calib_factor.I_over_Ic.
+;
+    _name.category_id             pd_qpa_calib_factor
+    _name.object_id               I_over_Ic_su
+    _name.linked_item_id          '_pd_qpa_calib_factor.I_over_Ic'
+    _units.code                   none
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+save_
+
+save_pd_qpa_calib_factor.other
+
+    _definition.id                '_pd_qpa_calib_factor.other'
+    _definition.update            2023-01-24
+    _description.text
+;
+    A calibration value associated with the given phase which allows
+    quantitative phase analysis to be undertaken.
+
+    The type of data this value represents must be given in
+    _pd_qpa_calib_factor.special_details.
+
+    A description of the associated quantification procedure must be given in
+    _pd_qpa_overall.method.
+
+    When this data item is used in many phases present in the same
+    diffractogram, the person creating the CIF file must ensure that they
+    have consistent definitions.
+;
+    _name.category_id             pd_qpa_calib_factor
+    _name.object_id               other
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _units.code                   none
+
+save_
+
+save_pd_qpa_calib_factor.other_su
+
+    _definition.id                '_pd_qpa_calib_factor.other_su'
+    _definition.update            2023-01-22
+    _description.text
+;
+    Standard uncertainty of _pd_qpa_calib_factor.other.
+;
+    _name.category_id             pd_qpa_calib_factor
+    _name.object_id               other_su
+    _name.linked_item_id          '_pd_qpa_calib_factor.other'
+    _units.code                   none
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+save_
+
+save_pd_qpa_calib_factor.phase_id
+
+    _definition.id                '_pd_qpa_calib_factor.phase_id'
+    _definition.update            2023-01-15
+    _description.text
+;
+    The phase (see _pd_phase.id) to which the calibration factor applies.
+;
+    _name.category_id             pd_qpa_calib_factor
+    _name.object_id               phase_id
+    _name.linked_item_id          '_pd_phase.id'
+    _type.purpose                 Link
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_pd_qpa_calib_factor.ponkcs
+
+    _definition.id                '_pd_qpa_calib_factor.PONKCS'
+    _definition.update            2023-01-22
+    _description.text
+;
+    A PONKCS calibration value associated with the given phase which allows
+    quantitative phase analysis to be undertaken.
+
+    This value, when coupled with the peak intensities for which it was
+    calibrated, forms a pseudo-ZMV value, and can also be used in
+    quantification with the ZMV algorithm.
+
+    A description of the associated quantification procedure can be found in
+    the equivalent enumeration in _pd_qpa_overall.method.
+;
+    _name.category_id             pd_qpa_calib_factor
+    _name.object_id               PONKCS
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _units.code                   none
+
+save_
+
+save_pd_qpa_calib_factor.ponkcs_su
+
+    _definition.id                '_pd_qpa_calib_factor.PONKCS_su'
+    _definition.update            2023-01-22
+    _description.text
+;
+    Standard uncertainty of _pd_qpa_calib_factor.PONKCS.
+;
+    _name.category_id             pd_qpa_calib_factor
+    _name.object_id               PONKCS_su
+    _name.linked_item_id          '_pd_qpa_calib_factor.PONKCS'
+    _units.code                   none
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+save_
+
+save_pd_qpa_calib_factor.rir
+
+    _definition.id                '_pd_qpa_calib_factor.RIR'
+    _definition.update            2023-01-22
+    _description.text
+;
+    A Reference Intensity Ratio (RIR) calibration value associated with the
+    given phase which allows quantitative phase analysis to be undertaken.
+
+    This ratio must NOT have been calculated with respect to corundum; for RIR
+    values calculated with corundum, please use _pd_qpa_calib_factor.I_over_IC.
+
+    Details of the reference material against which this RIR was determined
+    should be given in _pd_qpa_calib_factor.special_details.
+
+    A description of the associated quantification procedure can be found in
+    the equivalent enumeration in _pd_qpa_overall.method.
+;
+    _name.category_id             pd_qpa_calib_factor
+    _name.object_id               RIR
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _units.code                   none
+
+save_
+
+save_pd_qpa_calib_factor.rir_su
+
+    _definition.id                '_pd_qpa_calib_factor.RIR_su'
+    _definition.update            2023-01-22
+    _description.text
+;
+    Standard uncertainty of _pd_qpa_calib_factor.RIR.
+;
+    _name.category_id             pd_qpa_calib_factor
+    _name.object_id               RIR_su
+    _name.linked_item_id          '_pd_qpa_calib_factor.RIR'
+    _units.code                   none
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+save_
+
+save_pd_qpa_calib_factor.special_details
+
+    _definition.id                '_pd_qpa_calib_factor.special_details'
+    _definition.update            2023-01-15
+    _description.text
+;
+    Description of calibration factor details that require additional detail,
+    or cannot otherwise be recorded using other PD_QPA_CALIB_FACTOR data items.
+;
+    _name.category_id             pd_qpa_calib_factor
+    _name.object_id               special_details
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_pd_qpa_calib_factor.zmv
+
+    _definition.id                '_pd_qpa_calib_factor.ZMV'
+    _definition.update            2023-01-22
+    _description.text
+;
+    A ZMV calibration value associated with the given phase which allows
+    quantitative phase analysis to be undertaken.
+
+    If this value is not given, please ensure that _cell.volume and either
+    _cell.atomic_mass or the atoms in the unit cell are given in an ATOM_TYPE
+    list, to allow for the correct calculation of ZMV.
+
+    A description of the associated quantification procedure can be found in
+    the equivalent enumeration in _pd_qpa_overall.method.
+;
+    _name.category_id             pd_qpa_calib_factor
+    _name.object_id               ZMV
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _units.code                   none
+
+save_
+
+save_pd_qpa_calib_factor.zmv_su
+
+    _definition.id                '_pd_qpa_calib_factor.ZMV_su'
+    _definition.update            2023-01-22
+    _description.text
+;
+    Standard uncertainty of _pd_qpa_calib_factor.ZMV.
+;
+    _name.category_id             pd_qpa_calib_factor
+    _name.object_id               ZMV_su
+    _name.linked_item_id          '_pd_qpa_calib_factor.ZMV'
+    _units.code                   none
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+save_
+
+save_PD_QPA_EXTERNAL_STD
+
+    _definition.id                PD_QPA_EXTERNAL_STD
+    _definition.scope             Category
+    _definition.class             Set
+    _definition.update            2023-01-15
+    _description.text
+;
+    This category identifies the external diffractogram used for
+    quantitative phase analysis.
+
+    Quantification by external standard is typically carried out
+    using the O'Connor and Raven algorithm in conjunction with whole-pattern
+    Rietveld modelling, and relies on the determination of
+    the diffractometer constant, K. The use of an external standard
+    allows for the calculation of absolute mass fractions, giving
+    an indication of amorphous content. This method requires the
+    mass attenuation coefficient of the specimen to be measured or
+    calculated. For a review on quantitative phase analysis, see
+    Chapter 3.9 of International Tables, Vol. H, and references therein.
+;
+    _name.category_id             PD_GROUP
+    _name.object_id               PD_QPA_EXTERNAL_STD
+    _category_key.name            '_pd_qpa_external_std.diffractogram_id'
+
+save_
+
+save_pd_qpa_external_std.diffractogram_id
+
+    _definition.id                '_pd_qpa_external_std.diffractogram_id'
+    _definition.update            2023-01-15
+    _description.text
+;
+    The diffractogram (see _pd_diffractogram.id) which is being used to
+    calculate the diffractometer constant.
+;
+    _name.category_id             pd_qpa_external_std
+    _name.object_id               diffractogram_id
+    _name.linked_item_id          '_pd_diffractogram.id'
+    _type.purpose                 Link
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_pd_qpa_external_std.k_factor
+
+    _definition.id                '_pd_qpa_external_std.k_factor'
+    _definition.update            2023-01-06
+    _description.text
+;
+    The value of the diffractometer constant, K, applied to the
+    quantification of the phases present in the given diffractogram.
+
+    The external standard method is described by O'Connor and Raven.
+    In this method, the absolute mass percent of a phase is given as
+
+    W~k~ = 100 * s~k~ * M~k~ * V~k~ * μ^*^ / K
+
+    where W~k~, s~k~, M~k~, & V~k~ are the absolute mass percent, Rietveld
+    scale factor, unit cell mass, and unit cell volume of phase k.
+    μ^*^ is the mass attenuation coefficient of the specimen, and K is
+    the normalising diffractometer constant.
+
+    O'Connor, B. H., & Raven, M. D. (1988). Application of the Rietveld
+    Refinement Procedure in Assaying Powdered Mixtures. Powder Diffraction,
+    3(1), 2-6. doi:10.1017/s0885715600013026
+;
+    _name.category_id             pd_qpa_external_std
+    _name.object_id               k_factor
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _units.code                   none
+
+save_
+
+save_pd_qpa_external_std.k_factor_su
+
+    _definition.id                '_pd_qpa_external_std.k_factor_su'
+    _definition.update            2022-12-01
+    _description.text
+;
+    Standard uncertainty of _pd_qpa_external_std.k_factor.
+;
+    _name.category_id             pd_qpa_external_std
+    _name.object_id               k_factor_su
+    _name.linked_item_id          '_pd_qpa_external_std.k_factor'
+    _units.code                   none
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+save_
+
+save_pd_qpa_external_std.phase_id
+
+    _definition.id                '_pd_qpa_external_std.phase_id'
+    _definition.update            2022-12-03
+    _description.text
+;
+    The phase (see _pd_phase.id) used as the external standard.
+;
+    _name.category_id             pd_qpa_external_std
+    _name.object_id               phase_id
+    _name.linked_item_id          '_pd_phase.id'
+    _type.purpose                 Link
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_pd_qpa_external_std.special_details
+
+    _definition.id                '_pd_qpa_external_std.special_details'
+    _definition.update            2023-01-03
+    _description.text
+;
+    Description of external standard details that cannot otherwise
+    be recorded using other PD_QPA_EXTERNAL_STD data items.
+;
+    _name.category_id             pd_qpa_external_std
+    _name.object_id               special_details
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_PD_QPA_INTENSITY_FACTOR
+
+    _definition.id                PD_QPA_INTENSITY_FACTOR
+    _definition.scope             Category
+    _definition.class             Loop
+    _definition.update            2023-01-22
+    _description.text
+;
+    This category gives the value of the intensity or scale factor which is
+    divided by the corresponding calibration factor in order to allow
+    quantitative phase analysis to be undertaken. Further normalisation may be
+    necessary, and can be indicated.
+
+    The supported methodologies are enumerated in _pd_qpa_overall.method.
+
+    For a review on quantitative phase analysis, see Chapter 3.9 of
+    International Tables, Vol. H, and references therein.
+;
+    _name.category_id             PD_GROUP
+    _name.object_id               PD_QPA_INTENSITY_FACTOR
+
+    loop_
+      _category_key.name
+         '_pd_qpa_intensity_factor.diffractogram_id'
+         '_pd_qpa_intensity_factor.phase_id'
+
+save_
+
+save_pd_qpa_intensity_factor.diffractogram_id
+
+    _definition.id                '_pd_qpa_intensity_factor.diffractogram_id'
+    _definition.update            2023-01-15
+    _description.text
+;
+    The diffractogram (see _pd_diffractogram.id) to which the intensity factor
+    relates.
+;
+    _name.category_id             pd_qpa_intensity_factor
+    _name.object_id               diffractogram_id
+    _name.linked_item_id          '_pd_diffractogram.id'
+    _type.purpose                 Link
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_pd_qpa_intensity_factor.phase_id
+
+    _definition.id                '_pd_qpa_intensity_factor.phase_id'
+    _definition.update            2023-01-22
+    _description.text
+;
+    The phase (see _pd_phase.id) to which the intensity factor applies.
+;
+    _name.category_id             pd_qpa_intensity_factor
+    _name.object_id               phase_id
+    _name.linked_item_id          '_pd_phase.id'
+    _type.purpose                 Link
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_pd_qpa_intensity_factor.value
+
+    _definition.id                '_pd_qpa_intensity_factor.value'
+    _definition.update            2023-01-22
+    _description.text
+;
+    An intensity or scale factor value associated with the given phase and
+    diffractogram, which, when divided by the appropriate calibration value
+    defined in _pd_qpa_calib_factor.*, allows quantitative phase analysis to be
+    undertaken.
+
+    This value is not, in general, transferable between different program types
+    and versions, as each software package may incorporate different constants
+    or normalisations into their calculations. However, if all values for a
+    given diffractogram are self-consistent, then quantification can be
+    undertaken.
+
+    A description of the associated quantification procedure can be found in
+    the equivalent enumeration in _pd_qpa_overall.method.
+;
+    _name.category_id             pd_qpa_intensity_factor
+    _name.object_id               value
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _units.code                   none
+
+save_
+
+save_pd_qpa_intensity_factor.value_su
+
+    _definition.id                '_pd_qpa_intensity_factor.value_su'
+    _definition.update            2023-01-22
+    _description.text
+;
+    Standard uncertainty of _pd_qpa_intensity_factor.value.
+;
+    _name.category_id             pd_qpa_intensity_factor
+    _name.object_id               value_su
+    _name.linked_item_id          '_pd_qpa_intensity_factor.value'
+    _units.code                   none
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+save_
+
+save_PD_QPA_INTERNAL_STD
+
+    _definition.id                PD_QPA_INTERNAL_STD
+    _definition.scope             Category
+    _definition.class             Set
+    _definition.update            2023-01-16
+    _description.text
+;
+    This category identifies the internal standard used for
+    quantitative phase analysis.
+
+    Quantification by internal standard can be carried out by a variety
+    of different methods, including the Reference Intensity Ratio or the
+    Hill & Howard algorithm in conjunction with whole-pattern Rietveld
+    modelling.
+
+    In general, the use of an internal standard converts relative phase
+    mass percentages into absolute mass percentage, allowing determination
+    of the 'unknown' (or 'amorphous', 'noncrystalline', or 'unanalysed')
+    fraction of the specimen.
+
+    This can be done as
+
+        W~p~^abs.^ = W~p~^rel.^ * (W~s~^known^ / W~s~^rel.^)
+
+    where p and s represent the analyte phase and standard phase, respectively,
+    W is the weight fraction, 'abs.' is absolute, 'rel.' is relative, and
+    'known' is the known addition. Here, W~s~^rel.^ is the relative amount of
+    standard as calculated by the quantification algorithm.
+
+    For a review on quantitative phase analysis, see Chapter 3.9 of
+    International Tables, Vol. H, and references therein.
+;
+    _name.category_id             PD_GROUP
+    _name.object_id               PD_QPA_INTERNAL_STD
+
+    loop_
+      _category_key.name
+         '_pd_qpa_internal_std.diffractogram_id'
+         '_pd_qpa_internal_std.phase_id'
+
+save_
+
+save_pd_qpa_internal_std.crystallinity_percent
+
+    _definition.id                '_pd_qpa_internal_std.crystallinity_percent'
+    _definition.update            2023-01-23
+    _description.text
+;
+    Per cent crystallinity of the internal standard.
+
+    Materials are rarely 100% crystalline as the crystal structure at the
+    material's surface is able to relax, and/or contain reaction products. This
+    thin, disordered surface layer can account for several mass percent of the
+    standard, and, as such, can affect any resultant quantification based on the
+    standard.
+
+    Knowledge of the internal standard crystallinity allows for the known mass
+    addition to be corrected to a crystalline addition, which is the addition
+    being analysed in a diffraction experiment.
+;
+    _name.category_id             pd_qpa_internal_std
+    _name.object_id               crystallinity_percent
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:100.0
+    _enumeration.default          100.0
+    _units.code                   none
+
+save_
+
+save_pd_qpa_internal_std.crystallinity_percent_su
+
+    _definition.id
+        '_pd_qpa_internal_std.crystallinity_percent_su'
+    _definition.update            2023-01-23
+    _description.text
+;
+    Standard uncertainty of _pd_qpa_internal_std.crystallinity_percent.
+;
+    _name.category_id             pd_qpa_internal_std
+    _name.object_id               crystallinity_percent_su
+    _name.linked_item_id          '_pd_qpa_internal_std.crystallinity_percent'
+    _units.code                   none
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+save_
+
+save_pd_qpa_internal_std.diffractogram_id
+
+    _definition.id                '_pd_qpa_internal_std.diffractogram_id'
+    _definition.update            2023-02-02
+    _description.text
+;
+    A diffractogram ID code (see _pd_diffractogram.id) identifying the
+    diffractogram to which the internal standard relates.
+
+    The diffractogram will be identified by a _pd_diffractogram.id code matching
+    the code in _pd_qpa_overall.diffractogram_id.
+;
+    _name.category_id             pd_qpa_internal_std
+    _name.object_id               diffractogram_id
+    _name.linked_item_id          '_pd_diffractogram.id'
+    _type.purpose                 Link
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_pd_qpa_internal_std.mass_percent
+
+    _definition.id                '_pd_qpa_internal_std.mass_percent'
+    _alias.definition_id          '_pd_calib_std_internal_mass_%'
+    _definition.update            2023-01-16
+    _description.text
+;
+    Per cent presence of the internal standard expressed as 100 times the mass
+    of standard added divided by the sum of the mass of standard added and the
+    original sample mass.
+
+    This value does not take into account the crystallinity of the internal
+    standard. That is, if 1 g of a 90% crystalline internal standard is added
+    to 3 g of sample, the _pd_qpa_internal_std.mass_percent is 25%.
+;
+    _name.category_id             pd_qpa_internal_std
+    _name.object_id               mass_percent
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:100.0
+    _units.code                   none
+
+save_
+
+save_pd_qpa_internal_std.mass_percent_su
+
+    _definition.id                '_pd_qpa_internal_std.mass_percent_su'
+    _definition.update            2023-01-16
+    _description.text
+;
+    Standard uncertainty of _pd_qpa_internal_std.mass_percent.
+;
+    _name.category_id             pd_qpa_internal_std
+    _name.object_id               mass_percent_su
+    _name.linked_item_id          '_pd_qpa_internal_std.mass_percent'
+    _units.code                   none
+
+    _import.get                   [{'file':templ_attr.cif  'save':general_su}]
+
+save_
+
+save_pd_qpa_internal_std.phase_id
+
+    _definition.id                '_pd_qpa_internal_std.phase_id'
+    _definition.update            2023-01-16
+    _description.text
+;
+    The phase (see _pd_phase.id) used as the internal standard.
+;
+    _name.category_id             pd_qpa_internal_std
+    _name.object_id               phase_id
+    _name.linked_item_id          '_pd_phase.id'
+    _type.purpose                 Link
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_pd_qpa_internal_std.special_details
+
+    _definition.id                '_pd_qpa_internal_std.special_details'
+    _definition.update            2023-01-16
+    _description.text
+;
+    Description of internal standard details that cannot otherwise
+    be recorded using other PD_QPA_INTERNAL_STD data items
+;
+    _name.category_id             pd_qpa_internal_std
+    _name.object_id               special_details
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_PD_QPA_OVERALL
+
+    _definition.id                PD_QPA_OVERALL
+    _definition.scope             Category
+    _definition.class             Set
+    _definition.update            2023-02-06
+    _description.text
+;
+    This category gives the overall information about the quantitative phase
+    analysis methodology applied to a given diffractogram.
+
+    For a review on quantitative phase analysis, see Chapter 3.9 of
+    International Tables, Vol. H, and references therein.
+;
+    _name.category_id             PD_GROUP
+    _name.object_id               PD_QPA_OVERALL
+    _category_key.name            '_pd_qpa_overall.diffractogram_id'
+
+save_
+
+save_pd_qpa_overall.diffractogram_id
+
+    _definition.id                '_pd_qpa_overall.diffractogram_id'
+    _definition.update            2023-01-16
+    _description.text
+;
+    A diffractogram ID code (see _pd_diffractogram.id) identifying the
+    diffractogram to which the quantitative phase analysis information relates.
+
+    The diffractogram will be identified by a _pd_diffractogram.id code matching
+    the code in _pd_qpa_overall.diffractogram_id.
+;
+    _name.category_id             pd_qpa_overall
+    _name.object_id               diffractogram_id
+    _name.linked_item_id          '_pd_diffractogram.id'
+    _type.purpose                 Link
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_pd_qpa_overall.method
+
+    _definition.id                '_pd_qpa_overall.method'
+    _definition.update            2023-11-12
+    _description.text
+;
+    The type of quantification method applied to the given diffractogram.
+
+    This data item allows the origin of the values of _pd_phase_mass.percent
+    to be determined. Additionally, it allows for the proper interpretation
+    of any _pd_qpa_calib_factor.* value that is given.
+
+    If 'other' is chosen, further information must be given in
+    _pd_qpa_overall.special_details
+;
+    _name.category_id             pd_qpa_overall
+    _name.object_id               method
+    _type.purpose                 State
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Code
+
+    loop_
+      _enumeration_set.state
+      _enumeration_set.detail
+         absorption_diffraction
+;
+         Quantitative phase analysis was undertaken following the
+         absorption-diffraction methodology [1].
+
+         The absolute weight fraction of phase p, W~p~, is given by
+
+             W~p~ = [I~p~ / C~p~] * μ^*^~m~
+
+         where I~p~ is the intensity of the analyte peak, μ^*^~m~ is the mass
+         absorption coefficient of the entire specimen, and C~p~ is a previously
+         determined calibration constant which depends on the data collection
+         conditions and the nature of the phase being calibrated. Intensities
+         from unknown specimens must be collected under the same conditions as
+         the calibration was determined, or normalised to match.
+
+         _pd_char.mass_atten_coef_mu_calc or _pd_char.mass_atten_coef_mu_meas
+         must be given for the specimen in each diffractogram.
+
+         The values utilised for I~p~ and C~p~ can be recorded using
+         _pd_qpa_intensity_factor.value and
+         _pd_qpa_calib_factor.absorption_diffraction, respectively.
+
+         [1] Klug, H.P. & Alexander, L.E. (1974). X-Ray Diffraction Procedures:
+         For Polycrystalline and Amorphous Materials. New York: Wiley. pp.
+         532-534.
+;
+         DDM
+;
+         Quantitative phase analysis was undertaken following the Direct
+         Derivation Method [1-6].
+
+         The relative weight fraction of phase p, W~p~, is given by
+
+             W~p~ = (I~p~ / C~p~) / Sum(I~k~ / C~k~, k=1:P)
+
+         where I~p~ is the integrated, Lp-normalised intensity of the analyte
+         phase over the entire diffractogram. The sum is taken over all phases
+         present. C~p~ is given by
+
+             C~p~ = (1/M~p~) * Sum(n~i,p~^2^, i=1:N~p~)
+
+         where M~p~ is the chemical formula weight of phase p, n~i,p~ is the
+         number of electrons belonging to the i^th^ atom of phase p, and N~p~ is
+         the number of atoms in the formula unit of phase p.
+
+         The values utilised for I~p~ and C~p~ can be recorded using
+         _pd_qpa_intensity_factor.value and _pd_qpa_calib_factor.DDM,
+         respectively.
+
+         If an internal standard, s, is present with a known addition, the
+         relative weight fractions can be converted to absolute weight fractions
+         by
+
+            W~p~^absolute^ = W~p~^relative^ * (W~s~^known^ / W~s~^relative^)
+
+         Any difference between the sum of the individual phase weight
+         percentages and 100 wt% can be attributed to unanalysed or amorphous
+         phases.
+
+         [1] Toraya, H. (2016). J. Appl. Crystallogr. 49, 1508-1516.
+         [2] Toraya, H. (2017). J. Appl. Crystallogr. 50, 820-829.
+         [3] Toraya, H. (2017). J. Appl. Crystallogr. 50, 665-665.
+         [4] Toraya, H. (2018). J. Appl. Crystallogr. 51, 446-455.
+         [5] Toraya, H. (2019). J. Appl. Crystallogr. 52, 520-531.
+         [6] Toraya, H. & Omote, K. (2019). J. Appl. Crystallogr. 52, 13-22.
+;
+         external_standard
+;
+         Quantitative phase analysis was undertaken following the external
+         standard methodology [1] to quantify absolute phase fractions taken
+         from Rietveld [2] refinements.
+
+         The absolute weight fraction of phase p, W~p~, is given by
+
+             W~p~ = [I~p~ / C~p~] * μ^*^~m~
+
+         where I~p~ = S~p~/K, where S~p~ is the Rietveld scale factor of the
+         analyte phase and K is a previously determined diffractometer constant.
+         μ^*^~m~ is the mass absorption coefficient of the entire specimen.
+         C~p~ is given as
+
+             C~p~ = 1 /(Z * M * V)~p~
+
+         where Z is the number of formula units per unit cell, M is the chemical
+         formula weight, and V is the volume of the unit cell, all of phase p.
+
+         _pd_char.mass_atten_coef_mu_calc or _pd_char.mass_atten_coef_mu_meas
+         must be given for the specimen in each diffractogram.
+
+         The values utilised for I~p~ and C~p~ can be recorded using
+         _pd_qpa_intensity_factor.value and
+         _pd_qpa_calib_factor.external_standard, respectively, however, data
+         items from the PD_QPA_EXTERNAL_STD category should be preferentially
+         used.
+
+         [1] O'Connor, B. H. & Raven, M. D. (1988). Powder Diffr. 3, 2-6.
+         [2] Rietveld, H. M. (1969). J. Appl. Crystallogr. 2, 65-71.
+;
+         I/Ic
+;
+         A Reference Intensity Ratio (RIR) in the specific case where the RIR
+         value was determined using corundum (α-alumina) as the standard, and
+         the mass ratio of the standard and analyte phases was 50:50.
+
+         For a description of the RIR methodology, see the entry for the 'RIR'.
+
+         The values utilised for I~p~ and C~p~ can be recorded using
+         _pd_qpa_intensity_factor.value and _pd_qpa_calib_factor.I_over_Ic,
+         respectively.
+;
+         PONKCS
+;
+         Quantitative phase analysis was undertaken following the Partial Or No
+         Known Crystal Structure methodology [1].
+
+         The relative weight fraction of phase p, W~p~, is given by
+
+             W~p~ = (S~p~ / C~p~) / Sum(S~k~ / C~k~, k=1:P)
+
+         where S~p~ is the Rietveld scale factor of the analyte phase. The sum
+         is taken over all phases present, and
+
+             C~p~ = (W~s~/W~p~) * (S~p~/S~s~) * (1/(ZMV)~s~)
+
+         where W is the weight fraction, S is the Rietveld scale factor, Z is
+         the number of formula units per unit cell, M is the chemical
+         formula weight, and V is the volume of the unit cell. The subscript p
+         denotes the analyte phase, and s denotes the standard phase.
+
+         The intensities of the peaks assigned to the PONKCS phase, when taken
+         in combination with C~p~, act as pseudo-F_squared values. Because of
+         this, once a particular phase has been calibrated, it's value of C~p~
+         is consistent with ZMV values and can be used in conjunction with the
+         ZMV algorithm with normal, crystalline phases to quantify relative
+         phase fractions in mixtures containing this phase.
+
+         If any phase in an analysis of a diffractogram uses the PONKCS
+         approach, the entire quantification is to be marked as 'PONKCS', and
+         all phases should define _pd_qpa_calib_factor.ponkcs.
+
+         The values utilised for I~p~ and C~p~ can be recorded using
+         _pd_qpa_intensity_factor.value and _pd_qpa_calib_factor.PONKCS,
+         respectively.
+
+         If an internal standard, s, is present with a known addition, the
+         relative weight fractions can be converted to absolute weight fractions
+         by
+
+            W~p~^absolute^ = W~p~^relative^ * (W~s~^known^ / W~s~^relative^)
+
+         Any difference between the sum of the individual phase weight
+         percentages and 100 wt% can be attributed to unanalysed or amorphous
+         phases.
+
+         [1] Scarlett, N.V.Y. & Madsen, I.C. (2006). Powder Diffr. 21, 278-284.
+;
+         RIR
+;
+         For an RIR value made with reference to corundum, see the state
+         'I/Ic'.
+
+         Quantitative phase analysis was undertaken following the Reference
+         Intensity Ratio methodology [1].
+
+         The method of determining the RIR value, and the particular standard
+         against which it was calculated should be given in the
+         _pd_qpa_calib_factor.special_details for each phase.
+
+         The relative weight fraction of phase p, W~p~, is given by
+
+             W~p~ = [I~p~ / C~p~] / Sum[I~k~ / C~k~, k=1:P]
+
+         where I~p~=I~p~^'^/I~p,rel~, where I~p~^'^ is the intensity of the
+         analyte peak of phase p and I~P,rel~ is the intensity ratio between the
+         analyte peak and the most intense peak for phase p. The sum is taken
+         over all phases present in the specimen. C~p~ is the reference
+         intensity ratio for phase p, must be pre-calculated with a known,
+         crystalline internal standard, as
+
+             C~p~ = (W~s~/W~p~) * (I~p~^'^/I~s~^'^) * (I~s,rel~/(I~p,rel~)
+
+         The values utilised for I~p~ and C~p~ can be recorded using
+         _pd_qpa_intensity_factor.value and _pd_qpa_calib_factor.RIR,
+         respectively.
+
+         If an internal standard, s, is present with a known addition, the
+         relative weight fractions can be converted to absolute weight fractions
+         by
+
+            W~p~^absolute^ = W~p~^relative^ * (W~s~^known^ / W~s~^relative^)
+
+         Any difference between the sum of the individual phase weight
+         percentages and 100 wt% can be attributed to unanalysed or amorphous
+         phases.
+
+         [1] Snyder, R. L. (1992). Powder Diffr. 7, 186-192.
+;
+         ZMV
+;
+         Quantitative phase analysis was undertaken following the ZMV
+         algorithm [1-2] in conjunction with Rietveld [3] refinements.
+
+         The relative weight fraction of phase p, W~p~, is given by
+
+             W~p~ = (S~p~ / C~p~) / Sum(S~k~ / C~k~, k=1:P)
+
+         where S~p~ is the Rietveld scale factor of the analyte phase. The sum
+         is taken over all phases present, and
+
+             C~p~ = 1/(Z * M * V)~p~
+
+         where Z is the number of formula units per unit cell, M is the chemical
+         formula weight, and V is the volume of the unit cell, all of phase p.
+
+         The values utilised for I~p~ and C~p~ can be recorded using
+         _pd_qpa_intensity_factor.value and _pd_qpa_calib_factor.ZMV,
+         respectively.
+
+         If an internal standard, s, is present with a known addition, the
+         relative weight fractions can be converted to absolute weight fractions
+         by
+
+            W~p~^absolute^ = W~p~^relative^ * (W~s~^known^ / W~s~^relative^)
+
+         Any difference between the sum of the individual phase weight
+         percentages and 100 wt% can be attributed to unanalysed or amorphous
+         phases.
+
+         [1] Hill,R.J. & Howard, C.J. (1987). J. Appl. Crystallogr. 20, 467-474.
+         [1] Bish,D.L. & Howard, S.A. (1988). J. Appl. Crystallogr. 21, 86-91.
+         [2] Rietveld, H. M. (1969). J. Appl. Crystallogr. 2, 65-71.
+;
+         other
+;
+         Please give details in _pd_qpa_overall.special_details.
+;
+
+save_
+
+save_pd_qpa_overall.special_details
+
+    _definition.id                '_pd_qpa_overall.special_details'
+    _definition.update            2023-01-16
+    _description.text
+;
+    Description of overall QPA details that require additional detail,
+    or cannot otherwise be recorded using other PD_QPA_OVERALL data items.
+;
+    _name.category_id             pd_qpa_overall
+    _name.object_id               special_details
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_PD_SPEC
+
+    _definition.id                PD_SPEC
+    _definition.scope             Category
+    _definition.class             Set
+    _definition.update            2023-03-25
+    _description.text
+;
+    This section contains information about the specimen used for measurement of
+    the diffraction data set.
+
+    'Specimen', 'sample', and 'material' have specific meanings, and sometimes
+    cannot be specifically deliniated. The 'specimen' is the artefact placed
+    into the beam from which the diffraction measurement is taken, and is
+    described in PD_SPEC. The specimen is made from the 'sample', which can have
+    information specified in PD_PREP. The sample is drawn from a 'material',
+    which may exist in an actual or idealised sense, which can have information
+    specified in PD_CHAR. For example: the material might be BaTiO3, the
+    sample might be a specific batch from a specific manufacturer, and the
+    specimen is the material taken from the bottle and placed in the instrument.
+;
+    _name.category_id             PD_GROUP
+    _name.object_id               PD_SPEC
+
+    loop_
+      _category_key.name
+         '_pd_spec.id'
+         '_pd_spec.prep_id'
+
+save_
+
+save_pd_spec.description
+
+    _definition.id                '_pd_spec.description'
+    _alias.definition_id          '_pd_spec_description'
+    _definition.update            2014-06-20
+    _description.text
+;
+    A description of the specimen, such as the source of the
+    specimen, identification of standards, mixtures etc.
+;
+    _name.category_id             pd_spec
+    _name.object_id               description
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_pd_spec.id
+
+    _definition.id                '_pd_spec.id'
+    _definition.update            2023-03-25
+    _description.text
+;
+    Arbitrary label identifying a powder diffraction specimen.
+;
+    _name.category_id             pd_spec
+    _name.object_id               id
+    _type.purpose                 Key
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_pd_spec.mount_mode
+
+    _definition.id                '_pd_spec.mount_mode'
+    _alias.definition_id          '_pd_spec_mount_mode'
+    _definition.update            2014-06-20
+    _description.text
+;
+    A code describing the beam path through the specimen.
+;
+    _name.category_id             pd_spec
+    _name.object_id               mount_mode
+    _type.purpose                 Encode
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Code
+
+    loop_
+      _enumeration_set.state
+         reflection
+         transmission
+
+save_
+
+save_pd_spec.mounting
+
+    _definition.id                '_pd_spec.mounting'
+    _alias.definition_id          '_pd_spec_mounting'
+    _definition.update            2014-06-20
+    _description.text
+;
+    A description of how the specimen is mounted.
+;
+    _name.category_id             pd_spec
+    _name.object_id               mounting
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+
+    loop_
+      _description_example.case
+         'vanadium can with He exchange gas'
+         'quartz capillary'
+         'packed powder pellet'
+         'drifted powder on off-cut Si'
+         'drifted powder on Kapton film'
+
+save_
+
+save_pd_spec.orientation
+
+    _definition.id                '_pd_spec.orientation'
+    _alias.definition_id          '_pd_spec_orientation'
+    _definition.update            2014-06-20
+    _description.text
+;
+    The orientation of the ω (θ) and 2θ axis.
+    Note that this axis is parallel to the specimen axial axis
+    and perpendicular to the plane containing the incident and
+    scattered beams.
+
+    Thus for a horizontal orientation, scattering
+    measurements are made in a plane perpendicular to the
+    ground (the 2θ axis is parallel to the ground);
+    for vertical orientation, scattering measurements are
+    made in a plane parallel with the ground (the 2θ axis
+    is perpendicular to the ground). 'Both' is appropriate for
+    experiments where measurements are made in both planes,
+    for example using two-dimensional detectors.
+;
+    _name.category_id             pd_spec
+    _name.object_id               orientation
+    _type.purpose                 State
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Code
+
+    loop_
+      _enumeration_set.state
+         horizontal
+         vertical
+         both
+
+save_
+
+save_pd_spec.prep_id
+
+    _definition.id                '_pd_spec.prep_id'
+    _definition.update            2023-06-04
+    _description.text
+;
+    The identifier for the sample from which this specimen was taken.
+;
+    _name.category_id             pd_spec
+    _name.object_id               prep_id
+    _name.linked_item_id          '_pd_prep.id'
+    _type.purpose                 Link
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_pd_spec.preparation
+
+    _definition.id                '_pd_spec.preparation'
+    _alias.definition_id          '_pd_spec_preparation'
+    _definition.update            2014-06-20
+    _description.text
+;
+    A description of the preparation steps for producing the
+    diffraction specimen from the sample. Include any procedures
+    related to grinding, sieving, spray drying etc. For
+    information relevant to how the sample is synthesized, use
+    the PD_PREP entries.
+;
+    _name.category_id             pd_spec
+    _name.object_id               preparation
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+
+    loop_
+      _description_example.case
+         'wet grinding in acetone'
+         'sieved through a 44 micron (325 mesh/inch) sieve'
+         'spray dried in water with 1% clay'
+
+save_
+
+save_pd_spec.shape
+
+    _definition.id                '_pd_spec.shape'
+    _alias.definition_id          '_pd_spec_shape'
+    _definition.update            2014-06-20
+    _description.text
+;
+    A code describing the specimen shape.
+;
+    _name.category_id             pd_spec
+    _name.object_id               shape
+    _type.purpose                 State
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Code
+
+    loop_
+      _enumeration_set.state
+         cylinder
+         flat_sheet
+         irregular
+
+save_
+
+save_pd_spec.size_axial
+
+    _definition.id                '_pd_spec.size_axial'
+    _alias.definition_id          '_pd_spec_size_axial'
+    _definition.update            2017-10-18
+    _description.text
+;
+    The size of the specimen in three mutually perpendicular
+    directions in millimetres.
+    The perpendicular to the plane containing the incident
+    and scattered beam is the *_axial direction.
+    In transmission geometry, the scattering vector is parallel
+    to *_equat and in reflection geometry the scattering vector is
+    parallel to *_thick.
+;
+    _name.category_id             pd_spec
+    _name.object_id               size_axial
+    _type.purpose                 Number
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   millimetres
+
+save_
+
+save_pd_spec.size_equat
+
+    _definition.id                '_pd_spec.size_equat'
+    _alias.definition_id          '_pd_spec_size_equat'
+    _definition.update            2017-10-18
+    _description.text
+;
+    The size of the specimen in three mutually perpendicular
+    directions in millimetres.
+    The perpendicular to the plane containing the incident
+    and scattered beam is the *_axial direction.
+    In transmission geometry, the scattering vector is parallel
+    to *_equat and in reflection geometry the scattering vector is
+    parallel to *_thick.
+;
+    _name.category_id             pd_spec
+    _name.object_id               size_equat
+    _type.purpose                 Number
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   millimetres
+
+save_
+
+save_pd_spec.size_thick
+
+    _definition.id                '_pd_spec.size_thick'
+    _alias.definition_id          '_pd_spec_size_thick'
+    _definition.update            2017-10-18
+    _description.text
+;
+    The size of the specimen in three mutually perpendicular
+    directions in millimetres.
+    The perpendicular to the plane containing the incident
+    and scattered beam is the *_axial direction.
+    In transmission geometry, the scattering vector is parallel
+    to *_equat and in reflection geometry the scattering vector is
+    parallel to *_thick.
+;
+    _name.category_id             pd_spec
+    _name.object_id               size_thick
+    _type.purpose                 Number
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.range            0.0:
+    _units.code                   millimetres
+
+save_
+
+save_pd_spec.special_details
+
+    _definition.id                '_pd_spec.special_details'
+    _alias.definition_id          '_pd_spec_special_details'
+    _definition.update            2014-06-20
+    _description.text
+;
+    Descriptive information about the specimen that cannot be
+    included in other data items.
+;
+    _name.category_id             pd_spec
+    _name.object_id               special_details
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_REFLN
+
+    _definition.id                REFLN
+    _definition.scope             Category
+    _definition.class             Loop
+    _definition.update            2016-11-09
+    _description.text
+;
+    The CATEGORY of data items used to describe the reflection data
+    used in the refinement of one or more crystallographic phases.
+;
+    _name.category_id             DIFFRACTION
+    _name.object_id               REFLN
+
+    loop_
+      _category_key.name
+         '_refln.index_h'
+         '_refln.index_k'
+         '_refln.index_l'
+         '_pd_refln.phase_id'
+
+save_
+
+save_pd_refln.peak_id
+
+    _definition.id                '_pd_refln.peak_id'
+    _alias.definition_id          '_pd_refln_peak_id'
+    _definition.update            2014-06-20
+    _description.text
+;
+    Code which identifies the powder diffraction peak that
+    contains the current reflection. This code must match a
+    _pd_peak.id code.
+;
+    _name.category_id             refln
+    _name.object_id               peak_id
+    _name.linked_item_id          '_pd_peak.id'
+    _type.purpose                 Link
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Code
+
+save_
+
+save_pd_refln.peak_overall_id
+
+    _definition.id                '_pd_refln.peak_overall_id'
+    _definition.update            2023-04-13
+    _description.text
+;
+    A code linking to general information about peak description and
+    determination for the reflection peaks.
+;
+    _name.category_id             refln
+    _name.object_id               peak_overall_id
+    _name.linked_item_id          '_pd_peak_overall.id'
+    _type.purpose                 Link
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Code
+
+save_
+
+save_pd_refln.phase_id
+
+    _definition.id                '_pd_refln.phase_id'
+    _alias.definition_id          '_pd_refln_phase_id'
+    _definition.update            2016-11-09
+    _description.text
+;
+    A code which identifies the particular phase to which
+    this reflection belongs.
+;
+    _name.category_id             refln
+    _name.object_id               phase_id
+    _name.linked_item_id          '_pd_phase.id'
+    _type.purpose                 Link
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_refln.f_complex
+
+    _definition.id                '_refln.F_complex'
+    _alias.definition_id          '_refln_F_complex'
+    _definition.update            2017-03-07
+    _description.text
+;
+    The structure factor vector for the reflection calculated from
+    the atom site data for the phase given by phase_id.
+;
+    _name.category_id             refln
+    _name.object_id               F_complex
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Complex
+    _enumeration.default          0.+0.j
+    _method.purpose               Definition
+    _method.expression
+;
+         If (_diffrn_radiation.probe == "neutron")  _units.code =  "femtometres"
+    Else If (_diffrn_radiation.probe == "electron") _units.code =  "volts"
+    Else                                            _units.code =  "electrons"
+;
+
+save_
+
+save_refln.f_squared_meas
+
+    _definition.id                '_refln.F_squared_meas'
+    _alias.definition_id          '_refln_F_squared_meas'
+    _definition.update            2017-03-22
+    _description.text
+;
+    The structure factor amplitude for the reflection derived by partitioning
+    the background-subtracted observed intensity _pd_proc.intensity_net between
+    reflections in the same proportion as those reflections contribute to
+    the corresponding background-free calculated point in _pd_calc.intensity_net
+;
+    _name.category_id             refln
+    _name.object_id               F_squared_meas
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _enumeration.default          0.
+    _method.purpose               Definition
+    _method.expression
+;
+         If (_diffrn_radiation.probe == "neutron")  _units.code =
+    "femtometre_squared" Else If (_diffrn_radiation.probe == "electron")
+    _units.code =  "volt_squared" Else
+      _units.code =  "electron_squared"
+;
+
+save_
+
+save_refln.wavelength_id
+
+    _definition.id                '_refln.wavelength_id'
+
+    loop_
+      _alias.definition_id
+         '_refln_wavelength_id'
+         '_pd_refln.wavelength_id'
+         '_pd_refln_wavelength_id'
+
+    _definition.update            2021-12-06
+    _description.text
+;
+    _pd_refln.wavelength_id is DEPRECATED. _refln.wavelength_id should
+    be used instead.
+;
+    _name.category_id             refln
+    _name.object_id               wavelength_id
+    _name.linked_item_id          '_diffrn_radiation_wavelength.id'
+    _type.purpose                 Link
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Word
+
+save_
+
+    loop_
+      _dictionary_audit.version
+      _dictionary_audit.date
+      _dictionary_audit.revision
+         2.0.1                    2014-06-20
+;
+       Initial conversion to DDLm (Syd Hall)
+;
+         2.0.2                    2016-10-21
+;
+       Substantial edits to conform to current DDLm, CIF2 syntax
+       and intended DDL1 usage (James Hester).
+;
+         2.0.3                    2016-11-03
+;
+       Removed pd_refln category and pd_refln.phase_id, remaining
+       datanames assigned to core REFLN category (James Hester).
+;
+         2.1.0                    2016-11-09
+;
+       Changed PD_PHASE to Set category. Multiple phases are now
+       covered by an extension dictionary. (James Hester)
+;
+         2.2.0                    2016-11-12
+;
+       Added _pd_calib_offset.detector_id to allow for per-detector
+       2 theta offsets (James Hester)
+;
+         2.3.0                    2017-01-26
+;
+       Returned pd_phase and pd_refln.phase_id to dictionary after
+       acceptance of _dictionary.formalism mechanism. Set
+       _dictionary.formalism to 'powder'.
+;
+         2.4.0                    2017-04-05
+;
+       Added definition for _refln.F_meas after consultation with
+       PD DMG. (James Hester)
+;
+         2.4.1                    2021-12-06
+;
+       Changed the content type of multiple data items from 'Count'
+       to 'Integer' and assigned the appropriate enumeration range
+       if needed.
+
+       Corrected the object id of the _pd_proc.2theta_range_inc data item.
+
+       Deprecated _pd_refln.wavelength_id after consultation with PDDMG.
+;
+         2.5.0                    2025-04-18
+;
+       ## Retain above version number and increment date until final
+       ## release
+
+       Added mass absorption coefficient and improved absorption
+       definitions. Added missing su definitions.
+
+       Corrected datetime examples to proper RFC3339 compliance.
+
+       Added pd_calib_d_to_tof.
+
+       Corrected a typo in the PD_CALIB_D_TO_TOF category description.
+
+       Add PD_DIFFRACTOGRAM category and linked data names.
+
+       Added PD_CALC_COMPONENT and related data names.
+
+       Updated many datanames from Number to Measurand.
+
+       Made PD_BLOCK a Loop category.
+
+       Created PD_PREF_ORIENT_MARCH_DOLLASE and
+       PD_PREF_ORIENT_SPHERICAL_HARMONICS to record preferred orienation
+       corrections.
+
+       Updated intensity/count definitions in PD_CALC, PD_MEAS, and PD_PROC.
+
+       Updated descriptions of _pd_meas.counts, _pd_meas.intensity_background,
+       _pd_meas.intensity_container, and _pd_meas.intensity_monitor.
+
+       Removed enumeration range for _pd_proc.intensity_net.
+
+       Added ability to record detector circle radius, both fixed and
+       varying by measurement point.
+
+       Updated many datanames from Number to Measurand.
+
+       Made PD_PHASE a Set category.
+
+       Created PD_QPA_EXTERNAL_STD and PD_QPA_INTERNAL_STD to record
+       quantitative phase analysis by the external and internal standard
+       approaches.
+
+       Changed _pd_meas.step_count_time and _pd_meas.time_of_flight from
+       Integer to Real.
+
+       Created PD_BACKGROUND.
+
+       Update definitions of _pd_phase.name, _pd_qpa_ext_std.phase_name, and
+       _pd_qpa_int_std.phase_name to better represent their contents.
+
+       Created PD_AMORPHOUS.
+
+       Deprecate _pd_calib.std_internal_mass_percent and
+       _pd_calib.std_internal_mass_percent_su.
+
+       Added phase_id and diffractogram_id to PD_PREF_ORIENT_MARCH_DOLLASE and
+       PD_PREF_ORIENT_SPHERICAL_HARMONICS.
+
+       Updated data items to hold block ID values to be of type Link, and to
+       link them formally to _pd_block.id
+
+       Added _pd_phase.id and/or _pd_diffractogram.id-linked data items to
+       PD_CALC_OVERALL, PD_CALIB_D_TO_TOF, PD_INSTR, PD_MEAS_INFO_AUTHOR,
+       PD_MEAS_OVERALL, PD_PREF_ORIENT, PD_PROC_INFO_AUTHOR, PD_PROC_OVERALL,
+       PD_SPEC
+
+       Created PD_QPA_OVERALL to record details about the overall quantitative
+       phase analysis method.
+
+       Update description of _pd_proc.info_datetime to maintain consistency
+       with its Set category.
+
+       Renamed _pd_char.mass_atten_coef_mu_obs to
+       _pd_char.mass_atten_coef_mu_meas.
+
+       Created PD_CALIB_XCOORD and PD_CALIB_XCOORD_OVERALL
+
+       Updated _pd_phase.name
+
+       Created PD_CALIB_DETECTED_INTENSITY
+
+       Created PD_CALIB_INCIDENT_INTENSITY
+
+       Created PD_CALIB_WAVELENGTH
+
+       Updated _pd_phase.name.
+
+       Created PD_QPA_INTENSITY_FACTOR.
+
+       Updated description of _pd_calibration.conversion_eqn.
+
+       Updated descriptions of PD_CHAR, PD_PREP, and PD_SPEC to clarify
+       differences between 'specimen', 'sample', and 'material'. Updated some
+       data item descriptions to maintain a consistent nomenclature.
+
+       Updated description of _pd_proc.wavelength.
+
+       Remove '_pd_phase_mass_percent' as an alias for '_pd_phase_mass.percent'.
+
+       Added _pd_spec.id and _pd_diffractogram.spec_id.
+
+       Added _pd_proc_ls.diffractogram_id
+
+       Added _pd_peak_overall.id.
+
+       Added child data names of _pd_peak_overall.id to PD_AMORPHOUS,
+       PD_BACKGROUND, and REFLN.
+
+       Created category keys for PD_CHAR and PD_PREP. Added link keys to join
+       PD_CHAR to PD_PREP, and PD_PREP to PD_SPEC.
+
+       Deprecated PD_CALIB, PD_CALIB_OFFSET, and PD_CALIB_STD.
+
+       Deprecated PD_MEAS_INFO_AUTHOR and PD_PROC_INFO_AUTHOR in favour of
+       AUDIT_AUTHOR and AUDIT_AUTHOR_ROLE.
+
+       Add _pd_calib_xcoord.diffractogram_id.
+
+       Add _pd_peak.diffractogram_id and _pd_peak_overall.diffractogram_id.
+
+       Altered PD_CALIB_INCIDENT_INTENSITY to be a Set category.
+
+       Redefined _pd_meas.detector_id in terms of _pd_instr_detector.id. Linked
+       all _pd_*.detector_id data names to _pd_instr_detector.id.
+
+       Switch to using multiblock dictionary as base dictionary.
+
+       Converted all 'Array' and 'Matrix'-type data items to be 'List', except
+       _pd_pref_orient_march_dollase.hkl.
+
+       Change units of _pd_calib_incident_intensity.incident_* to
+       counts_per_second and per_second.
+
+       Clarified description of _pd_meas.rocking_angle.
+
+       Changed the _type.source attribute of all SU data items to 'Related'.
+
+       Updated the CIF_CORE dictionary import statement with the new Head
+       category name.
+
+       Deprecated PD_BLOCK, PD_BLOCK_DIFFRACTOGRAM, PD_PHASE_BLOCK, and all
+       related data items in favour of PD_PHASE and PD_DIFFRACTOGRAM.
+
+;

--- a/dictionaries/ddl.dic
+++ b/dictionaries/ddl.dic
@@ -1,0 +1,3119 @@
+#\#CIF_2.0
+##############################################################################
+#                                                                            #
+#                      DDLm REFERENCE DICTIONARY                             #
+#                                                                            #
+##############################################################################
+
+data_DDL_DIC
+
+    _dictionary.title             DDL_DIC
+    _dictionary.class             Reference
+    _dictionary.version           4.2.0
+    _dictionary.date              2025-02-19
+    _dictionary.uri
+        https://raw.githubusercontent.com/COMCIFS/cif_core/master/ddl.dic
+    _dictionary.ddl_conformance   4.2.0
+    _dictionary.namespace         DdlDic
+    _description.text
+;
+    This dictionary contains the definitions of attributes that
+    make up the DDLm dictionary definition language. It provides
+    the meta meta data for all CIF dictionaries.
+;
+
+save_ATTRIBUTES
+
+    _definition.id                ATTRIBUTES
+    _definition.scope             Category
+    _definition.class             Head
+    _definition.update            2011-07-27
+    _description.text
+;
+    This category is parent of all other categories in the DDLm
+    dictionary.
+;
+    _name.category_id             DDL_DIC
+    _name.object_id               ATTRIBUTES
+
+save_
+
+save_ALIAS
+
+    _definition.id                ALIAS
+    _definition.scope             Category
+    _definition.class             Loop
+    _definition.update            2013-09-08
+    _description.text
+;
+    The attributes used to specify the aliased names of definitions.
+;
+    _name.category_id             ATTRIBUTES
+    _name.object_id               ALIAS
+    _category_key.name            '_alias.definition_id'
+
+save_
+
+save_alias.definition_id
+
+    _definition.id                '_alias.definition_id'
+    _definition.class             Attribute
+    _definition.update            2019-04-02
+    _description.text
+;
+    Identifier tag of an aliased definition.
+;
+    _name.category_id             alias
+    _name.object_id               definition_id
+    _type.purpose                 Encode
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Tag
+
+save_
+
+save_alias.deprecation_date
+
+    _definition.id                '_alias.deprecation_date'
+    _definition.class             Attribute
+    _definition.update            2024-02-05
+    _description.text
+;
+    Date that the aliased tag was deprecated as a definition tag.
+
+    An unquoted value of '.' indicates that the associated alias has not been
+    deprecated.
+;
+    _name.category_id             alias
+    _name.object_id               deprecation_date
+    _type.purpose                 Audit
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Date
+    _enumeration.default          .
+
+save_
+
+save_alias.dictionary_uri
+
+    _definition.id                '_alias.dictionary_uri'
+    _definition.class             Attribute
+    _definition.update            2024-04-04
+    _description.text
+;
+    An absolute URI of the dictionary that includes the aliased definition.
+    The URI should preferably point to a specific version of the dictionary
+    identified by the _alias.dictionary_version attribute, however, a more
+    general URI, e.g. one that always points to the latest version of the
+    dictionary, can also be provided when this is not possible.
+;
+    _name.category_id             alias
+    _name.object_id               dictionary_uri
+    _type.purpose                 Identify
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Uri
+
+save_
+
+save_alias.dictionary_version
+
+    _definition.id                '_alias.dictionary_version'
+    _definition.class             Attribute
+    _definition.update            2024-04-04
+    _description.text
+;
+    The version identifier of the dictionary containing a compatible version of
+    the aliased definition.
+;
+    _name.category_id             alias
+    _name.object_id               dictionary_version
+    _type.purpose                 Identify
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_CATEGORY_KEY
+
+    _definition.id                CATEGORY_KEY
+    _definition.scope             Category
+    _definition.class             Loop
+    _definition.update            2020-10-29
+    _description.text
+;
+    The attributes used to specify (possibly multiple)
+    keys for a given category.
+;
+    _name.category_id             ATTRIBUTES
+    _name.object_id               CATEGORY_KEY
+    _category_key.name            '_category_key.name'
+
+save_
+
+save_category_key.name
+
+    _definition.id                '_category_key.name'
+    _definition.class             Attribute
+    _definition.update            2021-08-18
+    _description.text
+;
+    A minimal list of tag(s) that together constitute a compound key
+    to access other items in a Loop category. In other words, the combined
+    values of the data items listed in this loop must be unique, so that
+    unambiguous access to a packet (row) in the table of values is possible.
+;
+    _name.category_id             category_key
+    _name.object_id               name
+    _type.purpose                 Identify
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Tag
+
+save_
+
+save_DEFINITION
+
+    _definition.id                DEFINITION
+    _definition.scope             Category
+    _definition.class             Set
+    _definition.update            2011-06-20
+    _description.text
+;
+    The attributes for classifying dictionary definitions.
+;
+    _name.category_id             ATTRIBUTES
+    _name.object_id               DEFINITION
+
+save_
+
+save_definition.class
+
+    _definition.id                '_definition.class'
+    _definition.class             Attribute
+    _definition.update            2019-10-08
+    _description.text
+;
+    The nature and the function of a definition or definitions.
+;
+    _name.category_id             definition
+    _name.object_id               class
+    _type.purpose                 State
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Code
+
+    loop_
+      _enumeration_set.state
+      _enumeration_set.detail
+         Attribute
+;
+         Item used as an attribute in the definition of other data items in
+         DDLm dictionaries. These items never appear in data instance files.
+;
+         Functions
+;
+         Category of items that are transient function definitions used only in
+         dREL methods scripts. These items never appear in data instance files.
+;
+         Datum
+;
+         Item defined in a domain-specific dictionary. These items appear only
+         in data instance files.
+;
+         Head
+;
+         Category of items that is the parent of all other categories in the
+         dictionary.
+;
+         Loop
+;
+         Category of items that in a data file may reside in a loop-list with a
+         key item defined.
+;
+         Set
+;
+         Category of items that form a set (but not a loopable list). These
+         items may be referenced as a class of items in a dREL methods
+         expression.
+;
+
+    _enumeration.default          Datum
+
+save_
+
+save_definition.id
+
+    _definition.id                '_definition.id'
+    _definition.class             Attribute
+    _definition.update            2006-11-16
+    _description.text
+;
+    Identifier name of the Item or Category being defined.
+;
+    _name.category_id             definition
+    _name.object_id               id
+    _type.purpose                 Identify
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Code
+
+save_
+
+save_definition.scope
+
+    _definition.id                '_definition.scope'
+    _definition.class             Attribute
+    _definition.update            2006-11-16
+    _description.text
+;
+    The extent to which a definition affects other definitions.
+;
+    _name.category_id             definition
+    _name.object_id               scope
+    _type.purpose                 State
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Code
+
+    loop_
+      _enumeration_set.state
+      _enumeration_set.detail
+         Dictionary           'Applies to all defined items in the dictionary.'
+         Category             'Applies to all defined items in the category.'
+         Item                 'Applies to a single item definition.'
+
+    _enumeration.default          Item
+
+save_
+
+save_definition.update
+
+    _definition.id                '_definition.update'
+    _definition.class             Attribute
+    _definition.update            2006-11-16
+    _description.text
+;
+    The date that a definition was last changed.
+;
+    _name.category_id             definition
+    _name.object_id               update
+    _type.purpose                 Audit
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Date
+
+save_
+
+save_DEFINITION_REPLACED
+
+    _definition.id                DEFINITION_REPLACED
+    _definition.scope             Category
+    _definition.class             Loop
+    _definition.update            2019-04-02
+    _description.text
+;
+    Attributes used to describe deprecated and replaced definitions.
+;
+    _name.category_id             DEFINITION
+    _name.object_id               DEFINITION_REPLACED
+    _category_key.name            '_definition_replaced.id'
+
+save_
+
+save_definition_replaced.by
+
+    _definition.id                '_definition_replaced.by'
+    _definition.class             Attribute
+    _definition.update            2019-04-02
+    _description.text
+;
+    Name of the data item that should be used instead of the defined data
+    item. The defined data item is deprecated and should not be used. A
+    value of '.' signifies that the data item is deprecated, with no
+    replacement.
+;
+    _name.category_id             definition_replaced
+    _name.object_id               by
+    _type.purpose                 Encode
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Tag
+
+save_
+
+save_definition_replaced.id
+
+    _definition.id                '_definition_replaced.id'
+    _definition.class             Attribute
+    _definition.update            2019-04-02
+    _description.text
+;
+    An opaque identifier for the replacement.
+;
+    _name.category_id             definition_replaced
+    _name.object_id               id
+    _type.purpose                 Key
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Code
+
+save_
+
+save_DESCRIPTION
+
+    _definition.id                DESCRIPTION
+    _definition.scope             Category
+    _definition.class             Set
+    _definition.update            2011-06-20
+    _description.text
+;
+    The attributes of descriptive (non-machine parsable) parts of
+    definitions.
+;
+    _name.category_id             ATTRIBUTES
+    _name.object_id               DESCRIPTION
+
+save_
+
+save_description.common
+
+    _definition.id                '_description.common'
+    _definition.class             Attribute
+    _definition.update            2006-11-16
+    _description.text
+;
+    Commonly-used identifying name for the item.
+;
+    _description.common           'common name'
+    _name.category_id             description
+    _name.object_id               common
+    _type.purpose                 Describe
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_description.key_words
+
+    _definition.id                '_description.key_words'
+    _definition.class             Attribute
+    _definition.update            2013-03-06
+    _description.text
+;
+    List of key-words categorising the item.
+;
+    _description.common           'key words'
+    _name.category_id             description
+    _name.object_id               key_words
+    _type.purpose                 Encode
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_description.text
+
+    _definition.id                '_description.text'
+    _definition.class             Attribute
+    _definition.update            2021-07-20
+    _description.text
+;
+    The text description of the defined item, category,
+    or dictionary.
+;
+    _description.common           description
+    _name.category_id             description
+    _name.object_id               text
+    _type.purpose                 Describe
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_DESCRIPTION_EXAMPLE
+
+    _definition.id                DESCRIPTION_EXAMPLE
+    _definition.scope             Category
+    _definition.class             Loop
+    _definition.update            2021-07-20
+    _description.text
+;
+    Descriptive (non-machine parsable) examples of values of the
+    defined items and categories.
+;
+    _name.category_id             DESCRIPTION
+    _name.object_id               DESCRIPTION_EXAMPLE
+    _category_key.name            '_description_example.case'
+
+save_
+
+save_description_example.case
+
+    _definition.id                '_description_example.case'
+    _definition.class             Attribute
+    _definition.update            2021-11-15
+    _description.text
+;
+    An example case of the defined item or category. Category example cases
+    present data names and values as they would appear in a CIF-formatted file.
+    Item example cases present values only, which inherit the enumeration range,
+    enumeration set, container, dimension, content and purpose type constraints
+    of the defining item.
+;
+    _name.category_id             description_example
+    _name.object_id               case
+    _type.purpose                 Describe
+    _type.source                  Assigned
+    _type.container               Implied
+    _type.contents                Implied
+
+save_
+
+save_description_example.detail
+
+    _definition.id                '_description_example.detail'
+    _definition.class             Attribute
+    _definition.update            2021-07-20
+    _description.text
+;
+    A description of an example case for the defined item or category.
+;
+    _name.category_id             description_example
+    _name.object_id               detail
+    _type.purpose                 Describe
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_DICTIONARY
+
+    _definition.id                DICTIONARY
+    _definition.scope             Category
+    _definition.class             Set
+    _definition.update            2011-06-20
+    _description.text
+;
+    Attributes for identifying and registering the dictionary. The items
+    in this category are NOT used as attributes of INDIVIDUAL data items.
+;
+    _name.category_id             ATTRIBUTES
+    _name.object_id               DICTIONARY
+
+save_
+
+save_dictionary.class
+
+    _definition.id                '_dictionary.class'
+    _definition.class             Attribute
+    _definition.update            2012-05-07
+    _description.text
+;
+    The nature, or field of interest, of data items defined in the dictionary.
+;
+    _name.category_id             dictionary
+    _name.object_id               class
+    _type.purpose                 State
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Code
+
+    loop_
+      _enumeration_set.state
+      _enumeration_set.detail
+         Reference           'DDLm reference attribute definitions.'
+         Instance            'Domain-specific data instance definitions.'
+         Template            'Domain-specific attribute/enumeration templates.'
+         Function            'Domain-specific method function scripts.'
+
+    _enumeration.default          Instance
+
+save_
+
+save_dictionary.date
+
+    _definition.id                '_dictionary.date'
+    _definition.class             Attribute
+    _definition.update            2006-11-16
+    _description.text
+;
+    The date that the last dictionary revision took place.
+;
+    _name.category_id             dictionary
+    _name.object_id               date
+    _type.purpose                 Audit
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Date
+
+save_
+
+save_dictionary.ddl_conformance
+
+    _definition.id                '_dictionary.ddl_conformance'
+    _definition.class             Attribute
+    _definition.update            2006-11-16
+    _description.text
+;
+    The version number of the DDL dictionary that this dictionary
+    conforms to.
+;
+    _name.category_id             dictionary
+    _name.object_id               ddl_conformance
+    _type.purpose                 Audit
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Version
+
+save_
+
+save_dictionary.doi
+
+    _definition.id                '_dictionary.DOI'
+    _definition.class             Attribute
+    _definition.update            2023-06-19
+    _description.text
+;
+    The digital object identifier (DOI) of the dictionary.
+;
+    _name.category_id             dictionary
+    _name.object_id               doi
+    _type.purpose                 Identify
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Text
+    _description_example.case     10.5555/12345678
+
+save_
+
+save_dictionary.formalism
+
+    _definition.id                '_dictionary.formalism'
+    _definition.class             Attribute
+    _definition.update            2021-08-18
+    _description.text
+;
+    The definitions contained in this dictionary are associated
+    with the value of this attribute. Data items may only be
+    redefined if the value of this attribute is also changed, and
+    any such redefinitions must include the original behaviour as
+    a particular case.
+;
+    _name.category_id             dictionary
+    _name.object_id               formalism
+    _type.purpose                 Audit
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_dictionary.namespace
+
+    _definition.id                '_dictionary.namespace'
+    _definition.class             Attribute
+    _definition.update            2006-12-05
+    _description.text
+;
+    The namespace code that may be prefixed (with a trailing double colon
+    '::') to an item tag defined in the defining dictionary when used
+    in particular applications. Because tags must be unique, namespace
+    codes are unlikely to be used in data files.
+;
+    _name.category_id             dictionary
+    _name.object_id               namespace
+    _type.purpose                 Audit
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Code
+
+save_
+
+save_dictionary.title
+
+    _definition.id                '_dictionary.title'
+    _definition.class             Attribute
+    _definition.update            2006-11-16
+    _description.text
+;
+    The common title of the dictionary. Will usually match the name
+    attached to the data_ statement of the dictionary file.
+;
+    _name.category_id             dictionary
+    _name.object_id               title
+    _type.purpose                 Audit
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Code
+
+save_
+
+save_dictionary.uri
+
+    _definition.id                '_dictionary.uri'
+    _definition.class             Attribute
+    _definition.update            2006-11-16
+    _description.text
+;
+    An absolute uniform resource identifier (URI) for this dictionary.
+;
+    _name.category_id             dictionary
+    _name.object_id               uri
+    _type.purpose                 Identify
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Uri
+
+save_
+
+save_dictionary.version
+
+    _definition.id                '_dictionary.version'
+    _definition.class             Attribute
+    _definition.update            2017-07-21
+    _description.text
+;
+    A unique version identifier for the dictionary.
+;
+    _name.category_id             dictionary
+    _name.object_id               version
+    _type.purpose                 Audit
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Version
+
+save_
+
+save_DICTIONARY_AUDIT
+
+    _definition.id                DICTIONARY_AUDIT
+    _definition.scope             Category
+    _definition.class             Loop
+    _definition.update            2013-09-08
+    _description.text
+;
+    Attributes for identifying and registering the dictionary. The items
+    in this category are NOT used as attributes of individual data items.
+;
+    _name.category_id             DICTIONARY
+    _name.object_id               DICTIONARY_AUDIT
+    _category_key.name            '_dictionary_audit.version'
+
+save_
+
+save_dictionary_audit.date
+
+    _definition.id                '_dictionary_audit.date'
+    _definition.class             Attribute
+    _definition.update            2011-06-27
+    _description.text
+;
+    The date of each dictionary revision.
+;
+    _name.category_id             dictionary_audit
+    _name.object_id               date
+    _type.purpose                 Audit
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Date
+
+save_
+
+save_dictionary_audit.revision
+
+    _definition.id                '_dictionary_audit.revision'
+    _definition.class             Attribute
+    _definition.update            2011-06-27
+    _description.text
+;
+    A description of the revision applied for the _dictionary_audit.version.
+;
+    _name.category_id             dictionary_audit
+    _name.object_id               revision
+    _type.purpose                 Describe
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_dictionary_audit.version
+
+    _definition.id                '_dictionary_audit.version'
+    _definition.class             Attribute
+    _definition.update            2019-04-02
+    _description.text
+;
+    A unique version identifier for each revision of the dictionary.
+;
+    _name.category_id             dictionary_audit
+    _name.object_id               version
+    _type.purpose                 Encode
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Version
+
+save_
+
+save_DICTIONARY_AUTHOR
+
+    _definition.id                DICTIONARY_AUTHOR
+    _definition.scope             Category
+    _definition.class             Loop
+    _definition.update            2023-06-02
+    _description.text
+;
+    Attributes used to record the dictionary author information.
+;
+    _name.category_id             DICTIONARY
+    _name.object_id               DICTIONARY_AUTHOR
+    _category_key.name            '_dictionary_author.id'
+
+save_
+
+save_dictionary_author.email
+
+    _definition.id                '_dictionary_author.email'
+    _definition.class             Attribute
+    _definition.update            2023-07-13
+    _description.text
+;
+    The electronic mail address of an author of the dictionary, in a form
+    recognizable to international networks. The format of e-mail addresses is
+    given in Section 3.4, Address Specification, of Internet Message Format,
+    RFC 2822, P. Resnick (Editor), Network Standards Group, April 2001.
+;
+    _name.category_id             dictionary_author
+    _name.object_id               email
+    _type.purpose                 Encode
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+
+    loop_
+      _description_example.case
+         name@host.domain.country
+         bm@iucr.org
+
+save_
+
+save_dictionary_author.id
+
+    _definition.id                '_dictionary_author.id'
+    _definition.class             Attribute
+    _definition.update            2023-07-13
+    _description.text
+;
+    Arbitrary identifier for this author.
+;
+    _name.category_id             dictionary_author
+    _name.object_id               id
+    _type.purpose                 Key
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Word
+
+save_
+
+save_dictionary_author.id_orcid
+
+    _definition.id                '_dictionary_author.id_ORCID'
+    _definition.class             Attribute
+    _definition.update            2023-07-13
+    _description.text
+;
+    Identifier in the ORCID Registry of a publication
+    author. ORCID is an open, non-profit, community-driven
+    service to provide a registry of unique researcher
+    identifiers (https://orcid.org/).
+;
+    _name.category_id             dictionary_author
+    _name.object_id               id_ORCID
+    _type.purpose                 Encode
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Code
+    _description_example.case     0000-0003-0391-0002
+
+save_
+
+save_dictionary_author.name
+
+    _definition.id                '_dictionary_author.name'
+    _definition.class             Attribute
+    _definition.update            2025-02-19
+    _description.text
+;
+    The name of an author of this dictionary. The family name(s), followed
+    by a comma and including any dynastic components, precedes the first
+    name(s) or initial(s). For authors with only one name, provide the full
+    name without abbreviation.
+;
+    _name.category_id             dictionary_author
+    _name.object_id               name
+    _type.purpose                 Describe
+    _type.source                  Recorded
+    _type.container               Single
+    _type.contents                Text
+
+    loop_
+      _description_example.case
+         "Bleary, Percival R."
+         "O'Neil, F.K."
+         "Van den Bossche, G."
+         "Yang, D.-L."
+         "Simonov, Yu.A."
+         "Müller, H.A."
+         "Ross II, C.R."
+         "Chandra"
+
+save_
+
+save_DICTIONARY_VALID
+
+    _definition.id                DICTIONARY_VALID
+    _definition.scope             Category
+    _definition.class             Loop
+    _definition.update            2021-07-20
+    _description.text
+;
+    Data items which are used to specify the contents of definitions in
+    the dictionary in terms of the _definition.scope and the required
+    and prohibited attributes. Validation rules described by data items
+    in this category apply only to Reference and Instance dictionaries.
+;
+    _name.category_id             DICTIONARY
+    _name.object_id               DICTIONARY_VALID
+
+    loop_
+      _category_key.name
+         '_dictionary_valid.scope'
+         '_dictionary_valid.option'
+
+save_
+
+save_dictionary_valid.application
+
+    _definition.id                '_dictionary_valid.application'
+    _definition.class             Attribute
+    _definition_replaced.id       1
+    _definition_replaced.by       .
+    _definition.update            2021-07-20
+    _description.text
+;
+    Deprecated. Provides the information identifying the definition scope
+    (from the _definition.scope enumeration list) and the validity options
+    (from the _dictionary_valid.option enumeration list), as a two element
+    list.
+;
+    _name.category_id             dictionary_valid
+    _name.object_id               application
+    _type.purpose                 Encode
+    _type.source                  Assigned
+    _type.container               List
+    _type.dimension               '[2]'
+    _type.contents                Code
+    _method.purpose               Evaluation
+    _method.expression
+;
+    _dictionary_valid.application
+                     = [_dictionary_valid.scope,_dictionary_valid.option]
+;
+
+save_
+
+save_dictionary_valid.attributes
+
+    _definition.id                '_dictionary_valid.attributes'
+    _definition.class             Attribute
+    _definition.update            2021-07-21
+    _description.text
+;
+    A list of the attribute names and categories that are assessed
+    for application in the item, category and dictionary definitions. A
+    parent attribute category implicitly recursively includes all child
+    categories.
+;
+    _name.category_id             dictionary_valid
+    _name.object_id               attributes
+    _type.purpose                 Audit
+    _type.source                  Assigned
+    _type.container               List
+    _type.dimension               '[]'
+    _type.contents                Code
+
+save_
+
+save_dictionary_valid.option
+
+    _definition.id                '_dictionary_valid.option'
+    _definition.class             Attribute
+    _definition.update            2021-07-20
+    _description.text
+;
+    Option codes for applicability of attributes in definitions. Attributes
+    not listed as 'Prohibited' for a given scope are allowed in that scope.
+;
+    _name.category_id             dictionary_valid
+    _name.object_id               option
+    _type.purpose                 State
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Code
+
+    loop_
+      _enumeration_set.state
+      _enumeration_set.detail
+         Mandatory            'Attribute must be present in definition frame.'
+         Recommended          'Attribute is usually in definition frame.'
+         Prohibited           'Attribute must not be used in definition frame.'
+
+    _enumeration.default          Recommended
+
+save_
+
+save_dictionary_valid.scope
+
+    _definition.id                '_dictionary_valid.scope'
+    _definition.class             Attribute
+    _definition.update            2015-01-28
+    _description.text
+;
+    The scope to which the specified restriction on usable
+    attributes applies.
+;
+    _name.category_id             dictionary_valid
+    _name.object_id               scope
+    _type.purpose                 Audit
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Code
+
+    loop_
+      _enumeration_set.state
+      _enumeration_set.detail
+         Dictionary             'Restriction applies to dictionary definition.'
+         Category               'Restriction applies to a category definition.'
+         Item                   'Restriction applies to an item definition.'
+
+save_
+
+save_ENUMERATION
+
+    _definition.id                ENUMERATION
+    _definition.scope             Category
+    _definition.class             Set
+    _definition.update            2011-06-20
+    _description.text
+;
+    The attributes for restricting the values of defined data items.
+;
+    _name.category_id             ATTRIBUTES
+    _name.object_id               ENUMERATION
+
+save_
+
+save_enumeration.def_index_id
+
+    _definition.id                '_enumeration.def_index_id'
+    _definition.class             Attribute
+    _definition_replaced.id       1
+    _definition_replaced.by       '_enumeration.def_index_ids'
+    _definition.update            2023-06-23
+    _description.text
+;
+    Deprecated. The _enumeration.def_index_ids data item should be
+    used instead of this item.
+
+    Specifies the data name of the item with a value used as an index
+    to the DEFAULT enumeration list (in category enumeration_default)
+    in order to select the default enumeration value for the
+    defined item. The value of the identified data item must match
+    one of the _enumeration_default.index values.
+;
+    _name.category_id             enumeration
+    _name.object_id               def_index_id
+    _type.purpose                 Identify
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Tag
+
+save_
+
+save_enumeration.def_index_ids
+
+    _definition.id                '_enumeration.def_index_ids'
+    _definition.class             Attribute
+    _definition.update            2023-06-23
+    _description.text
+;
+    Specifies the data names of items that are collectively used to identify
+    the suitable default value in the ENUMERATION_DEFAULTS category loop.
+    The values of these items are used to construct an ordered list which is
+    checked against the values of the _enumeration_defaults.index attribute.
+;
+    _name.category_id             enumeration
+    _name.object_id               def_index_ids
+    _type.purpose                 Identify
+    _type.source                  Assigned
+    _type.container               List
+    _type.dimension               '[]'
+    _type.contents                Tag
+
+save_
+
+save_enumeration.default
+
+    _definition.id                '_enumeration.default'
+    _definition.class             Attribute
+    _definition.update            2021-11-15
+    _description.text
+;
+    The default value for the defined item if it is not specified explicitly.
+    Value of this attribute inherits the enumeration range, enumeration set,
+    container, dimension, content and purpose type constraints of the defining
+    item.
+;
+    _name.category_id             enumeration
+    _name.object_id               default
+    _type.purpose                 Encode
+    _type.source                  Assigned
+    _type.container               Implied
+    _type.contents                Implied
+
+save_
+
+save_enumeration.mandatory
+
+    _definition.id                '_enumeration.mandatory'
+    _definition.class             Attribute
+    _definition.update            2012-05-07
+    _description.text
+;
+    Yes or No flag on whether the enumerate states specified for an
+    item in the current definition (in which item appears) MUST be
+    used on instantiation.
+;
+    _name.category_id             enumeration
+    _name.object_id               mandatory
+    _type.purpose                 State
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Code
+
+    loop_
+      _enumeration_set.state
+      _enumeration_set.detail
+         Yes                      'Use of state is mandatory.'
+         No                       'Use of state is unnecessary.'
+
+    _enumeration.default          Yes
+
+save_
+
+save_enumeration.range
+
+    _definition.id                '_enumeration.range'
+    _definition.class             Attribute
+    _definition.update            2023-01-09
+    _description.text
+;
+    The inclusive range of numerical values allowed for the defined item.
+    If the defined item has associated SU values, the reported data values
+    may fall outside these limits.
+;
+    _name.category_id             enumeration
+    _name.object_id               range
+    _type.purpose                 Encode
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Range
+
+    loop_
+      _description_example.case
+      _description_example.detail
+         -4:10
+;
+         Values must be no less than -4 and no greater than 10.
+;
+         0:
+;
+         Values must be greater than or equal to 0.
+;
+         :3.1415
+;
+         Values must be less than or equal to 3.1415.
+;
+
+save_
+
+save_ENUMERATION_DEFAULT
+
+    _definition.id                ENUMERATION_DEFAULT
+    _definition.scope             Category
+    _definition.class             Loop
+    _definition.update            2023-06-23
+    _description.text
+;
+    Deprecated. The ENUMERATION_DEFAULTS category should be used instead
+    of this category.
+
+    Loop of pre-determined default enumeration values indexed to a
+    data item by the item _enumeration.def_index_id.
+;
+    _name.category_id             ENUMERATION
+    _name.object_id               ENUMERATION_DEFAULT
+    _category_key.name            '_enumeration_default.index'
+
+save_
+
+save_enumeration_default.index
+
+    _definition.id                '_enumeration_default.index'
+    _definition.class             Attribute
+    _definition_replaced.id       1
+    _definition_replaced.by       '_enumeration_defaults.index'
+    _definition.update            2023-06-23
+    _description.text
+;
+    Deprecated. The _enumeration_defaults.index data item should be
+    used instead of this item.
+
+    Index key in the list default values referenced to by the value
+    of _enumeration.def_index_id.
+;
+    _name.category_id             enumeration_default
+    _name.object_id               index
+    _type.purpose                 Encode
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Code
+
+save_
+
+save_enumeration_default.value
+
+    _definition.id                '_enumeration_default.value'
+    _definition.class             Attribute
+    _definition_replaced.id       1
+    _definition_replaced.by       '_enumeration_defaults.value'
+    _definition.update            2023-06-23
+    _description.text
+;
+    Deprecated. The _enumeration_defaults.value data item should be
+    used instead of this item.
+
+    Default enumeration value in the list referenced by the value of
+    _enumeration.def_index_id. The reference index key is given by
+    the value of _enumeration_default.index value.
+;
+    _name.category_id             enumeration_default
+    _name.object_id               value
+    _type.purpose                 Encode
+    _type.source                  Assigned
+    _type.container               Implied
+    _type.contents                Implied
+
+save_
+
+save_ENUMERATION_DEFAULTS
+
+    _definition.id                ENUMERATION_DEFAULTS
+    _definition.scope             Category
+    _definition.class             Loop
+    _definition.update            2023-06-23
+    _description.text
+;
+    Loop of pre-determined default enumeration values indexed by a set of data
+    items specified using the _enumeration.def_index_ids attribute.
+;
+    _name.category_id             ENUMERATION
+    _name.object_id               ENUMERATION_DEFAULTS
+    _category_key.name            '_enumeration_defaults.index'
+
+save_
+
+save_enumeration_defaults.index
+
+    _definition.id                '_enumeration_defaults.index'
+    _definition.class             Attribute
+    _definition.update            2023-06-23
+    _description.text
+;
+    An index value, in the form of an ordered list, which allows the
+    identification of the most suitable default value. The order of values in
+    the list must correspond to the order of the related data item references
+    in the _enumeration.def_index_ids attribute list. That is, the n^th^ list
+    element is assumed to represent a value that may be assigned to the data
+    item referenced at the n^th^ position of the _enumeration.def_index_ids
+    attribute list value.
+
+    The constituent values of the _enumeration_defaults.index attribute inherit
+    the enumeration range, enumeration set, and the content type from the
+    data item with which they are paired.
+;
+    _name.category_id             enumeration_defaults
+    _name.object_id               index
+    _type.purpose                 Encode
+    _type.source                  Assigned
+    _type.container               List
+    _type.dimension               '[]'
+    _type.contents                Inherited
+
+save_
+
+save_enumeration_defaults.source_id
+
+    _definition.id                '_enumeration_defaults.source_id'
+    _definition.class             Attribute
+    _definition.update            2023-07-13
+    _description.text
+;
+    An identifier which corresponds to an entry in the ENUMERATION_SOURCE
+    category loop. Used to provide a reference to the original source of
+    a specific enumeration value.
+;
+    _name.category_id             enumeration_defaults
+    _name.object_id               source_id
+    _name.linked_item_id          '_enumeration_source.id'
+    _type.purpose                 Link
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Word
+
+save_
+
+save_enumeration_defaults.value
+
+    _definition.id                '_enumeration_defaults.value'
+    _definition.class             Attribute
+    _definition.update            2023-06-23
+    _description.text
+;
+    The default enumeration value associated with a specific index value
+    constructed using data items referenced by the _enumeration.def_index_ids
+    attribute. The associated index value is provided using the
+    _enumeration_defaults.index attribute.
+;
+    _name.category_id             enumeration_defaults
+    _name.object_id               value
+    _type.purpose                 Encode
+    _type.source                  Assigned
+    _type.container               Implied
+    _type.contents                Implied
+
+save_
+
+save_ENUMERATION_SET
+
+    _definition.id                ENUMERATION_SET
+    _definition.scope             Category
+    _definition.class             Loop
+    _definition.update            2013-09-08
+    _description.text
+;
+    Attributes of data items which are used to define a
+    set of unique pre-determined values.
+;
+    _name.category_id             ENUMERATION
+    _name.object_id               ENUMERATION_SET
+    _category_key.name            '_enumeration_set.state'
+
+save_
+
+save_enumeration_set.detail
+
+    _definition.id                '_enumeration_set.detail'
+    _definition.class             Attribute
+    _definition.update            2011-06-27
+    _description.text
+;
+    The meaning of the code (identified by _enumeration_set.state)
+    in terms of the value of the quantity it describes.
+;
+    _name.category_id             enumeration_set
+    _name.object_id               detail
+    _type.purpose                 Describe
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_enumeration_set.state
+
+    _definition.id                '_enumeration_set.state'
+    _definition.class             Attribute
+    _definition.update            2023-11-07
+    _description.text
+;
+    Permitted value state for the defined item. Value of this attribute inherits
+    the enumeration range, enumeration set, container, dimension, content and
+    purpose type constraints of the defining item.
+;
+    _name.category_id             enumeration_set
+    _name.object_id               state
+    _type.purpose                 Encode
+    _type.source                  Assigned
+    _type.container               Implied
+    _type.contents                Implied
+
+save_
+
+save_ENUMERATION_SOURCE
+
+    _definition.id                ENUMERATION_SOURCE
+    _definition.scope             Category
+    _definition.class             Loop
+    _definition.update            2023-06-23
+    _description.text
+;
+    Attributes used to record the original sources of the default values
+    enumerated using the ENUMERATION_DEFAULTS category.
+;
+    _name.category_id             ENUMERATION
+    _name.object_id               ENUMERATION_SOURCE
+    _category_key.name            '_enumeration_source.id'
+
+    loop_
+      _description_example.case
+      _description_example.detail
+;
+         loop_
+         _enumeration_source.id
+         _enumeration_source.reference
+         a 'International Tables Vol. C Table 4.4.4.1 2nd ed.'
+         b 'International Tables Vol. H Table 4.3.2.1 1st ed.'
+
+         loop_
+         _enumeration_defaults.index
+         _enumeration_defaults.value
+         _enumeration_defaults.source_id
+         [ H  ]  1  a
+         [ H- ]  2  a
+         [ He ]  2  b
+         # ...
+;
+;
+         There are two sources for the default values given in the enumeration.
+         Entries marked with 'a' come from Table 4.4.4.1 in the 2nd edition of
+         Volume C of the International Tables of Crystallography. Entries marked
+         with 'b' come from Table 4.3.2.1 in the 1st edition of Volume H of the
+         International Tables of Crystallography.
+;
+;
+         _enumeration_source.reference
+             'https://doi.org/10.1107/S2053273322010944, Table S4'
+
+         loop_
+         _enumeration_defaults.index
+         _enumeration_defaults.value
+         [ He ] 0.8733928
+         [ Li ] 1.129319
+         [ Be ] 1.592162
+         # ...
+;
+;
+         There is a single source for all default values given in the
+         enumeration. All entries can be found in Table S4 of the material
+         referenced by the given DOI.
+;
+
+save_
+
+save_enumeration_source.id
+
+    _definition.id                '_enumeration_source.id'
+    _definition.class             Attribute
+    _definition.update            2023-06-23
+    _description.text
+;
+    A unique identifier of the source material from which the
+    _enumeration_defaults.value attribute values were taken.
+;
+    _name.category_id             enumeration_source
+    _name.object_id               id
+    _type.purpose                 Key
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Word
+
+save_
+
+save_enumeration_source.reference
+
+    _definition.id                '_enumeration_source.reference'
+    _definition.class             Attribute
+    _definition.update            2023-06-23
+    _description.text
+;
+    Bibliographic information sufficient to identify the original source of
+    the associated _enumeration_defaults.value attribute values.
+;
+    _name.category_id             enumeration_source
+    _name.object_id               reference
+    _type.purpose                 Describe
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_IMPORT
+
+    _definition.id                IMPORT
+    _definition.scope             Category
+    _definition.class             Set
+    _definition.update            2011-06-27
+    _description.text
+;
+    Used to import the values of specific attributes from other dictionary
+    definitions within and without the current dictionary.
+;
+    _name.category_id             ATTRIBUTES
+    _name.object_id               IMPORT
+
+save_
+
+save_import.get
+
+    _definition.id                '_import.get'
+    _definition.class             Attribute
+    _definition.update            2023-11-13
+    _description.text
+;
+    A list of tables of attributes defined individually in the category
+    IMPORT_DETAILS, used to import definitions from other dictionaries.
+;
+    _name.category_id             import
+    _name.object_id               get
+    _type.purpose                 Import
+    _type.source                  Assigned
+    _type.container               List
+    _type.dimension               '[]'
+    _type.contents                ByReference
+    _type.contents_referenced_id  '_import_details.single'
+    _method.purpose               Evaluation
+    _method.expression
+;
+     imp_order_list = []
+     loop id as import_details {
+         imp_order_list ++= id.order
+     }
+     imp_order_list = sort(imp_order_list)
+     final_val = []
+     for ord in imp_order_list {
+         final_val ++= import_details[ord].single
+     }
+    _import.get = final_val
+;
+
+save_
+
+save_IMPORT_DETAILS
+
+    _definition.id                IMPORT_DETAILS
+    _definition.scope             Category
+    _definition.class             Loop
+    _definition.update            2015-05-06
+    _description.text
+;
+    Items in IMPORT_DETAILS describe individual attributes of an import
+    operation.
+;
+    _name.category_id             IMPORT
+    _name.object_id               IMPORT_DETAILS
+    _category_key.name            '_import_details.order'
+
+save_
+
+save_import_details.file_id
+
+    _definition.id                '_import_details.file_id'
+    _definition.class             Attribute
+    _definition.update            2021-02-03
+    _description.text
+;
+    A URI reference as per RFC 3986 giving the location of the source
+    dictionary. When a relative URI is used, the base URI for the URI reference
+    is the _dictionary.uri of the importing dictionary.
+;
+    _name.category_id             import_details
+    _name.object_id               file_id
+    _type.purpose                 Identify
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Uri
+
+save_
+
+save_import_details.file_version
+
+    _definition.id                '_import_details.file_version'
+    _definition.class             Attribute
+    _definition.update            2017-07-21
+    _description.text
+;
+    The required version number for _dictionary.version of the
+    imported dictionary. Dictionaries with the same major version
+    number are compatible. If absent or null, any version is permitted.
+;
+    _name.category_id             import_details
+    _name.object_id               file_version
+    _type.purpose                 Identify
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Version
+
+save_
+
+save_import_details.frame_id
+
+    _definition.id                '_import_details.frame_id'
+    _definition.class             Attribute
+    _definition.update            2021-08-18
+    _description.text
+;
+    The save frame code of the definition frame to be imported.
+;
+    _name.category_id             import_details
+    _name.object_id               frame_id
+    _type.purpose                 Identify
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Code
+
+save_
+
+save_import_details.if_dupl
+
+    _definition.id                '_import_details.if_dupl'
+    _definition.class             Attribute
+    _definition.update            2021-11-09
+    _description.text
+;
+    Code identifying the action taken if the requested definition block
+    already exists within the importing dictionary in 'Full' mode, or
+    an attribute exists in both the importing definition block and the
+    requested definition block in 'Contents' mode.
+;
+    _name.category_id             import_details
+    _name.object_id               if_dupl
+    _type.purpose                 State
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Code
+
+    loop_
+      _enumeration_set.state
+      _enumeration_set.detail
+         Ignore
+;
+         Ignore imported definitions if block identifiers match in 'Full' mode.
+         Ignore imported attributes that match attributes already in the
+         importing definition in 'Contents' mode.
+
+         When importing in 'Contents' mode, if the ignored attribute belongs to
+         a Loop category, all attributes from that category must be ignored to
+         avoid loop mismatches.
+;
+         Replace
+;
+         Replace existing definitions with imported definitions if block
+         identifiers match in 'Full' mode.
+
+         When importing in 'Contents' mode, contents of the two save frames
+         should be merged and any duplicate attributes replaced with those from
+         the imported save frame. In case the replaced attribute belongs to a
+         Loop category, all attributes from that category must first be removed
+         from the importing save frame to avoid loop mismatches.
+;
+         Exit
+;
+         Issue an error exception and exit.
+;
+
+    _enumeration.default          Exit
+
+save_
+
+save_import_details.if_miss
+
+    _definition.id                '_import_details.if_miss'
+    _definition.class             Attribute
+    _definition.update            2015-05-06
+    _description.text
+;
+    Code identifying the action taken if the requested definition block
+    is missing from the source dictionary.
+;
+    _name.category_id             import_details
+    _name.object_id               if_miss
+    _type.purpose                 State
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Code
+
+    loop_
+      _enumeration_set.state
+      _enumeration_set.detail
+         Ignore                   'Ignore import.'
+         Exit                     'Issue error exception and exit.'
+
+    _enumeration.default          Exit
+
+save_
+
+save_import_details.mode
+
+    _definition.id                '_import_details.mode'
+    _definition.class             Attribute
+    _definition.update            2019-04-03
+    _description.text
+;
+    Code identifying how the definition referenced by
+    _import_details.frame_id is to be imported.
+
+    'Full' imports the entire definition together with any child definitions
+    (in the case of categories) found in the target dictionary. The importing
+    definition becomes the parent of the imported definition. As such, the
+    'Full' mode must only be used in category definitions.
+
+    As a special case, a 'Head' category importing a 'Head' category is
+    equivalent to importing all children of the imported 'Head' category
+    as children of the importing 'Head' category. A 'Head' category can
+    only be imported in 'Full' mode and only by another 'Head' category.
+
+    'Contents' imports only the attributes found in the imported definition.
+;
+    _name.category_id             import_details
+    _name.object_id               mode
+    _type.purpose                 State
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Code
+
+    loop_
+      _enumeration_set.state
+      _enumeration_set.detail
+         Full
+             'Import requested definition together with any child definitions.'
+         Contents
+             'Import contents of requested definition.'
+
+    _enumeration.default          Contents
+
+save_
+
+save_import_details.order
+
+    _definition.id                '_import_details.order'
+    _definition.class             Attribute
+    _definition.update            2021-03-01
+    _description.text
+;
+    The order in which the import described by the referenced row should be
+    executed.
+;
+    _name.category_id             import_details
+    _name.object_id               order
+    _type.purpose                 Encode
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Integer
+    _units.code                   none
+
+save_
+
+save_import_details.single
+
+    _definition.id                '_import_details.single'
+    _definition.class             Attribute
+    _definition.update            2017-07-21
+    _description.text
+;
+    A Table mapping attributes defined individually in category IMPORT to
+    their values; used to import definitions from other dictionaries.
+;
+    _name.category_id             import_details
+    _name.object_id               single
+    _type.purpose                 Internal
+    _type.source                  Assigned
+    _type.container               Table
+    _type.contents                Text
+    _type.indices                 ByReference
+    _type.indices_referenced_id   '_import_details.single_index'
+    _method.purpose               Evaluation
+    _method.expression
+;
+    with id as import_details
+    _import_details.single = {"file":id.file_id,
+                              "version":id.file_version,
+                              "save":id.frame_id,
+                              "mode":id.mode,
+                              "dupl":id.if_dupl,
+                              "miss":id.if_miss}
+;
+
+save_
+
+save_import_details.single_index
+
+    _definition.id                '_import_details.single_index'
+    _definition.class             Attribute
+    _definition.update            2021-08-18
+    _description.text
+;
+    One of the indices permitted in the entries of values of attribute
+    _import_details.single.
+;
+    _name.category_id             import_details
+    _name.object_id               single_index
+    _type.purpose                 Internal
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Code
+
+    loop_
+      _enumeration_set.state
+      _enumeration_set.detail
+         file
+;
+         URI reference as per RFC 3986 giving the location of the source
+         dictionary.
+;
+         version
+;
+         Version of source dictionary.
+;
+         save
+;
+         Save frame code of source definition.
+;
+         mode
+;
+         Mode for including save frames.
+;
+         dupl
+;
+         Option for duplicate entries.
+;
+         miss
+;
+         Option for missing duplicate entries.
+;
+
+save_
+
+save_METHOD
+
+    _definition.id                METHOD
+    _definition.scope             Category
+    _definition.class             Loop
+    _definition.update            2013-09-08
+    _description.text
+;
+    Methods used for evaluating, validating and defining items.
+;
+    _name.category_id             ATTRIBUTES
+    _name.object_id               METHOD
+    _category_key.name            '_method.purpose'
+
+save_
+
+save_method.expression
+
+    _definition.id                '_method.expression'
+    _definition.class             Attribute
+    _definition.update            2023-11-14
+    _description.text
+;
+    The method expression for the defined item or category.
+;
+    _name.category_id             method
+    _name.object_id               expression
+    _type.purpose                 Method
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Text
+
+save_
+
+save_method.purpose
+
+    _definition.id                '_method.purpose'
+    _definition.class             Attribute
+    _definition.update            2023-06-28
+    _description.text
+;
+    The purpose and scope of the method expression.
+;
+    _name.category_id             method
+    _name.object_id               purpose
+    _type.purpose                 State
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Code
+
+    loop_
+      _enumeration_set.state
+      _enumeration_set.detail
+         Evaluation
+;
+         Method evaluates an item from related item values. Definitions of
+         primitive data items should normally not contain methods of this type.
+;
+         Definition
+;
+         Method generates attribute value(s) in the definition.
+;
+         Validation
+;
+         Method compares an evaluation with existing item value.
+;
+
+    _enumeration.default          Evaluation
+
+save_
+
+save_NAME
+
+    _definition.id                NAME
+    _definition.scope             Category
+    _definition.class             Set
+    _definition.update            2011-06-20
+    _description.text
+;
+    Attributes for identifying items and item categories.
+;
+    _name.category_id             ATTRIBUTES
+    _name.object_id               NAME
+
+save_
+
+save_name.category_id
+
+    _definition.id                '_name.category_id'
+    _definition.class             Attribute
+    _definition.update            2011-07-27
+    _description.text
+;
+    The name of the category in which a category or item resides.
+    For Head categories this is the _dictionary.title given in the
+    enclosing data block.
+;
+    _name.category_id             name
+    _name.object_id               category_id
+    _type.purpose                 Identify
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Name
+
+save_
+
+save_name.linked_item_id
+
+    _definition.id                '_name.linked_item_id'
+    _definition.class             Attribute
+    _definition.update            2021-12-16
+    _description.text
+;
+    Data name of an equivalent item which has a
+    common set of values, or, in the definition of a type SU
+    item is the name of the associated measurand item to
+    which the standard uncertainty applies.
+;
+    _name.category_id             name
+    _name.object_id               linked_item_id
+    _type.purpose                 Identify
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Tag
+
+save_
+
+save_name.object_id
+
+    _definition.id                '_name.object_id'
+    _definition.class             Attribute
+    _definition.update            2011-07-27
+    _description.text
+;
+    The object name of a category or name unique within the
+    category or family of categories.
+;
+    _name.category_id             name
+    _name.object_id               object_id
+    _type.purpose                 Identify
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Name
+
+save_
+
+save_TYPE
+
+    _definition.id                TYPE
+    _definition.scope             Category
+    _definition.class             Set
+    _definition.update            2011-06-26
+    _description.text
+;
+    Attributes which specify the 'typing' of data items.
+;
+    _name.category_id             ATTRIBUTES
+    _name.object_id               TYPE
+
+save_
+
+save_type.container
+
+    _definition.id                '_type.container'
+    _definition.class             Attribute
+    _definition.update            2021-12-08
+    _description.text
+;
+    The structure of values for the defined data item.
+;
+    _name.category_id             type
+    _name.object_id               container
+    _type.purpose                 State
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Code
+
+    loop_
+      _enumeration_set.state
+      _enumeration_set.detail
+         Single
+;
+         Single value.
+;
+         List
+;
+         Ordered set of values. Elements need not be of same contents type.
+;
+         Array
+;
+         Ordered set of values of the same type. Operations across arrays are
+         equivalent to operations across elements of the Array.
+;
+         Matrix
+;
+         Ordered set of numerical values for a tensor. Tensor operations such
+         as dot and cross products, are valid cross matrix objects. A matrix
+         with a single dimension is interpreted as a row or column vector as
+         required.
+;
+         Table
+;
+         An unordered set of id:value elements.
+;
+         Implied
+;
+         >>> Applied ONLY in the DDLm Reference Dictionary <<<
+         The value structure is taken from _type.container in the definition in
+         which the defined attribute appears.
+;
+
+    _enumeration.default          Single
+
+save_
+
+save_type.contents
+
+    _definition.id                '_type.contents'
+    _definition.class             Attribute
+    _definition.update            2023-11-07
+    _description.text
+;
+    Syntax of the value elements within the container type. Where the
+    definition is of a 'List' or 'Array' type, this attribute
+    describes the contents of each element. Where the definition is
+    of a 'Table' container this attribute describes the construction
+    of the value elements within those (Table) values.  The CIF2
+    character set referenced below consists of the following Unicode
+    code points:
+
+    [U+0009], [U+000A], [U+000D], [U+0020-U+007E], [U+00A0-U+D7FF],
+    [U+E000-U+FDCF], [U+FDF0-U+FFFD], [U+10000-U+1FFFD],
+    [U+20000-U+2FFFD], [U+30000-U+3FFFD], [U+40000-U+4FFFD],
+    [U+50000-U+5FFFD], [U+60000-U+6FFFD], [U+70000-U+7FFFD],
+    [U+80000-U+8FFFD], [U+90000-U+9FFFD], [U+A0000-U+AFFFD],
+    [U+B0000-U+BFFFD], [U+C0000-U+CFFFD], [U+D0000-U+DFFFD],
+    [U+E0000-U+EFFFD], [U+F0000-U+FFFFD], [U+100000-U+10FFFD]
+
+    Two case-insensitive strings are considered identical when
+    they match under the Unicode canonical caseless matching algorithm.
+
+    In all cases, 'whitespace' refers to ASCII whitespace only, that
+    is [U+0009], [U+000A], [U+000D] and [U+0020].
+
+    Note that descriptions of text syntax are relevant only to those
+    formats that encode data values as text.
+;
+    _name.category_id             type
+    _name.object_id               contents
+    _type.purpose                 State
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Code
+
+    loop_
+      _enumeration_set.state
+      _enumeration_set.detail
+         Text
+;
+         Case-sensitive sequence of CIF2 characters.
+;
+         Word
+;
+         Case-sensitive sequence of CIF2 characters containing no ASCII
+         whitespace.
+;
+         Code
+;
+         Case-insensitive sequence of CIF2 characters containing no ASCII
+         whitespace.
+;
+         Name
+;
+         Case-insensitive sequence of ASCII alphanumeric characters or
+         underscore.
+;
+         Tag
+;
+         Case-insensitive CIF2 character sequence with leading underscore and
+         no ASCII whitespace.
+;
+         Uri
+;
+         Uniform Resource Identifier reference as defined in RFC 3986 Section
+         4.1.
+;
+         Date
+;
+         ISO standard date format <yyyy>-<mm>-<dd>. Use DateTime for all new
+         dictionaries.
+;
+         DateTime
+;
+         A timestamp. Text formats must use date-time or full-date productions
+         of RFC 3339 ABNF.
+;
+         Version
+;
+         Version number string that adheres to the formal grammar provided in
+         the Semantic Versioning specification version 2.0.0. Version strings
+         must take the general form of <major>.<minor>.<patch> and may also
+         contain an optional postfix with additional information such as the
+         pre-release identifier.
+
+         Reference: https://semver.org/spec/v2.0.0.html
+;
+         Dimension
+;
+         Size of an Array/Matrix/List expressed as a text string. The text
+         string itself consists of zero or more non-negative integers separated
+         by commas placed within bounding square brackets. Empty square
+         brackets represent a list of unknown size.
+;
+         Range
+;
+         Inclusive range of numerical values expressed using the min:max
+         notation in which the smallest value 'min' and the largest value
+         'max' are separated by a colon character. If 'max' is omitted, then
+         the range includes all values that are greater than or equal to 'min'.
+         If 'min' is omitted, then the range includes all values that are less
+         than or equal to 'max'.
+;
+         Integer
+;
+         A number from the set of all integers.
+;
+         Real
+;
+         Floating-point real number.
+;
+         Imag
+;
+         Floating-point imaginary number.
+;
+         Complex
+;
+         A complex number.
+;
+         Symop
+;
+         A string composed of a positive integer optionally followed by an
+         underscore or space and three or more digits.
+;
+         Implied
+;
+         >>> Applied ONLY in the DDLm Reference Dictionary <<<
+         The contents are described by the _type.contents attribute in the
+         definition in which the defined attribute appears.
+;
+         ByReference
+;
+         The contents have the same form as those of the attribute referenced
+         by _type.contents_referenced_id.
+;
+         Inherited
+;
+         >>> Applied ONLY in the DDLm Reference Dictionary <<<
+         Intended to be used with List, Array, Matrix or Table containers which
+         may simultaneously contain values of several content types. The content
+         type of each value in such containers matches the content type of the
+         data item to which it is directly related. Specific rules for relating
+         data values to data items MUST be provided as human-readable text in
+         the _description.text attribute of all data items that have the
+         Inherited content type.
+;
+    _enumeration.default          Text
+    _description_example.case     Integer
+    _description_example.detail   'Content is a single or multiple integer(s).'
+
+save_
+
+save_type.contents_referenced_id
+
+    _definition.id                '_type.contents_referenced_id'
+    _definition.class             Attribute
+    _definition.update            2015-04-24
+    _description.text
+;
+    The value of the _definition.id attribute of an attribute definition
+    whose type is to be used also as the type of this item. Meaningful only
+    when this item's _type.contents attribute has value 'ByReference'.
+;
+    _name.category_id             type
+    _name.object_id               contents_referenced_id
+    _type.purpose                 Identify
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Tag
+
+save_
+
+save_type.dimension
+
+    _definition.id                '_type.dimension'
+    _definition.class             Attribute
+    _definition.update            2021-07-28
+    _description.text
+;
+    The dimensions of a list, array or matrix of elements expressed as
+    a text string. A Matrix with a single dimension is interpreted as
+    a vector.
+;
+    _name.category_id             type
+    _name.object_id               dimension
+    _type.purpose                 Encode
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Dimension
+
+    loop_
+      _description_example.case
+      _description_example.detail
+         '[3,3]'                  '3x3 matrix of elements.'
+         '[6]'                    'List of 6 elements.'
+         '[]'                     'Unknown number of list elements.'
+
+save_
+
+save_type.indices
+
+    _definition.id                '_type.indices'
+    _definition.class             Attribute
+    _definition.update            2023-01-13
+    _description.text
+;
+    Used to specify the syntax construction of indices of the entries in the
+    defined object when the defined object has 'Table' as its
+    _type.container attribute. Values are a subset of the codes and
+    constructions defined for attribute _type.contents, accounting
+    for the fact that syntactically, indices are always case-sensitive
+    quoted strings.
+
+    Meaningful only when the defined item has _type.container 'Table'.
+
+    See the definition for _type.contents for the character set definition.
+;
+    _name.category_id             type
+    _name.object_id               indices
+    _type.purpose                 State
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Code
+
+    loop_
+      _enumeration_set.state
+      _enumeration_set.detail
+         Text
+;
+         A case-sensitive sequence of CIF2 characters.
+;
+         Code
+;
+         Case-insensitive sequence of CIF2 characters containing no ASCII
+         whitespace.
+;
+         Date
+;
+         ISO date format <yyyy>-<mm>-<dd>.
+;
+         Uri
+;
+         A Uniform Resource Identifier string, per RFC 3986.
+;
+         Version
+;
+         Version digit string of the form <major>.<version>.<update>
+;
+         ByReference
+;
+         Indices have the same form as the contents of the attribute identified
+         by _type.indices_referenced_id.
+;
+
+    _enumeration.default          Text
+
+save_
+
+save_type.indices_referenced_id
+
+    _definition.id                '_type.indices_referenced_id'
+    _definition.class             Attribute
+    _definition.update            2015-04-24
+    _description.text
+;
+    The _definition.id attribute of a definition whose type describes the
+    form and construction of the indices of entries in values of the present
+    item.
+
+    Meaningful only when the defined item's _type.container attribute has
+    value 'Table', and its _type.indices attribute has value 'ByReference'.
+;
+    _name.category_id             type
+    _name.object_id               indices_referenced_id
+    _type.purpose                 Identify
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Tag
+
+save_
+
+save_type.purpose
+
+    _definition.id                '_type.purpose'
+    _definition.class             Attribute
+    _definition.update            2023-11-14
+    _description.text
+;
+    The primary purpose or function the defined data item serves in a
+    dictionary or a specific data instance.
+;
+    _name.category_id             type
+    _name.object_id               purpose
+    _type.purpose                 State
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Code
+
+    loop_
+      _enumeration_set.state
+      _enumeration_set.detail
+         Import
+;
+         >>> Applied ONLY in the DDLm Reference Dictionary <<<
+         Used to type the SPECIAL attribute '_import.get' that is present in
+         dictionaries to instigate the importation of external dictionary
+         definitions.
+;
+         Method
+;
+         >>> Applied ONLY in the DDLm Reference Dictionary <<<
+         Used to type the attribute '_method.expression' that is present in
+         dictionary definitions to provide the text method expressing the
+         defined item in terms of other defined items.
+;
+         Audit
+;
+         >>> Applied ONLY in the DDLm Reference Dictionary <<<
+         Used to type attributes employed to record the audit definition
+         information (creation date, update version and cross reference codes)
+         of items, categories and files.
+;
+         Identify
+;
+         >>> Applied ONLY in the DDLm Reference Dictionary <<<
+         Used to type attributes that identify an item tag (or part thereof)
+         or external location.
+;
+         Describe
+;
+         Used to type items with values that are descriptive text intended for
+         human interpretation.
+;
+         Encode
+;
+         Used to type items with values that are text or codes that are
+         formatted to be machine parsable.
+;
+         State
+;
+         Used to type items with values that are restricted to codes present in
+         their _enumeration_set.state lists.
+;
+         Key
+;
+         Used to type an item with a value that is unique within the looped
+         list of these items, and does not contain encoded information.
+;
+         Link
+;
+         Used to type an item that acts as a foreign key between two
+         categories. The definition of the item must additionally contain the
+         attribute '_name.linked_item_id' specifying the data name of the item
+         with unique values in the linked category. The values of the defined
+         item are drawn from the set of values in the referenced item. Cross
+         referencing items from the same category is allowed.
+;
+         Composite
+;
+         Used to type items with value strings composed of separate parts.
+         These will usually need to be separated and parsed for complete
+         interpretation and application.
+;
+         Number
+;
+         Used to type items that are numerical and exact (i.e. no standard
+         uncertainty value).
+;
+         Measurand
+;
+         Used to type an item with a numerically estimated value that has been
+         recorded by measurement or derivation. A data item definition for the
+         standard uncertainty (SU) of this item must be provided in a separate
+         definition with _type.purpose of 'SU'. The value of a measurand item
+         should be accompanied by a value of its associated SU item, either: 1)
+         integrated with the measurand value in a manner characteristic of the
+         data format; or 2) as a separate, explicit value for the associated SU
+         item. These alternatives are semantically equivalent.
+;
+         SU
+;
+         Used to type an item with a numerical value that is the standard
+         uncertainty of another data item. The definition of an SU item must
+         have the _type.source attribute set to 'Related' and must include
+         the _name.linked_item_id attribute which explicitly identifies
+         the associated measurand item. SU values must be non-negative.
+;
+         Internal
+;
+         Used to type items that serve only internal purposes of the dictionary
+         in which they appear. The particular purpose served is not defined by
+         this state.
+;
+
+    _enumeration.default          Describe
+
+save_
+
+save_type.source
+
+    _definition.id                '_type.source'
+    _definition.class             Attribute
+    _definition.update            2023-07-11
+    _description.text
+;
+    The origin or source of the defined data item, indicating by what
+    recording process it has been added to the domain instance.
+
+    All data items can be classified as primitive or non-primitive based on
+    the origin of the data. Primitive data items record data that usually
+    cannot be deduced without repeating the entire experiment such as
+    measurements, observations (e.g. instrument settings) and decisions
+    made in nonlinear processes. Non-primitive data items record derivable
+    data that can be directly evaluated from other data.
+;
+    _name.category_id             type
+    _name.object_id               source
+    _type.purpose                 State
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Code
+
+    loop_
+      _enumeration_set.state
+      _enumeration_set.detail
+         Recorded
+;
+         Data value (numerical or otherwise) was recorded by observation or
+         measurement during the experimental collection of data.
+
+         Data items of this type are considered primitive.
+;
+         Assigned
+;
+         Data value (numerical or otherwise) was assigned as part of the data
+         collection, analysis or modelling required for a specific domain
+         instance.
+
+         These assignments often represent a decision made that determines the
+         course of the experiment (and therefore the data item may be deemed
+         primitive) or a particular choice in the way the data was analysed
+         (and therefore the data item may be considered non-primitive).
+;
+         Related
+;
+         Data item was added based on a relationship to another data item.
+
+         This state indicates that the item was used to record the SU value of
+         a related measurand item or that the item was used in the construction
+         of looped lists of data. In the latter case, it typically identifies
+         an item whose unique values are used as the reference key for a loop
+         category and/or an item which has values in common with those of
+         another loop category and is considered a Link between these lists.
+
+         Data items of this type includes both primitive and non-primitive
+         items.
+;
+         Derived
+;
+         Data item was derived from other data items within the domain instance.
+
+         Data items of this type are considered non-primitive.
+;
+
+    _enumeration.default          Assigned
+
+save_
+
+save_UNITS
+
+    _definition.id                UNITS
+    _definition.scope             Category
+    _definition.class             Set
+    _definition.update            2013-03-06
+    _description.text
+;
+    The attributes for specifying units of measure.
+;
+    _name.category_id             ATTRIBUTES
+    _name.object_id               UNITS
+
+save_
+
+save_units.code
+
+    _definition.id                '_units.code'
+    _definition.class             Attribute
+    _definition.update            2023-06-10
+    _description.text
+;
+    A code which identifies the units of measurement.
+
+    The 'unspecified' code should only be used in cases when the units cannot
+    be properly expressed in DDLm. A typical example of such situation is a
+    List data item with constituent values that may have differing units.
+;
+    _name.category_id             units
+    _name.object_id               code
+    _type.purpose                 State
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Code
+
+    _import.get                   [{'file':templ_enum.cif  'save':units_code}]
+
+save_
+
+    loop_
+      _dictionary_valid.scope
+      _dictionary_valid.option
+      _dictionary_valid.attributes
+         Dictionary  Mandatory    ['_dictionary.title'  '_dictionary.class'
+                                   '_dictionary.version'  '_dictionary.date'
+                                   '_dictionary.uri'
+                                   '_dictionary.ddl_conformance'
+                                   '_dictionary.namespace']
+         Dictionary  Recommended  ['_description.text'
+                                   '_dictionary_audit.version'
+                                   '_dictionary_audit.date'
+                                   '_dictionary_audit.revision'
+                                   '_dictionary.doi']
+         Dictionary  Prohibited   [ALIAS  CATEGORY_KEY  DEFINITION
+                                   DESCRIPTION_EXAMPLE  ENUMERATION  IMPORT
+                                   METHOD  NAME  TYPE  UNITS]
+         Category    Mandatory    ['_definition.id'  '_definition.scope'
+                                   '_definition.class'  '_definition.update'
+                                   '_name.category_id'  '_name.object_id']
+         Category    Recommended  ['_category_key.name'  '_description.text']
+         Category    Prohibited   [ALIAS  DICTIONARY  ENUMERATION  TYPE  UNITS]
+         Item        Mandatory    ['_definition.id'  '_definition.update'
+                                   '_name.object_id'  '_name.category_id'
+                                   '_type.container'  '_type.contents']
+         Item        Recommended  ['_definition.scope'  '_definition.class'
+                                   '_type.source'  '_type.purpose'
+                                   '_description.text']
+         Item        Prohibited   [CATEGORY_KEY  DICTIONARY]
+
+    loop_
+      _dictionary_audit.version
+      _dictionary_audit.date
+      _dictionary_audit.revision
+         3.3.0                    2004-11-09
+;
+       Change definition.import_id to definition_import.id in many defs.
+       Insert category DEFINITION_IMPORT and the items .id, .conflict,
+       .protocol and .source.
+;
+         3.3.1                    2004-11-10
+;
+       Make further changes to the DEFINITION_IMPORT definitions and
+       introduce the DEFINITION_TEMPLATE category.
+;
+         3.3.2                    2004-11-11
+;
+       Introduce an IMPORT category containing IMPORT_DICTIONARY,
+       IMPORT_DEFINITION, IMPORT_CATEGORY, IMPORT_ATTRIBUTE.
+       Change DEFINITION_TEMPLATE to IMPORT_TEMPLATE.
+;
+         3.3.3                    2004-11-12
+;
+       Major changes to all the new attributes. Introduce categories
+       DEFINITION_CONTEXT.
+;
+         3.3.4                    2004-11-13
+;
+       Cleaned up the IMPORT changes and cases of enumerates.
+;
+         3.3.5                    2004-11-16
+;
+       Further changes to IMPORT definitions.
+;
+         3.3.6                    2004-11-18
+;
+       Some minor correction of typos.
+;
+         3.3.7                    2005-11-22
+;
+       Changed _dictionary.name to _dictionary.filename.
+       Changed _dictionary_xref.name to _dictionary_xref.filename.
+       Added _dictionary.title to describe the common name of the dictionary.
+;
+         3.3.8                    2005-12-12
+;
+       Changed ddl to ddl_attr.
+       Added Template and Function to _dictionary.class.
+;
+         3.3.9                    2006-02-02
+;
+       Add the definition of _dictionary_xref.source.
+;
+         3.3.10                   2006-02-07
+;
+       Add import attribute definitions.
+;
+         3.4.1                    2006-02-12
+;
+       Remove save frames from dictionary attributes.
+       Change the attribute _dictionary.parent_name to _dictionary.parent_id.
+;
+         3.4.2                    2006-02-16
+;
+       In the import_*.conflict definitions change the enumeration state Unique
+       to Ignore, and change the default state to Error.
+       In the import_*.missing definitions change default enumeration state to
+       Error.
+;
+         3.5.1                    2006-03-07
+;
+       Structural changes to the file to conform with the import model 3.
+       Move the template file for *.relational_id to com_att.dic.
+       Change all references to *.relational_id into the tuple format.
+       Move the _codes_ddl.units_code to enum_set.dic and insert the
+       import_enum_set.id tuples.
+;
+         3.5.2                    2006-03-22
+;
+       Rename _enumeration.default_index_id to _enumeration.def_index_id.
+       Correct the attributes _enumeration_default.index and *.value.
+;
+         3.5.3                    2006-05-09
+;
+       Reword many of the import attributes.
+       Correct the tuple description for import_dictionary.
+       Insert all of the definitions for import_defaults attributes.
+       Update _dictionary.class definition - change "Template" to "Import".
+       Remove _enumeration.scope "open" from _definition_context.domain.
+;
+         3.6.1                    2006-06-16
+;
+       Major revamp of TYPE attributes... changed:
+          _type.value to _type.contents and expand enumeration list.
+          _type.purpose has new role and different enumeration states.
+       _name.object_id changed to _name.object_id.
+       _enumeration_set.code becomes _enumeration_set.state.
+       Changed the _type.value (now .contents) states to match expanded list.
+       Added _dictionary.ddl_conformance attribute.
+       Changed _category.join_set_id to _category.join_cat_id.
+       Remove _enumeration.scope definition.
+;
+         3.6.2                    2006-06-17
+;
+       Change the states of _type.purpose.
+;
+         3.6.3                    2006-06-18
+;
+       Correct _type.contents value in import_dictionary.id.
+;
+         3.6.4                    2006-06-20
+;
+       Change state 'Point' to 'Link' in _type.contents definition.
+       Add Formula to _type.contents.
+;
+         3.6.5                    2006-06-27
+;
+       Change all IMPORT attributes and apply.
+       Add _dictionary.namespace attribute and apply.
+       Add states to _definition.class and apply.
+       Add _enumeration_set.scope.
+       Add .context to ENUMERATE_SET, ENUMERATE_DEFAULT, DESCRIPTION_EXAMPLE
+;
+         3.6.6                    2006-07-18
+;
+       Change the descriptions of the _type.container states.
+       The _enumeration_set.scope removed (enumeration.mandatory used).
+       In _type_array.dimension change _type.contents to List.
+;
+         3.6.7                    2006-08-30
+;
+       Change 'att' to 'sta' in the imports of _type.contents and _units.code.
+       Replace states 'vector' and 'matrix' in _type.container with 'array'.
+       In _type.purpose change 'model' to 'assigned'; 'observe' to 'observed';
+       and 'measure' to 'measured'.
+;
+         3.6.8                    2006-08-31
+;
+       Remove the category TYPE_ARRAY and insert _type.dimension.
+       Replace _description.compact with _description.common.
+       Replace _description.abbreviated with _description.key_words.
+;
+         3.6.9                    2006-10-31
+;
+       Remove all attributes and categories referring to 'context'.
+;
+         3.6.10                   2006-11-09
+;
+       Replace _method.id with method.purpose.
+       Redefine the DICTIONARY_VALID values.
+;
+         3.7.1                    2006-11-16
+;
+       Apply _definition.scope changes.
+       Add _category.parent_join.
+       Add _dictionary.xref_code.
+       Add _enumeration_set.xref_dictionary.
+       Remove all relational keys.
+;
+         3.7.2                    2006-12-05
+;
+       Rewording of description.text in DDL_ATTR and definition.namespace.
+       Rewording of category_mandatory.item_id.
+       Reworded descriptions of definition.class descriptions.
+       Removed dictionary.filename.
+       Corrected examples in type.dimension.
+       Remove dictionary.parent_id and dictionary.parent_uri.
+;
+         3.7.3                    2006-12-21
+;
+       Default for _category.parent_join is now "No".
+;
+         3.7.4                    2007-02-06
+;
+       Change _category_key.item_id to _category_key.generic.
+       Add _category_key.primitive.
+;
+         3.7.5                    2007-02-08
+;
+       Change the _type.purpose of _category_key.generic and .primitive
+       to Identify.
+;
+         3.7.6                    2007-03-18
+;
+       Change the description for _name.linked_item_id.
+;
+         3.7.7                    2007-10-11
+;
+       Correct the _type.dimension assignments to [n[m]].
+       Remove _type_array.dimension from _type.dimension definition.
+;
+         3.7.8                    2008-01-17
+;
+       Change 'Definition' to 'Evaluation' in import_list.id.
+       Changed import.scope entries to leading uc character.
+;
+         3.7.9                    2008-02-12
+;
+       Change 'Itm' to 'Def' in import.scope.
+;
+         3.7.10                   2008-03-28
+;
+       Update the definition of _type.dimension.
+;
+         3.7.11                   2008-05-18
+;
+       Changed 2 type.contents values from "Implied" to "Inherited".
+       Change import_list.id to be ((.....)).
+;
+         3.7.12                   2008-08-05
+;
+       Correct _type.dimension definition.
+;
+         3.7.13                   2011-01-27
+;
+       Change definition scope of Head category to "Dictionary".
+       Remove all tabs and replace with blank string.
+;
+         3.7.14                   2011-03-25
+;
+       In the attribute import_list.id:
+        Change _type.contents  Tuple(Code,Tag,Uri,Code,Code)
+        To     _type.contents  Tuple(Code,Ctag,Uri,Code,Code)
+       In the attribute import.block:
+        Change _type.contents    Tag
+        To     _type.contents    Ctag
+       And change the case examples.
+;
+         3.8.1                    2011-06-07
+;
+       Remove the Tuple and Array enumerations from _type.container.
+       Change category class enumeration from List to Loop; and change
+       all invocations of _category.class in the definitions.
+       Introduce nested save frames for expressing nested categories.
+;
+         3.8.2                    2011-06-21
+;
+       Reconfigure _dictionary_valid attributes into lists, and reset the
+       attribute application criteria at the rear of the DDL dictionary.
+;
+         3.8.3                    2011-06-22
+;
+       Change IMPORT_LIST to IMPORT_TABLE. Change the IMPORT arguments to
+       match this. Change the import_list.id invocations to import_table
+       equivalents. Add _enumeration_set.table_tag.
+;
+         3.8.4                    2011-06-23
+;
+       Remove IMPORT_TABLE. Change the IMPORT to a set category.
+       Insert an import.get attribute to replace import_table.id.
+       Rename the DDL_ATTR category as ATTRIBUTES.
+;
+         3.8.5                    2011-06-27
+;
+       Change the _name.category_id value to reflect the parent category.
+;
+         3.8.6                    2011-06-29
+;
+       Change Reference in _type.purpose to Ref-key.
+;
+         3.8.7                    2011-06-30
+;
+       Change Reference in _definition.class to Ref-loop.
+       Remove import from type.contents and insert enumeration_set list.
+       Insert name.category_id into every category definition.
+;
+         3.8.8                    2011-07-28
+;
+       Add name.category_id and name.object_id to category definitions.
+       Remove category.parent_id from category definitions.
+       Remove definitions for category.parent_id and the CATEGORY_KEY
+       and CATEGORY_MANDATORY definitions. Define category.key_id.
+;
+         3.8.9                    2011-08-15
+;
+       Add the state "Extend" to the type.purpose" attribute.
+;
+         3.9.1                    2011-12-08
+;
+       Add types "Array" and "Matrix" to type.container attribute definition.
+       Add type "Su" to the type.purpose attribute definition.
+;
+         3.9.2                    2012-01-25
+;
+       For import.get change the key "fram" to "save".
+;
+         3.10.1                   2012-05-07
+;
+       Revamp the type.purpose states. Remove state "Limit".
+       Add the new attribute type.source.
+       Change dictionary.class "Attribute" to "Reference".
+       Removed attribute enumeration_set.construct.
+;
+         3.10.2                   2012-10-16
+;
+       Correct enum states for type.contents and type.container.
+;
+         3.10.3                   2012-11-20
+;
+       Remove "Implied" as an enumeration state for type.contents.
+;
+         3.10.4                   2013-02-12
+;
+       Added missing loop statement to methods of dictionary_valid.application.
+       Corrected the definition of the enumeration state 'Code' in
+       type.contents.
+;
+         3.10.5                   2013-02-22
+;
+       Add state value to enum_set loop of import.get defn as the key.
+;
+         3.10.6                   2013-02-25
+;
+       Remove the quotes from Multiple string in type.container definition.
+       Add 'Functions' to the enumeration states of definition.class.
+;
+         3.10.7                   2013-03-03
+;
+       Added type.contents enum state "Implied" for category key definitions.
+;
+         3.10.8                   2013-03-06
+;
+       Added various attributes to conform with ALIGN requirements.
+;
+         3.11.1                   2013-04-11
+;
+       Added type.source to all definitions.
+       Change type.contents state "Table" to "Pairs".
+;
+         3.11.2                   2013-04-16
+;
+       Removed 'Measured' as a state for type.source.
+;
+         3.11.3                   2013-04-24
+;
+       Changed type.source 'Quantity' to 'Number' or 'Encode'.
+       State 'Float' in type.contents removed.
+;
+         3.11.4                   2013-09-08
+;
+       Attribute _alias.deprecation_date added.
+       Attribute _category.key_list      added.
+       The attribute _category.key_list added to all Loop category defs.
+;
+         3.11.5                   2014-09-18
+;
+       Looped category _category_key replaces _category.key_list.
+       Added _category_key.name and changed all occurrences of
+       _category.key_list to _category_key.name.
+       Changed _type.source and _type.purpose to Recommended. (JRH)
+;
+         3.11.6                   2015-01-27
+;
+       Replaced stub category names with full category names in
+       _name.category_id and _name.object_id.
+       Corrected all _category.key_name to _category_key.name. (JRH)
+;
+         3.11.7                   2015-01-27
+;
+       Converted to CIF2 format using automatic tool and post-editing for
+       presentation (JRH).
+;
+         3.11.8                   2015-01-28
+;
+       Created _dictionary_valid.scope and corrected dREL method for
+       _dictionary_valid.application.
+;
+         3.11.9                   2015-05-07
+;
+       Removed _enumerated.table_id and replaced with ByReference attributes
+       _type.contents_referenced_id and _type.indices_referenced_id. Updated
+       _type.contents and _type.purpose to describe the ByReference approach.
+       Fixed _import.get dREL methods by moving individual table entries into
+       a sub-category and adding reference and order attributes. (James Hester/
+       John Bollinger)
+;
+         3.11.10                  2017-01-25
+;
+       Adjusted definition of _import_details.mode to remove references to
+       save frames and add special 'Head' category treatment. Added
+       _dictionary.formalism.
+;
+         3.11.11                  2017-06-10
+;
+       Added '_definition.replaced_by' to flag deprecated definitions.
+;
+         3.12.0                   2017-07-13
+;
+       Clarified character sets and syntax. Fixed incorrect use of Name in
+       '_definition.replaced_by'.
+;
+         3.13.0                   2017-07-23
+;
+       Added _import_details.file_version.  Removed 'Filename' as a data type.
+       Clarified use of URIs in dictionaries. (JRH)
+;
+         3.13.1                   2017-10-26
+;
+       Added 'Implied' container type to allow examples and defaults to adjust
+       to the item being defined. Changed relevant attribute definitions. (JRH)
+;
+         3.14.0                   2019-10-08
+;
+       Updated the description of the _description_example.case data item.
+
+       Updated the description of the 'Key' type purpose and changed the
+       purpose of several data items in order to avoid conflicts with
+       the new description.
+
+       Replaced the _definition.replaced_by data item with a looped
+       DEFINITION_REPLACED category.
+
+       Updated the definition of the _import_details.mode data item.
+
+       Changed the purpose of a dREL method in the definition of the
+       _dictionary_valid.application data item from 'Definition' to
+       'Evaluation'.
+
+       Changed the content type of the _loop.level data item from
+       'Index' to 'Integer'.
+
+       Deprecated the 'Index' and 'Count' content types.
+       Updated the description of the 'Loop' definition class. The new
+       description allows the child data items to appear in a loop-list instead
+       of strictly requiring it ('must' -> 'may').
+;
+         4.0.0                    2020-10-30
+;
+       Removed all xref datanames.
+       Removed LOOP category.
+       Removed complex dataname type (Multiple) and type specifications.
+       Removed non-import use of save frames and ref-loops.
+       Allow Arrays to include string types.
+       Removed purpose "Extend".
+       Removed CATEGORY category and category.key_id.
+       Removed 'Index' and 'Count' content types.
+;
+         4.0.1                    2021-07-20
+;
+       Clarified use of 'SU' data items.
+
+       Updated the _import_details.single_index data item description
+       to explicitly state that the 'file' index can refer not only to
+       URI, but also to URI reference values.
+
+       Updated the definition of the 'Uri' content type to explicitly state
+       that it allows URI-reference values. _alias.dictionary_uri is
+       explicitly an absolute URI.
+
+       Updated the DICTIONARY_VALID category description to explicitly state
+       that the rules only apply to Reference and Instance dictionaries.
+
+       Clarified the interpretation of the _dictionary_valid.option data item.
+
+       Removed the default enumeration value of the _units.code data item.
+
+       Added measurement units to the definition of the _import_details.order
+       data item.
+
+       Clarified use of DESCRIPTION_EXAMPLE category and _description.text.
+;
+         4.0.2                    2021-08-18
+;
+       Deprecated _dictionary_valid.application.
+
+       Marked the DESCRIPTION_EXAMPLE category as prohibited in
+       the 'Dictionary' scope.
+
+       Updated the descriptions of the _type.dimension and _type.container
+       data items to be more consistent with the rest of the dictionary.
+
+       Unified the spelling of certain words.
+;
+         4.1.0                    2023-01-13
+;
+       Added new 'Word' content type.
+
+       Removed _description.common from the list of attributes that
+       are recommended in the 'Item' scope.
+
+       Clarified use of if_dupl replacement when importing.
+
+       Updated the descriptions of the _enumeration.default and
+       _description_example.case data items to explicitly list
+       all the constraints that they inherit from the defining item.
+
+       Improved wording of "Implied" value descriptors.
+
+       Updated the description of the _name.linked_item_id data item.
+
+       Clarified that the "Range" content type can describe half-bounded
+       intervals. Added several usage examples of the _enumeration.range
+       attribute.
+
+       Updated definition of "Integer" in _type.contents.
+
+       Clarified the definition of the "Version" state in _type.contents
+       by explicitly specifying that it adheres to the formal grammar
+       provided in SemVer version 2.0.0.
+;
+         4.2.0                    2025-02-19
+;
+       # Please update the date above and describe the change below until
+       # ready for the next release
+
+       Added the "unspecified" enumeration value for the _units.code attribute.
+
+       Added DICTIONARY_AUTHOR to allow details of dictionary authors to be
+       recorded.
+
+       Added _dictionary.doi to record the persistent Digital Object Identifier
+       of a dictionary.
+
+       Added _enumeration.def_index_ids and ENUMERATION_DEFAULTS to allow
+       default values to be dependent on multiple keys. Deprecated the
+       _enumeration.def_index_id attribute and the ENUMERATION_DEFAULT category.
+
+       Added ENUMERATION_SOURCE and _enumeration_defaults.source_id to allow
+       the source of default enumeration values to be recorded.
+
+       Added 'Inherited' as an enumeration value to _type.contents.
+
+       Updated the description of _type.source and _method.purpose attributes.
+
+       Clarified the use of the 'SU' state of the _type.purpose attribute.
+
+       Changed _description.text of _dictionary.namespace to say "trailing
+       double colon '::' " in accordance with DDLm specs and other
+       discussion in Volume G 2ed (bm).
+
+       Some cosmetic changes (single quotes instead of double) to match
+       IUCr house style and angle brackets around <yyyy>-<mm>-<dd> (bm).
+
+       Updated the _enumeration_set.state attribute to inherit various
+       properties from the defining data item.
+
+       Explicitly specified that the _type.contents attribute value 'Implied'
+       can only be applied in the DDLm Reference dictionary.
+
+       Updated the description of the 'Symop' content type.
+
+       Updated the definition of the _method.expression attribute.
+
+       Updated definition of the _alias.deprecation_date attribute.
+       Updated definition of the _alias.dictionary_uri attribute.
+       Added the _alias.dictionary_version attribute.
+
+       Added _definition.update to the list of attributes that are mandatory
+       in the 'Category' scope.
+;

--- a/dictionaries/ddl_core_DDL1.dic
+++ b/dictionaries/ddl_core_DDL1.dic
@@ -1,0 +1,503 @@
+##############################################################################
+#                                                                            #
+#                             DDL CORE DICTIONARY                            #
+#                                                                            #
+##############################################################################
+
+
+data_on_this_dictionary
+
+    _dictionary_name            ddl_core.dic
+    _dictionary_version         1.4.3-dev-1
+    _dictionary_update          2021-03-19
+    _dictionary_history
+;
+  1991-03-08 "Implementing SMD in STAR: Dictionary Definition Language"
+                 A F P Cook, ORAC Ltd., 8 March 1991. AFPC
+  1991-06-25  Adjustments and refinement for CIF applications. SRH
+  1991-09-02  Further refinements prior to "cifdic.c91". SRH
+  1993-05-10  Additions arising from discussions with Phil Bourne,
+                 Tony Cook, Brian McMahon. SRH
+  1993-05-11  Further adjustments and Cyclops tests. SRH
+  1993-05-14  Proposed additional changes. PEB
+  1993-05-17  Further adjustments. SRH
+  1993-06-01  Refinements and additions. SRH
+  1993-07-19  Some tidying up. SRH
+  1993-08-10  Final checks before Beijing. SRH
+  1993-12-12  Following the Cambridge meeting with FHA and AFPC. SRH
+  1993-12-16  Following discussions with Brian McMahon in Chester. SRH
+  1993-12-17  Further adjustments. SRH
+  1994-02-18  Add _include_file provisions. SRH
+  1994-08-08  Install _type_construct definitions and apply. SRH
+  1994-08-24  Adjustments following Brian McMahon's comments. SRH
+  1994-11-16  Changes following Brussels workshop. SRH
+  1995-05-16  Changes to _units definitions. SRH
+  2005-02-09  Minor corrections to spelling and punctuation. Reference
+              to REGEX specifications updated. NJA
+  2005-06-11  Structural change to rationalise DDL1 dictionary against
+              specification documents in IT Vol. G. Initial global_ block
+              removed, "_enumeration_default none" added to definition of
+              _type_conditions and "_enumeration_default .*" to definition
+              of _type_construct. BMcM
+  2005-06-20  Minor corrections to reflect proof corrections for Chapter
+              4.9 of IT Vol. G. NJA
+  2005-06-29  Allow use of 'su' as synonym for 'esd' in _type_conditions
+              and describe 'esd' as 'deprecated'. BMcM
+  2017-07-14  Maintenance update: updated the _dictionary_version data item.
+              The type was changed from 'numb' to 'char', the construct type
+              was added and the definition was updated accordingly. AV
+  2017-07-14  Maintenance update: modified the _enumeration_range to allow
+              values that only contain an upper limit. AV
+  2021-03-19  Maintenance update: added several more examples to
+              the _unit data item definition. AV
+;
+
+
+data_category
+    _definition
+;              Character string which identifies the natural grouping of data
+               items to which the specified data item belongs. If the data
+               item belongs in a looped list, then it must be grouped only with
+               items from the same category, but there may be more than one
+               looped list of the same category provided that each loop has its
+               own independent reference item (see _list_reference).
+;
+    _name                      '_category'
+    _category                    category
+    _type                        char
+
+
+data_definition
+    _definition
+;              The text description of the defined item.
+;
+    _name                      '_definition'
+    _category                    definition
+    _type                        char
+
+
+data_dictionary_history
+    _definition
+;              A chronological record of the changes to the dictionary file
+               containing the definition. Normally this item is stored in the
+               separate data block labelled data_on_this_dictionary.
+;
+    _name                      '_dictionary_history'
+    _category                    dictionary
+    _type                        char
+
+
+data_dictionary_name
+    _definition
+;              The name string which identifies the generic identity of
+               the dictionary. The standard construction for these names is
+                       <application code>_<dictionary version>.dic
+               Normally this item is stored in the separate data block
+               labelled data_on_this_dictionary.
+;
+    _name                      '_dictionary_name'
+    _category                    dictionary
+    _type                        char
+    loop_ _example               ddl_core.dic  cif_core.dic
+
+
+data_dictionary_update
+    _definition
+;              The date that the dictionary was last updated.
+               Normally this item is stored in the separate data block
+               labelled data_on_this_dictionary.
+;
+    _name                      '_dictionary_update'
+    _category                    dictionary
+    _type                        char
+    _type_construct
+                   (_chronology_year)-(_chronology_month)-(_chronology_day)
+
+
+data_dictionary_version
+    _definition
+;              The dictionary version number string of the form
+               <major>.<minor>.<patch> where each part consists of non-negative
+               integers without leading zeros. Version numbers cannot decrease
+               with updates. Normally this item is stored in the separate data
+               block labelled data_on_this_dictionary.
+;
+    _name                      '_dictionary_version'
+    _category                    dictionary
+    _type                        char
+    _type_construct
+                 # ((0)|([1-9][0-9]*))[.]((0)|([1-9][0-9]*))[.]((0)|([1-9][0-9]*))
+                   (_major_version)[.](_minor_version)[.](_patch_version)
+    loop_
+    _example
+    1.0.0
+    0.23.0
+    1.5.16
+
+
+data_enumeration
+    _definition
+;              Permitted value(s) for the defined item.
+;
+    _name                      '_enumeration'
+    _category                    enumeration
+    _type                        char
+    _list                        both
+    _list_mandatory              yes
+
+
+data_enumeration_default
+    _definition
+;              The default value for the defined item if it is not specified
+               explicitly. If a data value is not declared, the default is
+               assumed to be the "most likely" or "natural" value.
+;
+    _name                      '_enumeration_default'
+    _category                    enumeration_default
+    _type                        char
+
+
+data_enumeration_detail
+    _definition
+;              A description of the permitted value(s) for the defined item, as
+               identified by _enumeration.
+;
+    _name                      '_enumeration_detail'
+    _category                    enumeration
+    _type                        char
+    _list                        both
+    _list_reference            '_enumeration'
+
+
+data_enumeration_range
+    _definition
+;              The range of values permitted for a defined item. This can
+               apply to 'numb' or 'char' items which have a preordained
+               sequence (e.g. numbers or alphabetical characters).
+               The minimum value 'min' and maximum value 'max' are separated 
+               by a colon character. If 'max' is omitted, then the item can
+               have any permitted value greater than or equal to 'min';
+               alternatively, if 'min' is omitted, then the item can have
+               any permitted value less than or equal to 'max'.
+;
+    _name                      '_enumeration_range'
+    _category                    enumeration_range
+    _type                        char
+    _type_construct            ((_sequence_minimum):((_sequence_maximum)?))|(:(_sequence_maximum))
+    loop_ _example                -4:10   a:z    B:R   0:   :100
+
+
+data_example
+    _definition
+;              An example value of the defined item.
+;
+    _name                      '_example'
+    _category                    example
+    _type                        char
+    _list                        both
+    _list_mandatory              yes
+
+
+data_example_detail
+    _definition
+;              A description of an example value for the defined item.
+;
+    _name                      '_example_detail'
+    _category                    example
+    _type                        char
+    _list                        both
+    _list_reference            '_example'
+
+
+data_list
+    _definition
+;              Signals whether the defined item is declared in a looped list.
+;
+    _name                      '_list'
+    _category                    list
+    _type                        char
+    loop_ _enumeration
+          _enumeration_detail   yes   'can only be declared in a looped list'
+                                no    'cannot be declared in a looped list'
+                                both  'declaration in a looped list optional'
+    _enumeration_default        no
+
+
+data_list_level
+    _definition
+;              Specifies the level of the loop structure in which a defined
+               item with the attribute _list 'yes' or 'both' must be declared.
+;
+    _name                      '_list_level'
+    _category                    list
+    _type                        numb
+    _enumeration_range           1:
+    _enumeration_default         1
+
+
+data_list_link_child
+    _definition
+;              Identifies data item(s) by name which must have a value which
+               matches that of the defined item. These items are referred to
+               as "child" references because they depend on the existence
+               of the defined item.
+;
+    _name                      '_list_link_child'
+    _category                    list_link_child
+    _type                        char
+    _list                        both
+
+
+data_list_link_parent
+    _definition
+;              Identifies a data item by name which must have a value which
+               matches that of the defined item, and which must be present in
+               the same data block as the defined item. This provides for a
+               reference to the "parent" data item.
+;
+    _name                      '_list_link_parent'
+    _category                    list_link_parent
+    _type                        char
+    _list                        both
+
+
+data_list_mandatory
+    _definition
+;               Signals whether the defined item must be present in the loop
+                structure containing other items of the designated _category.
+                This property is transferable to another data item which is
+                identified by _related_item and has _related_function set as
+                'alternate'.
+;
+    _name                      '_list_mandatory'
+    _category                    list
+    _type                        char
+    loop_ _enumeration
+          _enumeration_detail
+                           yes  'required item in this category of looped list'
+                           no   'optional item in this category of looped list'
+    _enumeration_default         no
+
+
+data_list_reference
+    _definition
+;              Identifies the data item, or items, which must be present
+               (collectively) in a looped list with the defined data item
+               for the loop structure to be valid. The data item(s)
+               identified by _list_reference provide a unique access code
+               to each loop packet. Note that this property may be
+               transferred to another item with _related_function 'alternate'.
+;
+    _name                      '_list_reference'
+    _category                    list_reference
+    _type                        char
+    _list                        both
+
+
+data_list_uniqueness
+    _definition
+;              Identifies data items which, collectively, must have unique
+               values for the loop structure of the designated _category items
+               to be valid. This attribute is specified in the
+               definition of a data item with _list_mandatory set to 'yes'.
+;
+    _name                      '_list_uniqueness'
+    _category                    list_uniqueness
+    _type                        char
+    _list                        both
+
+
+data_name
+    _definition
+;              The data name(s) of the defined item(s). If data items are
+               closely related or represent an irreducible set, their names
+               may be declared as a looped sequence in the same definition.
+;
+    _name                      '_name'
+    _category                    name
+    _type                        char
+    _list                        both
+    loop_ _example             '_atom_site_label'
+                               '_atom_attach_all   _atom_attach_ring'
+                               '_index_h   _index_k   _index_l'
+                               '_matrix_11 _matrix_12 _matrix_21 _matrix_22'
+
+
+data_related_item
+    _definition
+;              Identifies data item(s) which have a classified relationship
+               to the defined data item. The nature of this relationship is
+               specified by _related_function.
+;
+    _name                      '_related_item'
+    _category                    related
+    _type                        char
+    _list                        both
+    _list_mandatory              yes
+
+
+data_related_function
+    _definition
+;              Specifies the relationship between the defined item and the
+               item specified by _related_item. The following classifications
+               are recognized.
+
+               'alternate' signals that the item referred to in _related_item
+               has attributes that permit it to be used as an alternative to the
+               defined item for validation purposes.
+
+               'convention' signals that the item referred to in _related_item
+               is equivalent to the defined item except for a predefined
+               convention which requires a different _enumeration set.
+
+               'conversion' signals that the item referred to in _related_item
+               is equivalent to the defined item except that different scaling
+               or conversion factors are applied.
+
+               'replace' signals that the item referred to in _related_item
+               may be used identically to replace the defined item.
+;
+    _name                      '_related_function'
+    _category                    related
+    _type                        char
+    _list                        yes
+    _list_reference            '_related_item'
+    loop_ _enumeration
+          _enumeration_detail
+                         alternate  'used alternatively for validation tests'
+                         convention 'equivalent except for defined convention'
+                         conversion 'equivalent except for conversion factor'
+                         replace    'new definition replaces the current one'
+
+
+data_type
+    _definition
+;              The type specification of the defined item.
+
+               Type 'numb' identifies items which must have values that are
+               identifiable numbers. The acceptable syntax for these numbers
+               is application-dependent, but the formats illustrated by the
+               following identical numbers are considered to be interchangeable:
+               42   42.000  0.42E2  .42E+2  4.2E1  420000D-4  0.0000042D+07
+
+               Type 'char' identifies items which need not be interpretable
+               numbers. The specification of these items must comply with the
+               STAR syntax specification of either a 'contiguous single-line
+               string' bounded by blanks or blank-quotes, or a 'text string'
+               bounded by semicolons as the first character of a line.
+
+               Type 'null' identifies items which appear in the dictionary
+               for data-definition and descriptive purposes. These items
+               serve no function outside the dictionary files.
+;
+    _name                      '_type'
+    _category                    type
+    _type                        char
+    loop_ _enumeration
+          _enumeration_detail   numb  'numerically interpretable string'
+                                char  'character or text string'
+                                null  'for dictionary purposes only'
+
+
+data_type_conditions
+    _definition
+;              Codes defining conditions on the _type specification.
+
+               'su' permits a number string to contain an appended standard
+               uncertainty number enclosed within parentheses. E.g. 4.37(5)
+
+               'esd' is a deprecated synonym for 'su', arising from the
+               former use of the term 'estimated standard deviation'
+               for 'standard uncertainty', and permitting a number string to
+               contain an appended standard deviation within parentheses.
+               E.g. 4.37(5)
+
+               'seq' permits data to be declared as a sequence of values
+               separated by a comma <,> or a colon <:>.
+                  * The sequence v1,v2,v3,. signals that v1, v2, v3, etc.
+                    are alternative values.
+                  * The sequence v1:v2 signals that v1 and v2 are the boundary
+                    values of a continuous range of values satisfying the
+                    requirements of _enumeration for the defined item.
+               Combinations of alternative and range sequences are permitted.
+;
+    _name                      '_type_conditions'
+    _category                    type_conditions
+    _type                        char
+    _list                        both
+    _enumeration_default         none
+    loop_ _enumeration
+          _enumeration_detail
+
+                none   'no extra conditions apply to the defined _type'
+                esd    'synonym for su'
+                seq    'data may be declared as a permitted sequence'
+                su     'numbers *may* have s.u.'s appended within parentheses'
+
+
+data_type_construct
+    _definition
+;              String of characters specifying the construction of the data
+               value for the defined data item. The construction is composed
+               of two entities:
+                  (1) data names
+                  (2) construction characters
+               The rules of construction conform to the regular expression
+               (REGEX) specifications detailed in IEEE (1991) and International
+               Tables for Crystallography Volume G, Chapter 2.5.
+
+               Ref: IEEE (1991). IEEE Standard for Information Technology -
+               Portable Operating System Interface (POSIX) - Part 2: Shell
+               and Utilities, Vol. 1, IEEE Standard 1003.2-1992. New York:
+               The Institute of Electrical Engineers. International Tables for
+               Crystallography (2005). Vol. G, Definition and Exchange of
+               Crystallographic Data, edited by S. R. Hall and B. McMahon.
+               Heidelberg: Springer.
+;
+    _name                      '_type_construct'
+    _category                    type_construct
+    _type                        char
+    _enumeration_default         .*
+    _example                   (_year)-(_month)-(_day)
+    _example_detail            'a typical construction for _date'
+
+
+data_units
+    _definition
+;              A unique code which identifies the units of the defined data
+               item. A description of the units is provided in _units_detail.
+;
+    _name                      '_units'
+    _category                    units
+    _type                        char
+    loop_ _example
+          _example_detail
+                K    'kelvin'
+                C    'degree Celsius'
+                rad  'radian'
+                deg  'degree of arc'
+                e    'electron'
+                V    'volt'
+                Da   'dalton'
+                m    'metre'
+                A      'angstrom'
+                A^2^   'angstrom squared'
+                A^3^   'angstrom cubed'
+                A^-1^  'reciprocal angstrom'
+                A^-2^  'reciprocal angstrom squared'
+                kg     'kilogram'
+                s      'second'
+                Mg/m^3^ 'megagram per metre cubed'
+                e/A^3^  'electron per angstrom cubed'
+
+data_units_detail
+    _definition
+;              A description of the numerical units applicable to the defined
+               item and identified by the code _units.
+;
+    _name                      '_units_detail'
+    _category                    units
+    _type                        char
+
+
+#-eof-eof-eof-eof-eof-eof-eof-eof-eof-eof-eof-eof-eof-eof-eof-eof-eof-eof-eof

--- a/dictionaries/mmcif_ddl.dic
+++ b/dictionaries/mmcif_ddl.dic
@@ -1,0 +1,6814 @@
+data_mmcif_ddl.dic
+
+_datablock.id           mmcif_ddl.dic
+_datablock.description  
+;
+     This data block holds the core DDL.
+;
+
+#
+_dictionary.datablock_id  mmcif_ddl.dic
+_dictionary.title         mmcif_ddl.dic
+_dictionary.version       2.3.3
+#
+loop_
+_dictionary_history.version
+_dictionary_history.update
+_dictionary_history.revision
+1.1     1994-07-25  
+;
+       DDL 1.1 from Syd Hall et. al.
+;
+  
+1.2.1   1994-09-18  
+;
+       Changes:.........etc. etc. John Westbrook
+;
+  
+1.2.9   1994-10-05  
+;
+       Reflect the results of the Treaty of Brussels. JW.
+;
+  
+2.0.1   1994-10-15  
+;
+       Adapted for closer mapping to DDL1.3 and clearer presentation. SRH/NS.
+;
+  
+2.0.2   1994-10-16  
+;
+       Even closer...................  SRH/NS.
+;
+  
+2.0.3   1994-10-17  
+;
+       Coming to grips with the links and dependencies..... SRH/NS.
+;
+  
+2.0.4   1994-10-20  
+;
+       Backed in changes from mm-ddl 1.2.12
+       Many other changes  ...  (JW)
+;
+  
+2.0.5   1994-10-20  
+;
+       Some small adjustments..........SRH.
+;
+  
+2.0.6   1994-10-20  
+;
+       More small adjustments..........JW.
+;
+  
+2.0.7   1994-11-03  
+;
+       Changes:  (JW)
+         + Place all item and item_linked category definitions with the parent
+           item.
+         + Fixed a number of not so trivial typos.
+         + Corrected errors in the data type conversion table.
+         + Corrected key item inconsistencies.
+         + Added the item_aliases category.
+;
+  
+2.0.8   1994-11-10  
+;
+       Miscellaneous corrections:  (JW)
+         +    defined sub_category_group
+         +    corrected typo in category_examples.id definition
+         +    added  _item_type_conditions.name in item category
+         +    added  _item_structure.name in item category
+         +    corrected typo in item_aliases category definition
+         +    corrected typo in sub_category.method_id  definition
+;
+  
+2.0.9   1994-11-14  
+;
+       Changes: (JW)
+         +    added ITEM_UNITS, ITEM_UNITS_LIST, and UNITS_CONVERSION
+              categories.
+         +    added an additional primitive type for character type items
+              for which comparisons must be case insensitive.
+              Since it is customary to permit item names and category
+              identifiers to be specified in mixed case, it is necessary
+              to declare that case should NOT be considered in any
+              comparisons of these items.
+;
+  
+2.0.10  1994-11-23  
+;
+       Changes: (JW)
+         +    Several name category changes for the sake of consistency:
+                enumeration         -> item_enumeration
+                enumeration_default -> item_enumeration_default
+                enumeration_limit   -> item_enumeration_limit
+                units_conversion    -> item_units_conversion
+         +    Added _item_related.function_code alternate_exclusive
+              to identify mutually exclusive alternative declarations
+              of the same item.
+         +    Added structure options for real symmetric matrices.
+         +    Changed from zero based indices to one based indices
+              for compatibility with existing matrix component
+              definitions.
+         +    Add _item_linked.parent_name to the key of the item_linked
+              category.
+         +    Reorder items in the DDL so be alphabetical within
+              category groups.
+;
+  
+2.0.11  1994-11-28  
+;
+       Changes: (JW)
+         +    Corrected spelling error for the data type code in
+              the DICTIONARY_HISTORY category.
+         +    Add category BLOCK to hold the data block name and data
+              block description.  The block identifier was also added
+              to  the key of the item category.  The block identifier
+              can be implicitly derived from the STAR "data_" delimiter.
+              This identifier is required to form the key for categories
+              which are conceptually related to the data block as a
+              whole.
+;
+  
+2.0.12  1994-11-30  
+;
+       Changes: (JW)
+         +    Added a data item _block.scope to indicate the scope of
+              data item names defined within included data blocks.
+;
+  
+2.0.13  1994-12-12  
+;
+       Changes: (JW)
+         +    Deleted data item _block.scope.
+         +    Changed DICTIONARY category key to _dictionary.block_id
+              to guarantee only one dictionary definition per block.
+         +    Deleted data item _item.block_id as this will be replaced
+              by an item address syntax that will include block, save
+              frame, and url.
+;
+  
+2.0.14  1994-12-15  
+;
+       Changes: (JW)
+         +    Made some terminology changes suggested by PMDF
+              _item_enumeration.code   -> _item_enumeration.value
+              ITEM_ENUMERATION_DEFAULT -> ITEM_DEFAULT
+              ITEM_ENUMERATION_LIMIT   -> ITEM_RANGE
+         +    Added item _item_type_list.detail
+         +    Version 2.0.14 is being frozen and exported.
+;
+  
+2.0.15  1995-02-13  
+;
+       Changes: (JW)
+         +    Added '_' prefix to all data item save frame names.
+              References to data item names now always include
+              a leading underscore independent of the usage context.
+         +    A few miscellaneous corrections.
+;
+  
+2.0.16  1995-06-18  
+;
+       Changes: (JW)
+         +    Revised the block level categories in the following ways:
+                Changed category BLOCK to DATA_BLOCK.
+                Added connection from _data_block.id to _category.implicit_key
+                in order to provide a formal means of merging the contents
+                of categories between data blocks.
+         +    Moved enumerations for _method_list.code and
+              method_list.language to examples.
+         +    Removed symmetric matrix options from the enumerations
+              for _item_structure.organization.
+         +    Added _item_related.function codes for 'associated_value',
+              'associated_esd', 'replaces' and 'replacedby'
+         +    Added data items _item_aliases.dictionary and
+              _item_aliases.dictionary_version.
+         +    Reorganized method categories such that multiple methods can
+              be applied at each level of data structure.  Introduced a
+              consistent set of categories to hold method associations:
+              ITEM_METHODS, CATEGORY_METHODS, SUB_CATEGORY_METHODS, and
+              DATA_BLOCK_METHODS.  Removed data items  _category.method_id
+              _sub_category.method_id.
+;
+  
+2.0.17  1995-06-22  
+;
+       Changes: (JW)
+         +    Quoted data values containing the leading string  'data_'.
+;
+  
+2.1.0   1995-07-20  
+;
+       Changes: (JW)
+       Final adjustments before the first release of the mmCIF dictionary:
+             + changed data_block to datablock to avoid any problems with
+               the STAR data_ reserved token.
+             + created new category to hold item subcategory associations
+               and deleted the subcategory attribute from ITEM category.
+             + modified regular expressions to reflect limitations observed
+               on several platforms.
+             + expanded the enumeration of _item_related.function_code.
+             + removed default value from _item.mandatory_code.
+             + removed type construct for date and changed date data type
+               to yyyy-mm-dd
+             + added less restrictive data type for alias names.
+;
+  
+2.1.1   1995-09-26  
+;
+       Changes: (JW)
+             + Changed regular expressions for type code to permit
+               single quote.
+             + Corrected regular expression syntax for type name and
+               type date.
+             + Corrected lower bound description for item_range.minimum.
+               The incorrect <= condition is changed to <.
+             + _item_mandatory.code has been now a mandatory item.
+             + _item_aliases.dictionary and _item_aliases.dictionary_version
+               are added to the composite key for category ITEM_ALIASES.
+             + _datablock.id data type changes to type code.
+             + Shortened the name _item_aliases.dictionary_version to
+               _item_aliases.version
+;
+  
+2.1.2   1997-01-24  
+;
+       Changes: (JW)
+             + Added associated_error to the enumeration list of
+               _item_related.function_code.
+;
+  
+2.1.3   2000-10-16  
+;
+       Changes: (JW)
+             + Changed data type for regular expression in
+               _item_type_list.construct to type text.
+;
+  
+2.1.5   2003-06-23  
+;      Changes: (JW)
+             + NDB extensions adopted into ddl_core
+             + New partitioning scheme implemented
+;
+  
+2.1.6   2004-04-15  
+;      Changes: (JW)
+             + Name changed to mmcif_ddl.dic
+;
+  
+2.1.7   2007-05-30  
+;      Changes: (JW)
+	_items_examples.case, _item_range.minimum/maximum made mandatory.
+;
+  
+2.1.8   2008-10-31  
+;      Changes: (JW)
+	+ Add categories pdbx_item_link_group and pdbx_item_link_group_list
+;
+  
+2.1.9   2009-01-15  
+;      Changes: (JW)
+       + _ndb_item_examples.detail made optional
+;
+  
+2.1.10  2009-01-19  
+;      Changes: (JW)
+       + Add _item.mandatory_code enumeration implicit-ordinal to provide
+         an automatically generated ordinal index data item.   This feature
+         is added to address problems where the natural category key may
+         contain an undefined value (e.g. '.').
+;
+  
+2.1.11  2009-11-02  
+;      Changes: (JW)
+       + Add categories pdbx_item_context and pdbx_category_context
+;
+  
+2.1.12  2012-09-01  
+;      Changes: (JW) -
+       + Add categories ndb_item_range, ndb_item and ndb_item_type
+       + Add alternate categories under PDBx prefix:
+	pdbx_item_range,pdbx_item_type,pdbx_item,pdbx_category_description,
+	pdbx_category_examples,pdbx_item_description,pdbx_item_enumeration,
+	and pdbx_item_examples.
+;
+  
+2.1.13  2013-09-23  
+;      Changes: (JW) -
+       + Add _category.NX_mapping_details for Nexus correspondences.
+;
+  
+2.1.14  2013-10-14  
+;      Changes: (JW) -
+       + Add category pdbx_item_enumeration_details describing additional controls
+         for enumerated data items at deposition.
+;
+  
+2.1.15  2014-03-10  
+;      Changes: (JW) -
+       + Add enumerations for pdbx_item_enumeration_details.closed_flag
+;
+  
+2.1.16  2017-08-17  
+;      Changes: (JW) -
+       + Add extension categories pdbx_include_dictionary, pdbx_include_category,
+         pdbx_include_item, pdbx_dictionary_component and pdbx_dictionary_component_history,
+         pdbx_item_linked, pdbx_item_value_condition, and pdbx_item_value_condition_list.
+;
+  
+2.1.17  2019-04-04  
+;     Changes: (JW)
+      + Add extension item _item_sub_category.pdbx_label
+;
+  
+2.2.1   2019-06-05  
+;      Changes (JW):
+       +  Add items _method_list.method_source and _method_list.implementation_source
+       +  Make item _method_list.inline optional
+       +  Update examples for items in category method_list
+;
+  
+2.2.2   2020-06-05  
+;      Changes (JW):
+       +  Add items _item_enumeration.rcsb_detail_brief and _item_enumeration.rcsb_type_units_code
+;
+  
+2.3.0   2021-04-07  
+;      Changes (JW):
+       + Add generator for pdbx_dictionary_include/pdbx_category_include/pdbx_item_include
+       + Miscellaneous updates in item/category descriptions
+       + Add DATA or DEFINITION contexts to all DDL categories.
+;
+  
+2.3.1   2021-05-29  
+;      Changes (JW):
+       + Updated mmcif_ddl-ext-pdbx.dic extension including new items _pdbx_item_enumeration.value_display
+         and _item_enumeration.pdbx_value_display
+;
+  
+2.3.2   2021-06-02  
+;      Changes (JW):
+       + Updated mmcif_ddl-ext-pdbx.dic extension including new categories pdbx_item_set and pdbx_item_set_type_list
+;
+  
+2.3.3   2021-08-31  
+;      Changes (EP):
+       + Updated mmcif_ddl-ext-pdbx.dic extension including new categories
+         pdbx_category_conditional_context, pdbx_item_conditional_context
+	 and pdbx_conditional_context_list
+;
+  
+#
+loop_
+_item_type_list.code
+_item_type_list.primitive_code
+_item_type_list.detail
+_item_type_list.construct
+code        char   "A single word"                                     '[^\t\n "]*'  
+char        char   "A single line of text"                             "[^\n]*"  
+text        char   "Text which may span lines"                         .*  
+int         numb   "Unsigned integer data"                             "[0 -9]+"  
+name        uchar  "A data item name (restrictive type)"               "_[_A-Za-z0-9]+[.][][_A-Za-z0-9\<\>%/-]+"  
+aliasname   uchar  "A DDL 1.4 data item name (less restrictive type)"  '_[^\t\n "]+'  
+idname      uchar  "A data item name component or identifier"          "[_A-Za-z0-9]+"  
+any         char   "Any data type"                                     .*  
+yyyy-mm-dd  char   "A date format"                                     "[0-9][0-9][0-9][0-9]-[0-9]?[0-9]-[0-9][0-9]"  
+url         char   "Universal resource locator (URL) pattern"          
+;(?i)\b((?:[a-z][\w-]+:(?:/{1,3}|[a-z0-9%])|www\d{0,3}[.]|[a-z0-9.\-]+[.][a-z]{2,4}/)(?:[^\s()<>]+|\(([^\s()<>]+|(\([^\s()<>]+\)))*\))+(?:\(([^\s()<>]+|(\([^\s()<>]+\)))*\)|[^\s`!()\[\]{};:'".,<>?&#171;&#187;&#8220;&#8221;&#8216;&#8217;]))
+;
+  
+#
+loop_
+_category_group_list.id
+_category_group_list.parent_id
+_category_group_list.description
+ddl_group           .          
+;
+     Component categories of the macromolecular DDL
+;
+  
+datablock_group     ddl_group  
+;
+     Categories that describe the characteristics of data blocks.
+;
+  
+category_group      ddl_group  
+;
+     Categories that describe the characteristics of categories.
+;
+  
+sub_category_group  ddl_group  
+;
+     Categories that describe the characteristics of subcategories.
+;
+  
+item_group          ddl_group  
+;
+     Categories that describe the characteristics of data items.
+;
+  
+dictionary_group    ddl_group  
+;
+     Categories that describe the dictionary.
+;
+  
+compliance_group    ddl_group  
+;
+     Categories that are retained specifically for compliance with
+     older versions of the DDL.
+;
+  
+extension_group     ddl_group  
+;
+     Categories that contain extensions used by the NDB and wwPDB.
+;
+  
+#
+loop_
+_pdbx_dictionary_component.datablock_id
+_pdbx_dictionary_component.dictionary_component_id
+_pdbx_dictionary_component.title
+_pdbx_dictionary_component.version
+mmcif_ddl-ext-nx.dic         mmcif_ddl-ext-nx.dic         "mmCIF DDL Nexus (NX) extensions"                    1.1.0   
+mmcif_ddl-ext-ndb.dic        mmcif_ddl-ext-ndb.dic        "mmCIF DDL Nucleic Acid Database (NDB) extensions"   1.4.0   
+mmcif_ddl-ext-pdbx.dic       mmcif_ddl-ext-pdbx.dic       "mmCIF DDL Protein Data Bank (PDBx) extensions"      1.10.0  
+mmcif_ddl-ext-compose.dic    mmcif_ddl-ext-compose.dic    "mmCIF DDL PDBx Dictionary Composition Extensions"   1.1.0   
+mmcif_ddl-ext-condition.dic  mmcif_ddl-ext-condition.dic  "mmCIF DDL PDBx Conditional Value Extensions"        1.2.0   
+mmcif_ddl-ext-rcsb.dic       mmcif_ddl-ext-rcsb.dic       "mmCIF DDL RCSB Protein Data Bank (PDB) extensions"  1.1.0   
+#
+loop_
+_pdbx_dictionary_component_history.dictionary_component_id
+_pdbx_dictionary_component_history.version
+_pdbx_dictionary_component_history.update
+_pdbx_dictionary_component_history.revision
+mmcif_ddl-ext-nx.dic         1.0.0   2013-09-23  
+;
+Changes: (JW) -
++ Add item _category.NX_mapping_details for Nexus correspondences.
+;
+  
+mmcif_ddl-ext-nx.dic         1.1.0   2021-03-30  
+;
+Changes (JW):
++ Migrate to dictionary component mmcif_ddl-ext-nx.dic.
+;
+  
+mmcif_ddl-ext-ndb.dic        1.0.0   2003-06-23  
+;
+Changes: (JW)
++ Preliminary version of NDB extensions including categories ndb_category_description,
+  ndb_category_examples, ndb_item_description, ndb_item_enumeration, and ndb_item_examples
+;
+  
+mmcif_ddl-ext-ndb.dic        1.1.0   2009-01-15  
+;
+Changes: (JW)
++ _ndb_item_examples.detail make optional
+;
+  
+mmcif_ddl-ext-ndb.dic        1.2.0   2012-09-01  
+;
+Changes: (JW) -
++ Added categories ndb_item_range, ndb_item and ndb_item_type
+;
+  
+mmcif_ddl-ext-ndb.dic        1.3.0   2021-03-30  
+;
+Changes (JW):
++ Migrate to dictionary component mmcif_ddl-ext-ndb.dic.
+;
+  
+mmcif_ddl-ext-ndb.dic        1.4.0   2021-04-05  
+;
+Changes (JW):
++ Add to pdbx_item_linked_group and pdbx_item_linked_group_list details
+;
+  
+mmcif_ddl-ext-pdbx.dic       1.0.0   2008-10-31  
+;
+Changes: (JW)
++ Add categories pdbx_item_link_group and pdbx_item_link_group_list
+;
+  
+mmcif_ddl-ext-pdbx.dic       1.1.0   2009-11-02  
+;
+Changes: (JW)
++ Add categories pdbx_item_context and pdbx_category_context
+;
+  
+mmcif_ddl-ext-pdbx.dic       1.2.0   2012-09-01  
+;
+Changes: (JW) -
++ Add alternate categories under PDBx prefix:
+  pdbx_item_range,pdbx_item_type,pdbx_item,pdbx_category_description,
+  pdbx_category_examples,pdbx_item_description,pdbx_item_enumeration,
+  and pdbx_item_examples.
+;
+  
+mmcif_ddl-ext-pdbx.dic       1.3.0   2013-10-14  
+;
+Changes: (JW) -
++ Add category pdbx_item_enumeration_details describing additional controls
+  for enumerated data items at deposition.
+;
+  
+mmcif_ddl-ext-pdbx.dic       1.4.0   2014-03-10  
+;
+Changes: (JW) -
++ Add enumerations for pdbx_item_enumeration_details.closed_flag
+;
+  
+mmcif_ddl-ext-pdbx.dic       1.5.0   2019-04-04  
+;
+Changes: (JW)
++ Add extension item _item_sub_category.pdbx_label
+;
+  
+mmcif_ddl-ext-pdbx.dic       1.6.0   2021-03-30  
+;
+Changes (JW):
++ Migrate to dictionary component mmcif_ddl-ext-pdbx.dic.
+;
+  
+mmcif_ddl-ext-pdbx.dic       1.7.0   2021-04-05  
+;
+Changes (JW):
++ Add pdbx_include_dictionary/pdbx_include_category for dictionary compose and value conditions extensions
++ Add to pdbx_item_linked_group and pdbx_item_linked_group_list details
+;
+  
+mmcif_ddl-ext-pdbx.dic       1.8.0   2021-05-29  
+;
+Changes (JW):
++ Add _pdbx_item_enumeration.value_display and _item_enumeration.pdbx_value_display
+;
+  
+mmcif_ddl-ext-pdbx.dic       1.9.0   2021-06-02  
+;
+Changes (JW):
++ Add categories pdbx_item_set and pdbx_item_set_type_list
+;
+  
+mmcif_ddl-ext-pdbx.dic       1.10.0  2021-08-31  
+;
+Changes (EP):
++ Add conditional context extension. Adds categories pdbx_category_conditional_context,
+  pdbx_item_conditional_context, pdbx_conditional_context_list.
+;
+  
+mmcif_ddl-ext-compose.dic    1.0.0   2017-08-17  
+;
+Changes (JW):
++ Preliminary versions of categories pdbx_include_dictionary, pdbx_include_category,
+  pdbx_include_item, pdbx_dictionary_component and pdbx_dictionary_component_history
+;
+  
+mmcif_ddl-ext-compose.dic    1.1.0   2021-03-30  
+;
+Changes (JW):
++ Migrate to dictionary component mmcif_ddl-ext-compose.dic.
+;
+  
+mmcif_ddl-ext-compose.dic    1.2.0   2021-04-05  
+;
+Changes (JW):
++ Correct typo in pdbx_dictionary_component.dictionary_component_id item name.
+;
+  
+mmcif_ddl-ext-condition.dic  1.0.0   2017-08-17  
+;
+Changes (JW):
++ Preliminary versions of categories  pdbx_item_linked, pdbx_item_value_condition, and pdbx_item_value_condition_list
+;
+  
+mmcif_ddl-ext-condition.dic  1.1.0   2021-03-30  
+;
+Changes (JW):
++ Migrate to dictionary component mmcif_ddl-ext-condition.dic.
+;
+  
+mmcif_ddl-ext-condition.dic  1.2.0   2021-04-06  
+;
+Changes (JW):
++ Add data category pdbx_comparison_operator_list and items
+ _pdbx_item_linked.condition_child_log_op, _pdbx_item_linked.condition_child_target_name,
+ _pdbx_item_value_condition_list.log_op
+;
+  
+mmcif_ddl-ext-rcsb.dic       1.0.0   2020-06-05  
+;
+Changes (JW):
++  Add items _item_enumeration.rcsb_detail_brief and _item_enumeration.rcsb_type_units_code
+;
+  
+mmcif_ddl-ext-rcsb.dic       1.1.0   2021-03-30  
+;
+Changes (JW):
++ Migrate to dictionary component mmcif_ddl-ext-rcsb.dic.
+;
+  
+#
+loop_
+_pdbx_item_linked_group.category_id
+_pdbx_item_linked_group.link_group_id
+_pdbx_item_linked_group.label
+_pdbx_item_linked_group.context
+_pdbx_item_linked_group.condition_id
+ndb_item_range                     1  ndb_item_range:item:1                                              .  .  
+ndb_item_type                      1  ndb_item_type:item:1                                               .  .  
+ndb_item                           1  ndb_item:item:1                                                    .  .  
+ndb_category_description           1  ndb_category_description:category:1                                .  .  
+ndb_category_examples              1  ndb_category_examples:category:1                                   .  .  
+ndb_item_description               1  ndb_item_description:item:1                                        .  .  
+ndb_item_enumeration               1  ndb_item_enumeration:item:1                                        .  .  
+ndb_item_examples                  1  ndb_item_examples:item:1                                           .  .  
+pdbx_item_linked_group             1  pdbx_item_linked_group:category:1                                  .  .  
+pdbx_item_linked_group_list        1  pdbx_item_linked_group_list:item:1                                 .  .  
+pdbx_item_linked_group_list        2  pdbx_item_linked_group_list:item:2                                 .  .  
+pdbx_item_linked_group_list        3  pdbx_item_linked_group_list:pdbx_item_linked_group:3               .  .  
+pdbx_category_context              1  pdbx_category_context:category:1                                   .  .  
+pdbx_item_context                  1  pdbx_item_context:item:1                                           .  .  
+pdbx_item_enumeration_details      1  pdbx_item_enumeration_details:item:1                               .  .  
+pdbx_item_range                    1  pdbx_item_range:item:1                                             .  .  
+pdbx_item_type                     1  pdbx_item_type:item:1                                              .  .  
+pdbx_item                          1  pdbx_item:item:1                                                   .  .  
+pdbx_category_description          1  pdbx_category_description:category:1                               .  .  
+pdbx_category_examples             1  pdbx_category_examples:category:1                                  .  .  
+pdbx_item_description              1  pdbx_item_description:item:1                                       .  .  
+pdbx_item_enumeration              1  pdbx_item_enumeration:item:1                                       .  .  
+pdbx_item_examples                 1  pdbx_item_examples:item:1                                          .  .  
+pdbx_include_category              1  pdbx_include_category:pdbx_include_dictionary:1                    .  .  
+pdbx_include_item                  1  pdbx_include_item:pdbx_include_dictionary:1                        .  .  
+pdbx_dictionary_component          1  pdbx_dictionary_component:pdbx_dictionary_component_history:1      .  .  
+pdbx_dictionary_component_history  1  pdbx_dictionary_component_history:pdbx_dictionary_component:1      .  .  
+pdbx_item_value_condition          1  pdbx_item_value_condition:pdbx_item_value_condition_list:1         .  .  
+pdbx_item_value_condition_list     1  pdbx_item_value_condition_list:item:1                              .  .  
+pdbx_item_value_condition_list     2  pdbx_item_value_condition_list:item:2                              .  .  
+pdbx_item_value_condition_list     3  pdbx_item_value_condition_list:pdbx_comparison_operator_list:3     .  .  
+pdbx_item_linked                   1  pdbx_item_linked:item:1                                            .  .  
+pdbx_item_linked                   2  pdbx_item_linked:item:2                                            .  .  
+pdbx_item_linked                   3  pdbx_item_linked:item:3                                            .  .  
+pdbx_item_linked                   4  pdbx_item_linked:item:4                                            .  .  
+pdbx_item_linked                   5  pdbx_item_linked:pdbx_comparison_operator_list:5                   .  .  
+pdbx_item_set                      1  pdbx_item_set:pdbx_item_set_type_list:1                            .  .  
+pdbx_item_set                      2  pdbx_item_set:item:1                                               .  .  
+pdbx_category_conditional_context  1  pdbx_category_conditional_context:category:1                       .  .  
+pdbx_category_conditional_context  2  pdbx_category_conditional_context:pdbx_conditional_context_list:2  .  .  
+pdbx_conditional_context_list      1  pdbx_conditional_context_list:item:1                               .  .  
+pdbx_conditional_context_list      2  pdbx_conditional_context_list:item:2                               .  .  
+pdbx_conditional_context_list      3  pdbx_conditional_context_list:pdbx_comparison_list:3               .  .  
+pdbx_item_conditional_context      1  pdbx_item_conditional_context:item:1                               .  .  
+pdbx_item_conditional_context      2  pdbx_item_conditional_context:pdbx_conditional_context_list:2      .  .  
+category                           1  category:datablock:1                                               .  .  
+category_examples                  1  category_examples:category:1                                       .  .  
+category_group                     1  category_group:category:1                                          .  .  
+category_group                     2  category_group:category_group_list:2                               .  .  
+category_group_list                1  category_group_list:category_group_list:1                          .  .  
+category_key                       1  category_key:category:1                                            .  .  
+category_key                       2  category_key:item:2                                                .  .  
+category_methods                   1  category_methods:category:1                                        .  .  
+category_methods                   2  category_methods:method_list:2                                     .  .  
+datablock_methods                  1  datablock_methods:datablock:1                                      .  .  
+datablock_methods                  2  datablock_methods:method_list:2                                    .  .  
+dictionary                         1  dictionary:datablock:1                                             .  .  
+dictionary                         2  dictionary:dictionary_history:2                                    .  .  
+item                               1  item:category:1                                                    .  .  
+item_aliases                       1  item_aliases:item:1                                                .  .  
+item_default                       1  item_default:item:1                                                .  .  
+item_dependent                     1  item_dependent:item:1                                              .  .  
+item_dependent                     2  item_dependent:item:2                                              .  .  
+item_description                   1  item_description:item:1                                            .  .  
+item_enumeration                   1  item_enumeration:item:1                                            .  .  
+item_enumeration                   2  item_enumeration:item_units_list:2                                 .  .  
+item_examples                      1  item_examples:item:1                                               .  .  
+item_linked                        1  item_linked:item:1                                                 .  .  
+item_linked                        2  item_linked:item:2                                                 .  .  
+item_methods                       1  item_methods:item:1                                                .  .  
+item_methods                       2  item_methods:method_list:2                                         .  .  
+item_range                         1  item_range:item:1                                                  .  .  
+item_related                       1  item_related:item:1                                                .  .  
+item_related                       2  item_related:item:2                                                .  .  
+item_structure                     1  item_structure:item:1                                              .  .  
+item_structure                     2  item_structure:item_structure_list:2                               .  .  
+item_sub_category                  1  item_sub_category:item:1                                           .  .  
+item_sub_category                  2  item_sub_category:sub_category:2                                   .  .  
+item_type                          1  item_type:item:1                                                   .  .  
+item_type                          2  item_type:item_type_list:2                                         .  .  
+item_type_conditions               1  item_type_conditions:item:1                                        .  .  
+item_units                         1  item_units:item:1                                                  .  .  
+item_units                         2  item_units:item_units_list:2                                       .  .  
+item_units_conversion              1  item_units_conversion:item_units_list:1                            .  .  
+item_units_conversion              2  item_units_conversion:item_units_list:2                            .  .  
+sub_category_examples              1  sub_category_examples:sub_category:1                               .  .  
+sub_category_methods               1  sub_category_methods:method_list:1                                 .  .  
+sub_category_methods               2  sub_category_methods:sub_category:2                                .  .  
+#
+loop_
+_pdbx_item_linked_group_list.child_category_id
+_pdbx_item_linked_group_list.link_group_id
+_pdbx_item_linked_group_list.child_name
+_pdbx_item_linked_group_list.parent_name
+_pdbx_item_linked_group_list.parent_category_id
+ndb_category_description           1  "_ndb_category_description.id"                                "_category.id"                                         category                           
+ndb_category_examples              1  "_ndb_category_examples.id"                                   "_category.id"                                         category                           
+ndb_item_description               1  "_ndb_item_description.name"                                  "_item.name"                                           item                               
+ndb_item_enumeration               1  "_ndb_item_enumeration.name"                                  "_item.name"                                           item                               
+ndb_item_examples                  1  "_ndb_item_examples.name"                                     "_item.name"                                           item                               
+ndb_item_range                     1  "_ndb_item_range.name"                                        "_item.name"                                           item                               
+ndb_item_type                      1  "_ndb_item_type.name"                                         "_item.name"                                           item                               
+ndb_item                           1  "_ndb_item.name"                                              "_item.name"                                           item                               
+pdbx_item_linked_group             1  "_pdbx_item_linked_group.category_id"                         "_category.id"                                         category                           
+pdbx_item_linked_group_list        1  "_pdbx_item_linked_group_list.child_name"                     "_item.name"                                           item                               
+pdbx_item_linked_group_list        1  "_pdbx_item_linked_group_list.child_category_id"              "_item.category_id"                                    item                               
+pdbx_item_linked_group_list        2  "_pdbx_item_linked_group_list.parent_name"                    "_item.name"                                           item                               
+pdbx_item_linked_group_list        2  "_pdbx_item_linked_group_list.parent_category_id"             "_item.category_id"                                    item                               
+pdbx_item_linked_group_list        3  "_pdbx_item_linked_group_list.link_group_id"                  "_pdbx_item_linked_group.link_group_id"                pdbx_item_linked_group             
+pdbx_category_context              1  "_pdbx_category_context.category_id"                          "_category.id"                                         category                           
+pdbx_item_context                  1  "_pdbx_item_context.item_name"                                "_item.name"                                           item                               
+pdbx_item_enumeration_details      1  "_pdbx_item_enumeration_details.name"                         "_item.name"                                           item                               
+pdbx_category_description          1  "_pdbx_category_description.id"                               "_category.id"                                         category                           
+pdbx_category_examples             1  "_pdbx_category_examples.id"                                  "_category.id"                                         category                           
+pdbx_item_description              1  "_pdbx_item_description.name"                                 "_item.name"                                           item                               
+pdbx_item_enumeration              1  "_pdbx_item_enumeration.name"                                 "_item.name"                                           item                               
+pdbx_item_examples                 1  "_pdbx_item_examples.name"                                    "_item.name"                                           item                               
+pdbx_item_range                    1  "_pdbx_item_range.name"                                       "_item.name"                                           item                               
+pdbx_item_type                     1  "_pdbx_item_type.name"                                        "_item.name"                                           item                               
+pdbx_item                          1  "_pdbx_item.name"                                             "_item.name"                                           item                               
+pdbx_include_item                  1  "_pdbx_include_item.dictionary_id"                            "_pdbx_include_dictionary.dictionary_id"               pdbx_include_dictionary            
+pdbx_include_category              1  "_pdbx_include_category.dictionary_id"                        "_pdbx_include_dictionary.dictionary_id"               pdbx_include_dictionary            
+pdbx_dictionary_component          1  "_pdbx_dictionary_component.version"                          "_pdbx_dictionary_component_history.version"           pdbx_dictionary_component_history  
+pdbx_dictionary_component_history  1  "_pdbx_dictionary_component_history.dictionary_component_id"  "_pdbx_dictionary_component.dictionary_component_id"   pdbx_dictionary_component          
+pdbx_item_value_condition          1  "_pdbx_item_value_condition.item_name"                        "_pdbx_item_value_condition_list.target_item_name"     pdbx_item_value_condition_list     
+pdbx_item_value_condition          1  "_pdbx_item_value_condition.dependent_item_name"              "_pdbx_item_value_condition_list.dependent_item_name"  pdbx_item_value_condition_list     
+pdbx_item_value_condition_list     1  "_pdbx_item_value_condition_list.target_item_name"            "_item.name"                                           item                               
+pdbx_item_value_condition_list     2  "_pdbx_item_value_condition_list.dependent_item_name"         "_item.name"                                           item                               
+pdbx_item_value_condition_list     3  "_pdbx_item_value_condition_list.dependent_item_cmp_op"       "_pdbx_comparison_operator_list.code"                  pdbx_comparison_operator_list      
+pdbx_item_linked                   1  "_pdbx_item_linked.child_name"                                "_item.name"                                           item                               
+pdbx_item_linked                   2  "_pdbx_item_linked.parent_name"                               "_item.name"                                           item                               
+pdbx_item_linked                   3  "_pdbx_item_linked.condition_child_name"                      "_item.name"                                           item                               
+pdbx_item_linked                   4  "_pdbx_item_linked.condition_child_target_name"               "_item.name"                                           item                               
+pdbx_item_linked                   5  "_pdbx_item_linked.condition_child_cmp_op"                    "_pdbx_comparison_operator_list.code"                  pdbx_comparison_operator_list      
+pdbx_item_set                      1  "_pdbx_item_set.set_id"                                       "_pdbx_item_set_type_list.set_id"                      pdbx_item_set_type_list            
+pdbx_item_set                      2  "_pdbx_item_set.item_name"                                    "_item.name"                                           item                               
+pdbx_category_conditional_context  1  "_pdbx_category_conditional_context.category_id"              "_category.id"                                         category                           
+pdbx_category_conditional_context  2  "_pdbx_category_conditional_context.context_id"               "_pdbx_conditional_context_list.context_id"            pdbx_conditional_context_list      
+pdbx_conditional_context_list      1  "_pdbx_conditional_context_list.target_item_name"             "_item.name"                                           item                               
+pdbx_conditional_context_list      2  "_pdbx_conditional_context_list.dependent_item_name"          "_item.name"                                           item                               
+pdbx_conditional_context_list      3  "_pdbx_conditional_context_list.cmp_op"                       "_pdbx_comparison_operator_list.code"                  pdbx_comparison_operator_list      
+pdbx_item_conditional_context      1  "_pdbx_item_conditional_context.item_name"                    "_item.name"                                           item                               
+pdbx_item_conditional_context      2  "_pdbx_item_conditional_context.context_id"                   "_pdbx_conditional_context_list.context_id"            pdbx_conditional_context_list      
+category                           1  "_category.implicit_key"                                      "_datablock.id"                                        datablock                          
+category_examples                  1  "_category_examples.id"                                       "_category.id"                                         category                           
+category_group                     1  "_category_group.category_id"                                 "_category.id"                                         category                           
+category_group                     2  "_category_group.id"                                          "_category_group_list.id"                              category_group_list                
+category_group_list                1  "_category_group_list.parent_id"                              "_category_group_list.id"                              category_group_list                
+category_key                       1  "_category_key.id"                                            "_category.id"                                         category                           
+category_key                       2  "_category_key.name"                                          "_item.name"                                           item                               
+category_methods                   1  "_category_methods.category_id"                               "_category.id"                                         category                           
+category_methods                   2  "_category_methods.method_id"                                 "_method_list.id"                                      method_list                        
+datablock_methods                  1  "_datablock_methods.datablock_id"                             "_datablock.id"                                        datablock                          
+datablock_methods                  2  "_datablock_methods.method_id"                                "_method_list.id"                                      method_list                        
+dictionary                         1  "_dictionary.datablock_id"                                    "_datablock.id"                                        datablock                          
+dictionary                         2  "_dictionary.version"                                         "_dictionary_history.version"                          dictionary_history                 
+item                               1  "_item.category_id"                                           "_category.id"                                         category                           
+item_aliases                       1  "_item_aliases.name"                                          "_item.name"                                           item                               
+item_default                       1  "_item_default.name"                                          "_item.name"                                           item                               
+item_dependent                     1  "_item_dependent.name"                                        "_item.name"                                           item                               
+item_dependent                     2  "_item_dependent.dependent_name"                              "_item.name"                                           item                               
+item_description                   1  "_item_description.name"                                      "_item.name"                                           item                               
+item_enumeration                   1  "_item_enumeration.name"                                      "_item.name"                                           item                               
+item_enumeration                   2  "_item_enumeration.rcsb_type_units_code"                      "_item_units_list.code"                                item_units_list                    
+item_examples                      1  "_item_examples.name"                                         "_item.name"                                           item                               
+item_linked                        1  "_item_linked.child_name"                                     "_item.name"                                           item                               
+item_linked                        2  "_item_linked.parent_name"                                    "_item.name"                                           item                               
+item_methods                       1  "_item_methods.name"                                          "_item.name"                                           item                               
+item_methods                       2  "_item_methods.method_id"                                     "_method_list.id"                                      method_list                        
+item_range                         1  "_item_range.name"                                            "_item.name"                                           item                               
+item_related                       1  "_item_related.name"                                          "_item.name"                                           item                               
+item_related                       2  "_item_related.related_name"                                  "_item.name"                                           item                               
+item_structure                     1  "_item_structure.name"                                        "_item.name"                                           item                               
+item_structure                     2  "_item_structure.code"                                        "_item_structure_list.code"                            item_structure_list                
+item_sub_category                  1  "_item_sub_category.name"                                     "_item.name"                                           item                               
+item_sub_category                  2  "_item_sub_category.id"                                       "_sub_category.id"                                     sub_category                       
+item_type                          1  "_item_type.name"                                             "_item.name"                                           item                               
+item_type                          2  "_item_type.code"                                             "_item_type_list.code"                                 item_type_list                     
+item_type_conditions               1  "_item_type_conditions.name"                                  "_item.name"                                           item                               
+item_units                         1  "_item_units.name"                                            "_item.name"                                           item                               
+item_units                         2  "_item_units.code"                                            "_item_units_list.code"                                item_units_list                    
+item_units_conversion              1  "_item_units_conversion.from_code"                            "_item_units_list.code"                                item_units_list                    
+item_units_conversion              2  "_item_units_conversion.to_code"                              "_item_units_list.code"                                item_units_list                    
+sub_category_examples              1  "_sub_category_examples.id"                                   "_sub_category.id"                                     sub_category                       
+sub_category_methods               1  "_sub_category_methods.method_id"                             "_method_list.id"                                      method_list                        
+sub_category_methods               2  "_sub_category_methods.sub_category_id"                       "_sub_category.id"                                     sub_category                       
+##
+save_datablock
+   _category.description     
+;
+     Attributes defining the characteristics of a data block.
+;
+
+   _category.id              datablock
+   _category.mandatory_code  no
+   _category.implicit_key    mmcif_ddl.dic
+   #
+   _category_key.id    datablock
+   _category_key.name  "_datablock.id"
+   #
+   loop_
+   _category_group.id
+   _category_group.category_id
+     ddl_group        datablock  
+     datablock_group  datablock  
+   #
+   _pdbx_category_context.category_id  datablock
+   _pdbx_category_context.type         DATA
+   #
+save_
+#
+save__datablock.id
+   _item_description.name         "_datablock.id"
+   _item_description.description  
+;
+     The identity of the data block.
+;
+
+   #
+   _item.name            "_datablock.id"
+   _item.category_id     datablock
+   _item.mandatory_code  implicit
+   #
+   _item_type.name  "_datablock.id"
+   _item_type.code  code
+   #
+   loop_
+   _item_linked.parent_name
+   _item_linked.child_name
+     "_datablock.id"  "_datablock_methods.datablock_id"  
+     "_datablock.id"  "_dictionary.datablock_id"  
+     "_datablock.id"  "_category.implicit_key"  
+   #
+save_
+#
+save__datablock.description
+   _item_description.name         "_datablock.description"
+   _item_description.description  
+;
+     Text description of the data block.
+;
+
+   #
+   _item.name            "_datablock.description"
+   _item.category_id     datablock
+   _item.mandatory_code  yes
+   #
+   _item_type.name  "_datablock.description"
+   _item_type.code  text
+   #
+save_
+#
+save_datablock_methods
+   _category.description     
+;
+    Attributes specifying the association between data blocks and methods.
+;
+
+   _category.id              datablock_methods
+   _category.mandatory_code  no
+   _category.implicit_key    mmcif_ddl.dic
+   #
+   loop_
+   _category_key.id
+   _category_key.name
+     datablock_methods  "_datablock_methods.method_id"  
+     datablock_methods  "_datablock_methods.datablock_id"  
+   #
+   loop_
+   _category_group.id
+   _category_group.category_id
+     ddl_group        datablock_methods  
+     datablock_group  datablock_methods  
+   #
+   _pdbx_category_context.category_id  datablock_methods
+   _pdbx_category_context.type         DATA
+   #
+save_
+#
+save__datablock_methods.datablock_id
+   _item_description.name         "_datablock_methods.datablock_id"
+   _item_description.description  
+;
+     Identifier of data block.
+;
+
+   #
+   _item.name            "_datablock_methods.datablock_id"
+   _item.category_id     datablock_methods
+   _item.mandatory_code  implicit
+   #
+   _item_type.name  "_datablock_methods.datablock_id"
+   _item_type.code  code
+   #
+save_
+#
+save__datablock_methods.method_id
+   _item_description.name         "_datablock_methods.method_id"
+   _item_description.description  
+;
+     Unique method identifier associated with a data block.
+;
+
+   #
+   _item.name            "_datablock_methods.method_id"
+   _item.category_id     datablock_methods
+   _item.mandatory_code  yes
+   #
+   _item_type.name  "_datablock_methods.method_id"
+   _item_type.code  idname
+   #
+save_
+#
+save_category
+   _category.description     
+;
+     Attributes defining the functionality for the entire category.
+;
+
+   _category.id              category
+   _category.mandatory_code  no
+   _category.implicit_key    mmcif_ddl.dic
+   #
+   _category_key.id    category
+   _category_key.name  "_category.id"
+   #
+   loop_
+   _category_group.id
+   _category_group.category_id
+     ddl_group       category  
+     category_group  category  
+   #
+   _pdbx_category_context.category_id  category
+   _pdbx_category_context.type         DEFINITION
+   #
+save_
+#
+save__category.id
+   _item_description.name         "_category.id"
+   _item_description.description  
+;
+     The identity of the data category. Data items may only be looped
+     with items of the same category.
+;
+
+   #
+   _item.name            "_category.id"
+   _item.category_id     category
+   _item.mandatory_code  yes
+   #
+   _item_type.name  "_category.id"
+   _item_type.code  idname
+   #
+   loop_
+   _item_linked.child_name
+   _item_linked.parent_name
+     "_category_examples.id"          "_category.id"  
+     "_category_group.category_id"    "_category.id"  
+     "_category_key.id"               "_category.id"  
+     "_category_methods.category_id"  "_category.id"  
+     "_item.category_id"              "_category.id"  
+   #
+save_
+#
+save__category.description
+   _item_description.name         "_category.description"
+   _item_description.description  
+;
+     Text description of a category.
+;
+
+   #
+   _item.name            "_category.description"
+   _item.category_id     category
+   _item.mandatory_code  yes
+   #
+   _item_type.name  "_category.description"
+   _item_type.code  text
+   #
+save_
+#
+save__category.implicit_key
+   _item_description.name         "_category.implicit_key"
+   _item_description.description  
+;
+     An identifier that may be used to distinguish the contents of
+     like categories between data blocks.
+;
+
+   #
+   _item.name            "_category.implicit_key"
+   _item.category_id     category
+   _item.mandatory_code  implicit
+   #
+   _item_type.name  "_category.implicit_key"
+   _item_type.code  code
+   #
+save_
+#
+save__category.mandatory_code
+   _item_description.name         "_category.mandatory_code"
+   _item_description.description  
+;
+     Whether the category must be specified in a dictionary.
+;
+
+   #
+   _item.name            "_category.mandatory_code"
+   _item.category_id     category
+   _item.mandatory_code  yes
+   #
+   _item_type.name  "_category.mandatory_code"
+   _item_type.code  code
+   #
+save_
+#
+save_category_examples
+   _category.description     
+;
+     Example applications and descriptions of data items in this category.
+;
+
+   _category.id              category_examples
+   _category.mandatory_code  no
+   _category.implicit_key    mmcif_ddl.dic
+   #
+   loop_
+   _category_key.id
+   _category_key.name
+     category_examples  "_category_examples.id"  
+     category_examples  "_category_examples.case"  
+   #
+   _pdbx_category_context.category_id  category_examples
+   _pdbx_category_context.type         DEFINITION
+   #
+save_
+#
+save__category_examples.id
+   _item_description.name         "_category_examples.id"
+   _item_description.description  
+;
+     The name of category.
+;
+
+   #
+   _item.name            "_category_examples.id"
+   _item.category_id     category_examples
+   _item.mandatory_code  implicit
+   #
+   _item_type.name  "_category_examples.id"
+   _item_type.code  idname
+   #
+save_
+#
+save__category_examples.case
+   _item_description.name         "_category_examples.case"
+   _item_description.description  
+;
+     A case of examples involving items in this category.
+;
+
+   #
+   _item.name            "_category_examples.case"
+   _item.category_id     category_examples
+   _item.mandatory_code  yes
+   #
+   _item_type.name  "_category_examples.case"
+   _item_type.code  text
+   #
+save_
+#
+save__category_examples.detail
+   _item_description.name         "_category_examples.detail"
+   _item_description.description  
+;
+     A description of an example _category_examples.case
+;
+
+   #
+   _item.name            "_category_examples.detail"
+   _item.category_id     category_examples
+   _item.mandatory_code  no
+   #
+   _item_type.name  "_category_examples.detail"
+   _item_type.code  text
+   #
+save_
+#
+save_category_key
+   _category.description     
+;
+     This category holds a list of the item names that uniquely
+     identify the elements of the category.
+;
+
+   _category.id              category_key
+   _category.mandatory_code  no
+   _category.implicit_key    mmcif_ddl.dic
+   #
+   loop_
+   _category_key.id
+   _category_key.name
+     category_key  "_category_key.name"  
+     category_key  "_category_key.id"  
+   #
+   loop_
+   _category_group.id
+   _category_group.category_id
+     ddl_group       category_key  
+     category_group  category_key  
+   #
+   _pdbx_category_context.category_id  category_key
+   _pdbx_category_context.type         DEFINITION
+   #
+save_
+#
+save__category_key.name
+   _item_description.name         "_category_key.name"
+   _item_description.description  
+;
+     The name of a data item that serves as a key identifier for the
+     category (eg. a component of  the primary key).
+;
+
+   #
+   _item.name            "_category_key.name"
+   _item.category_id     category_key
+   _item.mandatory_code  yes
+   #
+   _item_type.name  "_category_key.name"
+   _item_type.code  name
+   #
+save_
+#
+save__category_key.id
+   _item_description.name         "_category_key.id"
+   _item_description.description  
+;
+     The identifier of the category (eg. a component of  the primary key).
+;
+
+   #
+   _item.name            "_category_key.id"
+   _item.category_id     category_key
+   _item.mandatory_code  implicit
+   #
+   _item_type.name  "_category_key.id"
+   _item_type.code  idname
+   #
+save_
+#
+save_category_group
+   _category.description     
+;
+     Provides a list of category groups to which the base category
+     belongs.
+;
+
+   _category.id              category_group
+   _category.mandatory_code  no
+   _category.implicit_key    mmcif_ddl.dic
+   #
+   loop_
+   _category_key.id
+   _category_key.name
+     category_group  "_category_group.id"  
+     category_group  "_category_group.category_id"  
+   #
+   loop_
+   _category_group.id
+   _category_group.category_id
+     ddl_group       category_group  
+     category_group  category_group  
+   #
+   _pdbx_category_context.category_id  category_group
+   _pdbx_category_context.type         DEFINITION
+   #
+save_
+#
+save__category_group.id
+   _item_description.name         "_category_group.id"
+   _item_description.description  
+;
+     The name of a category group ...
+;
+
+   #
+   _item.name            "_category_group.id"
+   _item.category_id     category_group
+   _item.mandatory_code  yes
+   #
+   _item_type.name  "_category_group.id"
+   _item_type.code  idname
+   #
+save_
+#
+save__category_group.category_id
+   _item_description.name         "_category_group.category_id"
+   _item_description.description  
+;
+     The name of a category  ...
+;
+
+   #
+   _item.name            "_category_group.category_id"
+   _item.category_id     category_group
+   _item.mandatory_code  implicit
+   #
+   _item_type.name  "_category_group.category_id"
+   _item_type.code  idname
+   #
+save_
+#
+save_category_group_list
+   _category.description     
+;
+     This category provides the definition of each category group.
+     A category group is a collection of related categories.
+;
+
+   _category.id              category_group_list
+   _category.mandatory_code  no
+   _category.implicit_key    mmcif_ddl.dic
+   #
+   _category_key.id    category_group_list
+   _category_key.name  "_category_group_list.id"
+   #
+   loop_
+   _category_group.id
+   _category_group.category_id
+     ddl_group       category_group_list  
+     category_group  category_group_list  
+   #
+   _pdbx_category_context.category_id  category_group_list
+   _pdbx_category_context.type         DATA
+   #
+save_
+#
+save__category_group_list.id
+   _item_description.name         "_category_group_list.id"
+   _item_description.description  
+;
+     The name of a category group ...
+;
+
+   #
+   _item.name            "_category_group_list.id"
+   _item.category_id     category_group_list
+   _item.mandatory_code  yes
+   #
+   _item_type.name  "_category_group_list.id"
+   _item_type.code  idname
+   #
+   loop_
+   _item_linked.child_name
+   _item_linked.parent_name
+     "_category_group.id"              "_category_group_list.id"  
+     "_category_group_list.parent_id"  "_category_group_list.id"  
+   #
+save_
+#
+save__category_group_list.description
+   _item_description.name         "_category_group_list.description"
+   _item_description.description  
+;
+     Text description of a category group...
+;
+
+   #
+   _item.name            "_category_group_list.description"
+   _item.category_id     category_group_list
+   _item.mandatory_code  yes
+   #
+   _item_type.name  "_category_group_list.description"
+   _item_type.code  text
+   #
+save_
+#
+save__category_group_list.parent_id
+   _item_description.name         "_category_group_list.parent_id"
+   _item_description.description  
+;
+     The name of the optional parent category group.
+;
+
+   #
+   _item.name            "_category_group_list.parent_id"
+   _item.category_id     category_group_list
+   _item.mandatory_code  no
+   #
+   _item_type.name  "_category_group_list.parent_id"
+   _item_type.code  idname
+   #
+save_
+#
+save_category_methods
+   _category.description     
+;
+    Attributes specifying the association between categories and methods.
+;
+
+   _category.id              category_methods
+   _category.mandatory_code  no
+   _category.implicit_key    mmcif_ddl.dic
+   #
+   loop_
+   _category_key.id
+   _category_key.name
+     category_methods  "_category_methods.method_id"  
+     category_methods  "_category_methods.category_id"  
+   #
+   loop_
+   _category_group.id
+   _category_group.category_id
+     ddl_group       category_methods  
+     category_group  category_methods  
+   #
+   _pdbx_category_context.category_id  category_methods
+   _pdbx_category_context.type         DEFINITION
+   #
+save_
+#
+save__category_methods.category_id
+   _item_description.name         "_category_methods.category_id"
+   _item_description.description  
+;
+     The name of the category
+;
+
+   #
+   _item.name            "_category_methods.category_id"
+   _item.category_id     category_methods
+   _item.mandatory_code  implicit
+   #
+   _item_type.name  "_category_methods.category_id"
+   _item_type.code  idname
+   #
+save_
+#
+save__category_methods.method_id
+   _item_description.name         "_category_methods.method_id"
+   _item_description.description  
+;
+     The name of the method
+;
+
+   #
+   _item.name            "_category_methods.method_id"
+   _item.category_id     category_methods
+   _item.mandatory_code  yes
+   #
+   _item_type.name  "_category_methods.method_id"
+   _item_type.code  idname
+   #
+save_
+#
+save_sub_category
+   _category.description     
+;
+     The purpose of a sub-category is to define an association between
+     data items within a category and optionally provide a method to
+     validate the collection of items.   The sub-category named
+     'cartesian' might be applied to the data items for the coordinates
+      x,  y, and z.
+;
+
+   _category.id              sub_category
+   _category.mandatory_code  no
+   _category.implicit_key    mmcif_ddl.dic
+   #
+   _category_key.id    sub_category
+   _category_key.name  "_sub_category.id"
+   #
+   loop_
+   _category_group.id
+   _category_group.category_id
+     ddl_group           sub_category  
+     sub_category_group  sub_category  
+   #
+   _pdbx_category_context.category_id  sub_category
+   _pdbx_category_context.type         DEFINITION
+   #
+save_
+#
+save__sub_category.id
+   _item_description.name         "_sub_category.id"
+   _item_description.description  
+;
+     The identity of the sub-category.
+;
+
+   #
+   _item.name            "_sub_category.id"
+   _item.category_id     sub_category
+   _item.mandatory_code  yes
+   #
+   _item_type.name  "_sub_category.id"
+   _item_type.code  idname
+   #
+   loop_
+   _item_linked.child_name
+   _item_linked.parent_name
+     "_sub_category_examples.id"              "_sub_category.id"  
+     "_sub_category_methods.sub_category_id"  "_sub_category.id"  
+     "_item_sub_category.id"                  "_sub_category.id"  
+   #
+save_
+#
+save__sub_category.description
+   _item_description.name         "_sub_category.description"
+   _item_description.description  
+;
+     Description of the sub-category.
+;
+
+   #
+   _item.name            "_sub_category.description"
+   _item.category_id     sub_category
+   _item.mandatory_code  yes
+   #
+   _item_type.name  "_sub_category.description"
+   _item_type.code  text
+   #
+save_
+#
+save_sub_category_examples
+   _category.description     
+;
+     Example applications and descriptions of data items in this subcategory.
+;
+
+   _category.id              sub_category_examples
+   _category.mandatory_code  no
+   _category.implicit_key    mmcif_ddl.dic
+   #
+   loop_
+   _category_key.id
+   _category_key.name
+     sub_category_examples  "_sub_category_examples.id"  
+     sub_category_examples  "_sub_category_examples.case"  
+   #
+   loop_
+   _category_group.id
+   _category_group.category_id
+     ddl_group           sub_category_examples  
+     sub_category_group  sub_category_examples  
+   #
+   _pdbx_category_context.category_id  sub_category_examples
+   _pdbx_category_context.type         DEFINITION
+   #
+save_
+#
+save__sub_category_examples.id
+   _item_description.name         "_sub_category_examples.id"
+   _item_description.description  
+;
+     The name for the subcategory.
+;
+
+   #
+   _item.name            "_sub_category_examples.id"
+   _item.category_id     sub_category_examples
+   _item.mandatory_code  yes
+   #
+   _item_type.name  "_sub_category_examples.id"
+   _item_type.code  idname
+   #
+save_
+#
+save__sub_category_examples.case
+   _item_description.name         "_sub_category_examples.case"
+   _item_description.description  
+;
+     An example involving items in this subcategory.
+;
+
+   #
+   _item.name            "_sub_category_examples.case"
+   _item.category_id     sub_category_examples
+   _item.mandatory_code  yes
+   #
+   _item_type.name  "_sub_category_examples.case"
+   _item_type.code  text
+   #
+save_
+#
+save__sub_category_examples.detail
+   _item_description.name         "_sub_category_examples.detail"
+   _item_description.description  
+;
+     A description of an example _sub_category_examples.case
+;
+
+   #
+   _item.name            "_sub_category_examples.detail"
+   _item.category_id     sub_category_examples
+   _item.mandatory_code  no
+   #
+   _item_type.name  "_sub_category_examples.detail"
+   _item_type.code  text
+   #
+save_
+#
+save_sub_category_methods
+   _category.description     
+;
+    Attributes specifying the association between subcategories and methods.
+;
+
+   _category.id              sub_category_methods
+   _category.mandatory_code  no
+   _category.implicit_key    mmcif_ddl.dic
+   #
+   loop_
+   _category_key.id
+   _category_key.name
+     sub_category_methods  "_sub_category_methods.method_id"  
+     sub_category_methods  "_sub_category_methods.sub_category_id"  
+   #
+   loop_
+   _category_group.id
+   _category_group.category_id
+     ddl_group           sub_category_methods  
+     sub_category_group  sub_category_methods  
+   #
+   _pdbx_category_context.category_id  sub_category_methods
+   _pdbx_category_context.type         DEFINITION
+   #
+save_
+#
+save__sub_category_methods.sub_category_id
+   _item_description.name         "_sub_category_methods.sub_category_id"
+   _item_description.description  
+;
+     The name of the subcategory
+;
+
+   #
+   _item.name            "_sub_category_methods.sub_category_id"
+   _item.category_id     sub_category_methods
+   _item.mandatory_code  yes
+   #
+   _item_type.name  "_sub_category_methods.sub_category_id"
+   _item_type.code  idname
+   #
+save_
+#
+save__sub_category_methods.method_id
+   _item_description.name         "_sub_category_methods.method_id"
+   _item_description.description  
+;
+     The name of the method
+;
+
+   #
+   _item.name            "_sub_category_methods.method_id"
+   _item.category_id     sub_category_methods
+   _item.mandatory_code  yes
+   #
+   _item_type.name  "_sub_category_methods.method_id"
+   _item_type.code  idname
+   #
+save_
+#
+save_item
+   _category.description     
+;
+     Attributes which describe the characteristics of a data item.
+;
+
+   _category.id              item
+   _category.mandatory_code  no
+   _category.implicit_key    mmcif_ddl.dic
+   #
+   _category_key.id    item
+   _category_key.name  "_item.name"
+   #
+   loop_
+   _category_group.id
+   _category_group.category_id
+     ddl_group   item  
+     item_group  item  
+   #
+   _pdbx_category_context.category_id  item
+   _pdbx_category_context.type         DEFINITION
+   #
+save_
+#
+save__item.name
+   _item_description.name         "_item.name"
+   _item_description.description  
+;
+     Data name of the defined item.
+;
+
+   #
+   _item_type.name  "_item.name"
+   _item_type.code  name
+   #
+   _item.name            "_item.name"
+   _item.category_id     item
+   _item.mandatory_code  implicit
+   #
+   loop_
+   _item_linked.child_name
+   _item_linked.parent_name
+     "_category_key.name"              "_item.name"  
+     "_item_aliases.name"              "_item.name"  
+     "_item_default.name"              "_item.name"  
+     "_item_dependent.name"            "_item.name"  
+     "_item_dependent.dependent_name"  "_item.name"  
+     "_item_description.name"          "_item.name"  
+     "_item_enumeration.name"          "_item.name"  
+     "_item_examples.name"             "_item.name"  
+     "_item_linked.child_name"         "_item.name"  
+     "_item_linked.parent_name"        "_item.name"  
+     "_item_methods.name"              "_item.name"  
+     "_item_range.name"                "_item.name"  
+     "_item_related.name"              "_item.name"  
+     "_item_related.related_name"      "_item.name"  
+     "_item_type.name"                 "_item.name"  
+     "_item_type_conditions.name"      "_item.name"  
+     "_item_structure.name"            "_item.name"  
+     "_item_sub_category.name"         "_item.name"  
+     "_item_units.name"                "_item.name"  
+   #
+save_
+#
+save__item.mandatory_code
+   _item_description.name         "_item.mandatory_code"
+   _item_description.description  
+;
+     Signals if the defined item is mandatory for the proper description
+     of its category.
+;
+
+   #
+   _item.name            "_item.mandatory_code"
+   _item.category_id     item
+   _item.mandatory_code  yes
+   #
+   _item_type.name  "_item.mandatory_code"
+   _item_type.code  code
+   #
+   loop_
+   _item_enumeration.name
+   _item_enumeration.value
+   _item_enumeration.detail
+     "_item.mandatory_code"  yes               "required item in this category"  
+     "_item.mandatory_code"  no                "optional item in this category"  
+     "_item.mandatory_code"  implicit          "required item but may be determined from context"  
+     "_item.mandatory_code"  implicit-ordinal  "required item determined from the row index of the category"  
+   #
+save_
+#
+save__item.category_id
+   _item_description.name         "_item.category_id"
+   _item_description.description  
+;
+     This is category id of the item.
+;
+
+   #
+   _item.name            "_item.category_id"
+   _item.category_id     item
+   _item.mandatory_code  implicit
+   #
+   _item_type.name  "_item.category_id"
+   _item_type.code  idname
+   #
+save_
+#
+save_item_aliases
+   _category.description     
+;
+    This category holds a list of possible alias names or synonyms for
+    each data item.  Each alias name is identified by the name and
+    version of the dictionary to which it belongs.
+;
+
+   _category.id              item_aliases
+   _category.mandatory_code  no
+   _category.implicit_key    mmcif_ddl.dic
+   #
+   loop_
+   _category_key.id
+   _category_key.name
+     item_aliases  "_item_aliases.alias_name"  
+     item_aliases  "_item_aliases.dictionary"  
+     item_aliases  "_item_aliases.version"  
+   #
+   _pdbx_category_context.category_id  item_aliases
+   _pdbx_category_context.type         DEFINITION
+   #
+save_
+#
+save__item_aliases.name
+   _item_description.name         "_item_aliases.name"
+   _item_description.description  
+;
+     Name for the data item.
+;
+
+   #
+   _item.name            "_item_aliases.name"
+   _item.category_id     item_aliases
+   _item.mandatory_code  implicit
+   #
+   _item_type.name  "_item_aliases.name"
+   _item_type.code  name
+   #
+save_
+#
+save__item_aliases.alias_name
+   _item_description.name         "_item_aliases.alias_name"
+   _item_description.description  
+;
+     Alias name for the data item.
+;
+
+   #
+   _item.name            "_item_aliases.alias_name"
+   _item.category_id     item_aliases
+   _item.mandatory_code  yes
+   #
+   _item_type.name  "_item_aliases.alias_name"
+   _item_type.code  aliasname
+   #
+save_
+#
+save__item_aliases.dictionary
+   _item_description.name         "_item_aliases.dictionary"
+   _item_description.description  
+;
+     The dictionary in which the alias name is defined.
+;
+
+   #
+   _item.name            "_item_aliases.dictionary"
+   _item.category_id     item_aliases
+   _item.mandatory_code  yes
+   #
+   _item_type.name  "_item_aliases.dictionary"
+   _item_type.code  char
+   #
+save_
+#
+save__item_aliases.version
+   _item_description.name         "_item_aliases.version"
+   _item_description.description  
+;
+     The version of the dictionary in which the alias name is defined.
+;
+
+   #
+   _item.name            "_item_aliases.version"
+   _item.category_id     item_aliases
+   _item.mandatory_code  yes
+   #
+   _item_type.name  "_item_aliases.version"
+   _item_type.code  char
+   #
+save_
+#
+save_item_default
+   _category.description     
+;
+     Attributes specifying the default value for a data item.
+;
+
+   _category.id              item_default
+   _category.mandatory_code  no
+   _category.implicit_key    mmcif_ddl.dic
+   #
+   _category_key.id    item_default
+   _category_key.name  "_item_default.name"
+   #
+   loop_
+   _category_group.id
+   _category_group.category_id
+     ddl_group   item_default  
+     item_group  item_default  
+   #
+   _pdbx_category_context.category_id  item_default
+   _pdbx_category_context.type         DEFINITION
+   #
+save_
+#
+save__item_default.name
+   _item_description.name         "_item_default.name"
+   _item_description.description  
+;
+     The name of item for which the default value is defined
+;
+
+   #
+   _item.name            "_item_default.name"
+   _item.category_id     item_default
+   _item.mandatory_code  implicit
+   #
+   _item_type.name  "_item_default.name"
+   _item_type.code  name
+   #
+save_
+#
+save__item_default.value
+   _item_description.name         "_item_default.value"
+   _item_description.description  
+;
+     The default value for the defined item if it is not specified
+     explicitly. If a data value is not declared, the default is
+     assumed to be the most likely or natural value.
+;
+
+   #
+   _item.name            "_item_default.value"
+   _item.category_id     item_default
+   _item.mandatory_code  no
+   #
+   _item_type.name  "_item_default.value"
+   _item_type.code  any
+   #
+save_
+#
+save_item_dependent
+   _category.description     
+;
+     Attributes which identify other data items that must be specified
+     for the defined data item to be valid.
+;
+
+   _category.id              item_dependent
+   _category.mandatory_code  no
+   _category.implicit_key    mmcif_ddl.dic
+   #
+   loop_
+   _category_key.id
+   _category_key.name
+     item_dependent  "_item_dependent.name"  
+     item_dependent  "_item_dependent.dependent_name"  
+   #
+   _pdbx_category_context.category_id  item_dependent
+   _pdbx_category_context.type         DEFINITION
+   #
+save_
+#
+save__item_dependent.name
+   _item_description.name         "_item_dependent.name"
+   _item_description.description  
+;
+     Item name of a dependent item.
+;
+
+   #
+   _item.name            "_item_dependent.name"
+   _item.category_id     item_dependent
+   _item.mandatory_code  implicit
+   #
+   _item_type.name  "_item_dependent.name"
+   _item_type.code  name
+   #
+save_
+#
+save__item_dependent.dependent_name
+   _item_description.name         "_item_dependent.dependent_name"
+   _item_description.description  
+;
+     Data name of a dependent item.
+;
+
+   #
+   _item.name            "_item_dependent.dependent_name"
+   _item.category_id     item_dependent
+   _item.mandatory_code  yes
+   #
+   _item_type.name  "_item_dependent.dependent_name"
+   _item_type.code  name
+   #
+save_
+#
+save_item_description
+   _category.description     
+;
+     This category holds the descriptions of each data item.
+;
+
+   _category.id              item_description
+   _category.mandatory_code  yes
+   _category.implicit_key    mmcif_ddl.dic
+   #
+   loop_
+   _category_key.id
+   _category_key.name
+     item_description  "_item_description.name"  
+     item_description  "_item_description.description"  
+   #
+   loop_
+   _category_group.id
+   _category_group.category_id
+     ddl_group   item_description  
+     item_group  item_description  
+   #
+   _pdbx_category_context.category_id  item_description
+   _pdbx_category_context.type         DEFINITION
+   #
+save_
+#
+save__item_description.name
+   _item_description.name         "_item_description.name"
+   _item_description.description  
+;
+    Tne name of data item.
+;
+
+   #
+   _item.name            "_item_description.name"
+   _item.category_id     item_description
+   _item.mandatory_code  implicit
+   #
+   _item_type.name  "_item_description.name"
+   _item_type.code  name
+   #
+save_
+#
+save__item_description.description
+   _item_description.name         "_item_description.description"
+   _item_description.description  
+;
+     Text description of the defined data item.
+;
+
+   #
+   _item.name            "_item_description.description"
+   _item.category_id     item_description
+   _item.mandatory_code  yes
+   #
+   _item_type.name  "_item_description.description"
+   _item_type.code  text
+   #
+save_
+#
+save_item_enumeration
+   _category.description     
+;
+     Attributes which specify the permitted enumeration of the items.
+;
+
+   _category.id              item_enumeration
+   _category.mandatory_code  no
+   _category.implicit_key    mmcif_ddl.dic
+   #
+   loop_
+   _category_key.id
+   _category_key.name
+     item_enumeration  "_item_enumeration.name"  
+     item_enumeration  "_item_enumeration.value"  
+   #
+   loop_
+   _category_group.id
+   _category_group.category_id
+     ddl_group   item_enumeration  
+     item_group  item_enumeration  
+   #
+   _pdbx_category_context.category_id  item_enumeration
+   _pdbx_category_context.type         DEFINITION
+   #
+save_
+#
+save__item_enumeration.name
+   _item_description.name         "_item_enumeration.name"
+   _item_description.description  
+;
+     Name of data item.
+;
+
+   #
+   _item.name            "_item_enumeration.name"
+   _item.category_id     item_enumeration
+   _item.mandatory_code  implicit
+   #
+   _item_type.name  "_item_enumeration.name"
+   _item_type.code  name
+   #
+save_
+#
+save__item_enumeration.value
+   _item_description.name         "_item_enumeration.value"
+   _item_description.description  
+;
+     A permissible value, character or number, for the defined item.
+;
+
+   #
+   _item.name            "_item_enumeration.value"
+   _item.category_id     item_enumeration
+   _item.mandatory_code  yes
+   #
+   _item_type.name  "_item_enumeration.value"
+   _item_type.code  any
+   #
+save_
+#
+save__item_enumeration.detail
+   _item_description.name         "_item_enumeration.detail"
+   _item_description.description  
+;
+     A description of a permissible value for the defined item.
+;
+
+   #
+   _item.name            "_item_enumeration.detail"
+   _item.category_id     item_enumeration
+   _item.mandatory_code  no
+   #
+   _item_type.name  "_item_enumeration.detail"
+   _item_type.code  text
+   #
+save_
+#
+save_item_examples
+   _category.description     
+;
+    Attributes for describing application examples of the data item.
+;
+
+   _category.id              item_examples
+   _category.mandatory_code  no
+   _category.implicit_key    mmcif_ddl.dic
+   #
+   loop_
+   _category_key.id
+   _category_key.name
+     item_examples  "_item_examples.name"  
+     item_examples  "_item_examples.case"  
+   #
+   loop_
+   _category_group.id
+   _category_group.category_id
+     ddl_group   item_examples  
+     item_group  item_examples  
+   #
+   _pdbx_category_context.category_id  item_examples
+   _pdbx_category_context.type         DEFINITION
+   #
+save_
+#
+save__item_examples.name
+   _item_description.name         "_item_examples.name"
+   _item_description.description  
+;
+     The name of data item for the example.
+;
+
+   #
+   _item.name            "_item_examples.name"
+   _item.category_id     item_examples
+   _item.mandatory_code  implicit
+   #
+   _item_type.name  "_item_examples.name"
+   _item_type.code  name
+   #
+save_
+#
+save__item_examples.case
+   _item_description.name         "_item_examples.case"
+   _item_description.description  
+;
+     An example application of the defined data item.
+;
+
+   #
+   _item.name            "_item_examples.case"
+   _item.category_id     item_examples
+   _item.mandatory_code  yes
+   #
+   _item_type.name  "_item_examples.case"
+   _item_type.code  text
+   #
+save_
+#
+save__item_examples.detail
+   _item_description.name         "_item_examples.detail"
+   _item_description.description  
+;
+     A description of an example specified in _item_example.case
+;
+
+   #
+   _item.name            "_item_examples.detail"
+   _item.category_id     item_examples
+   _item.mandatory_code  no
+   #
+   _item_type.name  "_item_examples.detail"
+   _item_type.code  text
+   #
+save_
+#
+save_item_linked
+   _category.description     
+;
+     Attributes which describe how equivalent data items are linked
+     within categories and across different categories.
+;
+
+   _category.id              item_linked
+   _category.mandatory_code  no
+   _category.implicit_key    mmcif_ddl.dic
+   #
+   loop_
+   _category_key.id
+   _category_key.name
+     item_linked  "_item_linked.child_name"  
+     item_linked  "_item_linked.parent_name"  
+   #
+   loop_
+   _category_group.id
+   _category_group.category_id
+     ddl_group   item_linked  
+     item_group  item_linked  
+   #
+   _pdbx_category_context.category_id  item_linked
+   _pdbx_category_context.type         DEFINITION
+   #
+save_
+#
+save__item_linked.child_name
+   _item_description.name         "_item_linked.child_name"
+   _item_description.description  
+;
+     Name of the child data item.
+;
+
+   #
+   _item.name            "_item_linked.child_name"
+   _item.category_id     item_linked
+   _item.mandatory_code  yes
+   #
+   _item_type.name  "_item_linked.child_name"
+   _item_type.code  name
+   #
+save_
+#
+save__item_linked.parent_name
+   _item_description.name         "_item_linked.parent_name"
+   _item_description.description  
+;
+     Name of the parent data item.
+;
+
+   #
+   _item.name            "_item_linked.parent_name"
+   _item.category_id     item_linked
+   _item.mandatory_code  implicit
+   #
+   _item_type.name  "_item_linked.parent_name"
+   _item_type.code  name
+   #
+save_
+#
+save_item_methods
+   _category.description     
+;
+    Attributes specifying the association between data items and methods.
+;
+
+   _category.id              item_methods
+   _category.mandatory_code  no
+   _category.implicit_key    mmcif_ddl.dic
+   #
+   loop_
+   _category_key.id
+   _category_key.name
+     item_methods  "_item_methods.method_id"  
+     item_methods  "_item_methods.name"  
+   #
+   loop_
+   _category_group.id
+   _category_group.category_id
+     ddl_group   item_methods  
+     item_group  item_methods  
+   #
+   _pdbx_category_context.category_id  item_methods
+   _pdbx_category_context.type         DEFINITION
+   #
+save_
+#
+save__item_methods.name
+   _item_description.name         "_item_methods.name"
+   _item_description.description  
+;
+     The name of the item
+;
+
+   #
+   _item.name            "_item_methods.name"
+   _item.category_id     item_methods
+   _item.mandatory_code  implicit
+   #
+   _item_type.name  "_item_methods.name"
+   _item_type.code  name
+   #
+save_
+#
+save__item_methods.method_id
+   _item_description.name         "_item_methods.method_id"
+   _item_description.description  
+;
+     The name of the item method
+;
+
+   #
+   _item.name            "_item_methods.method_id"
+   _item.category_id     item_methods
+   _item.mandatory_code  yes
+   #
+   _item_type.name  "_item_methods.method_id"
+   _item_type.code  idname
+   #
+save_
+#
+save_item_range
+   _category.description     
+;
+     The range of permissible values of a data item.  When multiple
+     ranges are specified they are interpreted sequentially
+     using a logical OR.  To specify that an item value may be
+     equal to a boundary value,  specify an item range where the
+     maximum and minimum values equal the boundary value.
+;
+
+   _category.id              item_range
+   _category.mandatory_code  no
+   _category.implicit_key    mmcif_ddl.dic
+   #
+   _category_key.id    item_range
+   _category_key.name  "_item_range.ordinal"
+   #
+   loop_
+   _category_group.id
+   _category_group.category_id
+     ddl_group   item_range  
+     item_group  item_range  
+   #
+   _pdbx_category_context.category_id  item_range
+   _pdbx_category_context.type         DEFINITION
+   #
+save_
+#
+save__item_range.ordinal
+   _item_description.name         "_item_range.ordinal"
+   _item_description.description  
+;
+     Name of data item ...
+;
+
+   #
+   _item.name            "_item_range.ordinal"
+   _item.category_id     item_range
+   _item.mandatory_code  implicit-ordinal
+   #
+   _item_type.name  "_item_range.ordinal"
+   _item_type.code  int
+   #
+save_
+#
+save__item_range.name
+   _item_description.name         "_item_range.name"
+   _item_description.description  
+;
+     Name of data item ...
+;
+
+   #
+   _item.name            "_item_range.name"
+   _item.category_id     item_range
+   _item.mandatory_code  implicit
+   #
+   _item_type.name  "_item_range.name"
+   _item_type.code  name
+   #
+save_
+#
+save__item_range.minimum
+   _item_description.name         "_item_range.minimum"
+   _item_description.description  
+;
+     Minimum permissible value of a data item or the lower bound
+     of a permissible range.  ( minimum value <  data value)
+;
+
+   #
+   _item.name            "_item_range.minimum"
+   _item.category_id     item_range
+   _item.mandatory_code  yes
+   #
+   _item_type.name  "_item_range.minimum"
+   _item_type.code  any
+   #
+save_
+#
+save__item_range.maximum
+   _item_description.name         "_item_range.maximum"
+   _item_description.description  
+;
+     Maximum permissible value of a data item or the upper bound
+     of a permissible range.  ( maximum value >  data value)
+;
+
+   #
+   _item.name            "_item_range.maximum"
+   _item.category_id     item_range
+   _item.mandatory_code  yes
+   #
+   _item_type.name  "_item_range.maximum"
+   _item_type.code  any
+   #
+save_
+#
+save_item_related
+   _category.description     
+;
+    Attributes which specify recognized relationships between data items.
+;
+
+   _category.id              item_related
+   _category.mandatory_code  no
+   _category.implicit_key    mmcif_ddl.dic
+   #
+   loop_
+   _category_key.id
+   _category_key.name
+     item_related  "_item_related.name"  
+     item_related  "_item_related.related_name"  
+     item_related  "_item_related.function_code"  
+   #
+   loop_
+   _category_group.id
+   _category_group.category_id
+     ddl_group   item_related  
+     item_group  item_related  
+   #
+   _pdbx_category_context.category_id  item_related
+   _pdbx_category_context.type         DEFINITION
+   #
+save_
+#
+save__item_related.name
+   _item_description.name         "_item_related.name"
+   _item_description.description  
+;
+     Identifies a defined data item ...
+;
+
+   #
+   _item.name            "_item_related.name"
+   _item.category_id     item_related
+   _item.mandatory_code  implicit
+   #
+   _item_type.name  "_item_related.name"
+   _item_type.code  name
+   #
+save_
+#
+save__item_related.related_name
+   _item_description.name         "_item_related.related_name"
+   _item_description.description  
+;
+     Identifies a data item by name which is closely related to the
+     defined data item by the manner described by _item_related.function_code
+;
+
+   #
+   _item.name            "_item_related.related_name"
+   _item.category_id     item_related
+   _item.mandatory_code  yes
+   #
+   _item_type.name  "_item_related.related_name"
+   _item_type.code  name
+   #
+save_
+#
+save__item_related.function_code
+   _item_description.name         "_item_related.function_code"
+   _item_description.description  
+;
+     The code for the type of relationship of the item identified by
+     _item_related.name and the defined item.
+
+      ALTERNATE  indicates that the item identified in
+      _item_related.related_name is an alternative expression in terms
+      of its application and attributes to the item in this definition.
+
+      ALTERNATE_EXCLUSIVE indicates that the item identified in
+      _item_related.related_name is an alternative expression in terms
+      of its application and attributes to the item in this definition.
+      Only one of the alternative forms may be specified.
+
+      CONVENTION  indicates that the item identified in
+      _item_related.related_name differs from the defined item only
+      in terms of a convention in its expression.
+
+      CONVERSION_CONSTANT indicates that the item identified in
+      _item_related.related_name differs from the defined item only
+      by a known constant.
+
+      CONVERSION_ARBITRARY indicates that the item identified in
+      _item_related.related_name differs from the defined item only
+      by a arbitrary constant.
+
+      REPLACES  indicates that the defined item replaces the item identified
+      in _item_related.related_name.
+
+      REPLACEDBY  indicates that the defined item is replaced by the
+      item identified in  _item_related.related_name.
+
+      ASSOCIATED_VALUE indicates that the item identified in
+      _item_related.related_name is meaningful when associated with the
+      defined item.
+
+      ASSOCIATED_ESD indicates that the item identified in
+      _item_related.related_name is the estimated standard deviation of
+      of the defined item.
+;
+
+   #
+   _item.name            "_item_related.function_code"
+   _item.category_id     item_related
+   _item.mandatory_code  yes
+   #
+   _item_type.name  "_item_related.function_code"
+   _item_type.code  code
+   #
+   loop_
+   _item_enumeration.name
+   _item_enumeration.value
+   _item_enumeration.detail
+     "_item_related.function_code"  alternate             "alternate form of the item"  
+     "_item_related.function_code"  alternate_exclusive   "mutually exclusive alternate form of the item"  
+     "_item_related.function_code"  convention            "depends on defined convention"  
+     "_item_related.function_code"  conversion_constant   "related by a known conversion factor"  
+     "_item_related.function_code"  conversion_arbitrary  "related by a arbitrary conversion factor"  
+     "_item_related.function_code"  replaces              "a replacement definition"  
+     "_item_related.function_code"  replacedby            "an obsolete definition"  
+     "_item_related.function_code"  associated_value      "a meaningful value when related to the item"  
+     "_item_related.function_code"  associated_esd        "an estimated standard deviation of the item"  
+     "_item_related.function_code"  associated_error      "an estimated error of the item"  
+   #
+save_
+#
+save_item_structure
+   _category.description     
+;
+    This category holds the association between data items and
+    named vector/matrix declarations.
+;
+
+   _category.id              item_structure
+   _category.mandatory_code  no
+   _category.implicit_key    mmcif_ddl.dic
+   #
+   _category_key.id    item_structure
+   _category_key.name  "_item_structure.name"
+   #
+   loop_
+   _category_group.id
+   _category_group.category_id
+     ddl_group   item_structure  
+     item_group  item_structure  
+   #
+   _pdbx_category_context.category_id  item_structure
+   _pdbx_category_context.type         DEFINITION
+   #
+save_
+#
+save__item_structure.name
+   _item_description.name         "_item_structure.name"
+   _item_description.description  
+;
+     The name of data item
+;
+
+   #
+   _item.name            "_item_structure.name"
+   _item.category_id     item_structure
+   _item.mandatory_code  implicit
+   #
+   _item_type.name  "_item_structure.name"
+   _item_type.code  name
+   #
+save_
+#
+save__item_structure.code
+   _item_description.name         "_item_structure.code"
+   _item_description.description  
+;
+     Provides an indirect reference into the list of structure
+     type definition in category item_structure_list.
+;
+
+   #
+   _item.name            "_item_structure.code"
+   _item.category_id     item_structure
+   _item.mandatory_code  yes
+   #
+   _item_type.name  "_item_structure.code"
+   _item_type.code  code
+   #
+save_
+#
+save__item_structure.organization
+   _item_description.name         "_item_structure.organization"
+   _item_description.description  
+;
+     Identifies if the struct is defined in column or row major order.
+     Only the unique elements of symmetric matrices are specified.
+;
+
+   #
+   _item.name            "_item_structure.organization"
+   _item.category_id     item_structure
+   _item.mandatory_code  yes
+   #
+   _item_type.name  "_item_structure.organization"
+   _item_type.code  code
+   #
+   loop_
+   _item_enumeration.name
+   _item_enumeration.value
+   _item_enumeration.detail
+     "_item_structure.organization"  columnwise  "column major order"  
+     "_item_structure.organization"  rowwise     "row major order"  
+   #
+save_
+#
+save_item_structure_list
+   _category.description     
+;
+     This category holds a description for each structure type.
+;
+
+   _category.id              item_structure_list
+   _category.mandatory_code  no
+   _category.implicit_key    mmcif_ddl.dic
+   #
+   loop_
+   _category_key.id
+   _category_key.name
+     item_structure_list  "_item_structure_list.code"  
+     item_structure_list  "_item_structure_list.index"  
+   #
+   loop_
+   _category_group.id
+   _category_group.category_id
+     ddl_group   item_structure_list  
+     item_group  item_structure_list  
+   #
+   _pdbx_category_context.category_id  item_structure_list
+   _pdbx_category_context.type         DATA
+   #
+save_
+#
+save__item_structure_list.code
+   _item_description.name         "_item_structure_list.code"
+   _item_description.description  
+;
+     The name of the matrix/vector structure declaration.
+;
+
+   #
+   _item.name            "_item_structure_list.code"
+   _item.category_id     item_structure_list
+   _item.mandatory_code  yes
+   #
+   _item_linked.parent_name  "_item_structure_list.code"
+   _item_linked.child_name   "_item_structure.code"
+   #
+   _item_type.name  "_item_structure_list.code"
+   _item_type.code  code
+   #
+save_
+#
+save__item_structure_list.index
+   _item_description.name         "_item_structure_list.index"
+   _item_description.description  
+;
+    Identifies the one based index of a row/column of the structure.
+;
+
+   #
+   _item.name            "_item_structure_list.index"
+   _item.category_id     item_structure_list
+   _item.mandatory_code  yes
+   #
+   loop_
+   _item_range.name
+   _item_range.minimum
+   _item_range.maximum
+     "_item_structure_list.index"  1  1  
+     "_item_structure_list.index"  1  .  
+   #
+   _item_type.name  "_item_structure_list.index"
+   _item_type.code  int
+   #
+save_
+#
+save__item_structure_list.dimension
+   _item_description.name         "_item_structure_list.dimension"
+   _item_description.description  
+;
+    Identifies the length of this row/column of the structure.
+;
+
+   #
+   _item.name            "_item_structure_list.dimension"
+   _item.category_id     item_structure_list
+   _item.mandatory_code  yes
+   #
+   loop_
+   _item_range.name
+   _item_range.minimum
+   _item_range.maximum
+     "_item_structure_list.dimension"  1  1  
+     "_item_structure_list.dimension"  1  .  
+   #
+   _item_type.name  "_item_structure_list.dimension"
+   _item_type.code  int
+   #
+save_
+#
+save_item_sub_category
+   _category.description     
+;
+     This category assigns data items to subcategories.
+;
+
+   _category.id              item_sub_category
+   _category.mandatory_code  no
+   _category.implicit_key    mmcif_ddl.dic
+   #
+   loop_
+   _category_key.id
+   _category_key.name
+     item_sub_category  "_item_sub_category.id"  
+     item_sub_category  "_item_sub_category.name"  
+   #
+   loop_
+   _category_group.id
+   _category_group.category_id
+     sub_category_group  item_sub_category  
+     item_group          item_sub_category  
+   #
+   _pdbx_category_context.category_id  item_sub_category
+   _pdbx_category_context.type         DEFINITION
+   #
+save_
+#
+save__item_sub_category.name
+   _item_description.name         "_item_sub_category.name"
+   _item_description.description  
+;
+    The name of data item
+;
+
+   #
+   _item.name            "_item_sub_category.name"
+   _item.category_id     item_sub_category
+   _item.mandatory_code  implicit
+   #
+   _item_type.name  "_item_sub_category.name"
+   _item_type.code  name
+   #
+save_
+#
+save__item_sub_category.id
+   _item_description.name         "_item_sub_category.id"
+   _item_description.description  
+;
+    The identifier of subcategory
+;
+
+   #
+   _item.name            "_item_sub_category.id"
+   _item.category_id     item_sub_category
+   _item.mandatory_code  yes
+   #
+   _item_type.name  "_item_sub_category.id"
+   _item_type.code  idname
+   #
+save_
+#
+save_item_type
+   _category.description     
+;
+     Attributes for specifying the data type code for each data item.
+;
+
+   _category.id              item_type
+   _category.mandatory_code  no
+   _category.implicit_key    mmcif_ddl.dic
+   #
+   _category_key.id    item_type
+   _category_key.name  "_item_type.name"
+   #
+   loop_
+   _category_group.id
+   _category_group.category_id
+     ddl_group   item_type  
+     item_group  item_type  
+   #
+   _pdbx_category_context.category_id  item_type
+   _pdbx_category_context.type         DEFINITION
+   #
+save_
+#
+save__item_type.name
+   _item_description.name         "_item_type.name"
+   _item_description.description  
+;
+    The name of data item
+;
+
+   #
+   _item.name            "_item_type.name"
+   _item.category_id     item_type
+   _item.mandatory_code  implicit
+   #
+   _item_type.name  "_item_type.name"
+   _item_type.code  name
+   #
+save_
+#
+save__item_type.code
+   _item_description.name         "_item_type.code"
+   _item_description.description  
+;
+    Data type of defined data item
+;
+
+   #
+   _item.name            "_item_type.code"
+   _item.category_id     item_type
+   _item.mandatory_code  yes
+   #
+   _item_type.name  "_item_type.code"
+   _item_type.code  code
+   #
+save_
+#
+save_item_type_conditions
+   _category.description     
+;
+    Attributes for specifying additional conditions associated with
+    the data type of the item.
+;
+
+   _category.id              item_type_conditions
+   _category.mandatory_code  no
+   _category.implicit_key    mmcif_ddl.dic
+   #
+   _category_key.id    item_type_conditions
+   _category_key.name  "_item_type_conditions.name"
+   #
+   loop_
+   _category_group.id
+   _category_group.category_id
+     ddl_group         item_type_conditions  
+     item_group        item_type_conditions  
+     compliance_group  item_type_conditions  
+   #
+   _pdbx_category_context.category_id  item_type_conditions
+   _pdbx_category_context.type         DEFINITION
+   #
+save_
+#
+save__item_type_conditions.name
+   _item_description.name         "_item_type_conditions.name"
+   _item_description.description  
+;
+     The name of data item
+;
+
+   #
+   _item.name            "_item_type_conditions.name"
+   _item.category_id     item_type_conditions
+   _item.mandatory_code  implicit
+   #
+   _item_type.name  "_item_type_conditions.name"
+   _item_type.code  name
+   #
+save_
+#
+save__item_type_conditions.code
+   _item_description.name         "_item_type_conditions.code"
+   _item_description.description  
+;
+     Codes defining conditions on the _item_type.code specification.
+
+     'esd' permits a number string to contain an appended standard
+           deviation number enclosed within parentheses. E.g. 4.37(5)
+
+     'seq' permits data to be declared as a sequence of values
+           separated by a comma <,> or a colon <:>.
+           * The sequence v1,v2,v3,. signals that v1, v2, v3, etc.
+             are alternative values or the data item.
+           * The sequence v1:v2 signals that v1 and v2 are the boundary
+             values of a continuous range of values. This mechanism
+             was used to specify permitted ranges of an item in
+             previous DDL versions.
+      Combinations of alternate and range sequences are permitted.
+;
+
+   #
+   _item.name            "_item_type_conditions.code"
+   _item.category_id     item_type_conditions
+   _item.mandatory_code  yes
+   #
+   _item_type.name  "_item_type_conditions.code"
+   _item_type.code  code
+   #
+   loop_
+   _item_enumeration.name
+   _item_enumeration.value
+   _item_enumeration.detail
+     "_item_type_conditions.code"  none  "no extra conditions apply to this data item"  
+     "_item_type_conditions.code"  esd   "numbers may have esd values appended within ()"  
+     "_item_type_conditions.code"  seq   "data may be declared as a comma or colon separated sequence"  
+   #
+save_
+#
+save_item_type_list
+   _category.description     
+;
+     Attributes which define each type code.
+;
+
+   _category.id              item_type_list
+   _category.mandatory_code  no
+   _category.implicit_key    mmcif_ddl.dic
+   #
+   _category_key.id    item_type_list
+   _category_key.name  "_item_type_list.code"
+   #
+   loop_
+   _category_group.id
+   _category_group.category_id
+     ddl_group   item_type_list  
+     item_group  item_type_list  
+   #
+   _pdbx_category_context.category_id  item_type_list
+   _pdbx_category_context.type         DATA
+   #
+save_
+#
+save__item_type_list.code
+   _item_description.name         "_item_type_list.code"
+   _item_description.description  
+;
+     The codes specifying the nature of the data value.
+;
+
+   #
+   _item.name            "_item_type_list.code"
+   _item.category_id     item_type_list
+   _item.mandatory_code  yes
+   #
+   _item_type.name  "_item_type_list.code"
+   _item_type.code  code
+   #
+   _item_linked.child_name   "_item_type.code"
+   _item_linked.parent_name  "_item_type_list.code"
+   #
+save_
+#
+save__item_type_list.primitive_code
+   _item_description.name         "_item_type_list.primitive_code"
+   _item_description.description  
+;
+     The codes specifying the primitive type of the data value.
+;
+
+   #
+   _item.name            "_item_type_list.primitive_code"
+   _item.category_id     item_type_list
+   _item.mandatory_code  yes
+   #
+   _item_type.name  "_item_type_list.primitive_code"
+   _item_type.code  code
+   #
+   loop_
+   _item_enumeration.name
+   _item_enumeration.value
+   _item_enumeration.detail
+     "_item_type_list.primitive_code"  numb   "numerically-interpretable string"  
+     "_item_type_list.primitive_code"  char   "character or text string (case-sensitive)"  
+     "_item_type_list.primitive_code"  uchar  "character or text string (case-insensitive)"  
+     "_item_type_list.primitive_code"  null   "for dictionary purposes only"  
+   #
+save_
+#
+save__item_type_list.construct
+   _item_description.name         "_item_type_list.construct"
+   _item_description.description  
+;
+    When a data value can be defined as a pre-determined sequence of
+    characters, or optional characters, or data names (for which the
+    definition is also available), it is specified as a construction.
+    The rules of construction conform to the the regular expression
+    (REGEX) specifications detailed in the IEEE document P1003.2
+    Draft 11.2 Sept 1991 (ftp file '/doc/POSIX/1003.2/p121-140').
+    Resolved data names for which _item_type_list.construct
+    specifications exist are replaced by these constructions,
+    otherwise the data name string is not replaced.
+;
+
+   #
+   _item.name            "_item_type_list.construct"
+   _item.category_id     item_type_list
+   _item.mandatory_code  no
+   #
+   _item_type.name  "_item_type_list.construct"
+   _item_type.code  text
+   #
+   _item_examples.name    "_item_type_list.construct"
+   _item_examples.case    {_year}-{_month}-{_day}
+   _item_examples.detail  "typical construction for _date"
+   #
+save_
+#
+save__item_type_list.detail
+   _item_description.name         "_item_type_list.detail"
+   _item_description.description  
+;
+     An optional description of the data type
+;
+
+   #
+   _item.name            "_item_type_list.detail"
+   _item.category_id     item_type_list
+   _item.mandatory_code  no
+   #
+   _item_type.name  "_item_type_list.detail"
+   _item_type.code  text
+   #
+save_
+#
+save_item_units
+   _category.description     
+;
+     Specifies the physical units in which data items are expressed.
+;
+
+   _category.id              item_units
+   _category.mandatory_code  no
+   _category.implicit_key    mmcif_ddl.dic
+   #
+   _category_key.id    item_units
+   _category_key.name  "_item_units.name"
+   #
+   loop_
+   _category_group.id
+   _category_group.category_id
+     ddl_group   item_units  
+     item_group  item_units  
+   #
+   _pdbx_category_context.category_id  item_units
+   _pdbx_category_context.type         DEFINITION
+   #
+save_
+#
+save__item_units.name
+   _item_description.name         "_item_units.name"
+   _item_description.description  
+;
+     The name of data item
+;
+
+   #
+   _item.name            "_item_units.name"
+   _item.category_id     item_units
+   _item.mandatory_code  implicit
+   #
+   _item_type.name  "_item_units.name"
+   _item_type.code  name
+   #
+save_
+#
+save__item_units.code
+   _item_description.name         "_item_units.code"
+   _item_description.description  
+;
+     The identifier of unit in which the data item is expressed.
+;
+
+   #
+   _item.name            "_item_units.code"
+   _item.category_id     item_units
+   _item.mandatory_code  yes
+   #
+   _item_type.name  "_item_units.code"
+   _item_type.code  code
+   #
+save_
+#
+save_item_units_conversion
+   _category.description     
+;
+     Conversion factors between the various units of measure defined
+     in the item_units_list category.
+;
+
+   _category.id              item_units_conversion
+   _category.mandatory_code  no
+   _category.implicit_key    mmcif_ddl.dic
+   #
+   loop_
+   _category_key.id
+   _category_key.name
+     item_units_conversion  "_item_units_conversion.from_code"  
+     item_units_conversion  "_item_units_conversion.to_code"  
+   #
+   loop_
+   _category_group.id
+   _category_group.category_id
+     ddl_group   item_units_conversion  
+     item_group  item_units_conversion  
+   #
+   _pdbx_category_context.category_id  item_units_conversion
+   _pdbx_category_context.type         DATA
+   #
+save_
+#
+save__item_units_conversion.from_code
+   _item_description.name         "_item_units_conversion.from_code"
+   _item_description.description  
+;
+     The unit system on which the conversion operation is applied
+     to produce the unit system specified in _item_units_conversion.to_code.
+
+         <to_code> =  <from_code> <operator> <factor>
+;
+
+   #
+   _item.name            "_item_units_conversion.from_code"
+   _item.category_id     item_units_conversion
+   _item.mandatory_code  yes
+   #
+   _item_type.name  "_item_units_conversion.from_code"
+   _item_type.code  code
+   #
+save_
+#
+save__item_units_conversion.to_code
+   _item_description.name         "_item_units_conversion.to_code"
+   _item_description.description  
+;
+     The unit system produced after an operation is applied to the unit
+     system specified by  _item_units_conversion.from_code.
+
+         <to_code> =  <from_code> <operator> <factor>
+;
+
+   #
+   _item.name            "_item_units_conversion.to_code"
+   _item.category_id     item_units_conversion
+   _item.mandatory_code  yes
+   #
+   _item_type.name  "_item_units_conversion.to_code"
+   _item_type.code  code
+   #
+save_
+#
+save__item_units_conversion.operator
+   _item_description.name         "_item_units_conversion.operator"
+   _item_description.description  
+;
+     The arithmetic operator required to convert between the
+     unit systems:
+         <to_code> =  <from_code> <operator> <factor>
+;
+
+   #
+   _item.name            "_item_units_conversion.operator"
+   _item.category_id     item_units_conversion
+   _item.mandatory_code  yes
+   #
+   _item_type.name  "_item_units_conversion.operator"
+   _item_type.code  code
+   #
+   loop_
+   _item_enumeration.name
+   _item_enumeration.value
+   _item_enumeration.detail
+     "_item_units_conversion.operator"  +  addition        
+     "_item_units_conversion.operator"  -  subtraction     
+     "_item_units_conversion.operator"  *  multiplication  
+     "_item_units_conversion.operator"  /  division        
+   #
+save_
+#
+save__item_units_conversion.factor
+   _item_description.name         "_item_units_conversion.factor"
+   _item_description.description  
+;
+     The arithmetic operation required to convert between the
+     unit systems:
+         <to_code> =  <from_code> <operator> <factor>
+;
+
+   #
+   _item.name            "_item_units_conversion.factor"
+   _item.category_id     item_units_conversion
+   _item.mandatory_code  yes
+   #
+   _item_type.name  "_item_units_conversion.factor"
+   _item_type.code  any
+   #
+save_
+#
+save_item_units_list
+   _category.description     
+;
+     Attributes which describe the physical units of measure
+     in which data items may be expressed.
+;
+
+   _category.id              item_units_list
+   _category.mandatory_code  no
+   _category.implicit_key    mmcif_ddl.dic
+   #
+   _category_key.id    item_units_list
+   _category_key.name  "_item_units_list.code"
+   #
+   loop_
+   _category_group.id
+   _category_group.category_id
+     ddl_group   item_units_list  
+     item_group  item_units_list  
+   #
+   _pdbx_category_context.category_id  item_units_list
+   _pdbx_category_context.type         DEFINITION
+   #
+save_
+#
+save__item_units_list.code
+   _item_description.name         "_item_units_list.code"
+   _item_description.description  
+;
+     The code specifying the name of the unit of measure.
+;
+
+   #
+   _item.name            "_item_units_list.code"
+   _item.category_id     item_units_list
+   _item.mandatory_code  yes
+   #
+   _item_type.name  "_item_units_list.code"
+   _item_type.code  code
+   #
+   loop_
+   _item_linked.child_name
+   _item_linked.parent_name
+     "_item_units.code"                        "_item_units_list.code"  
+     "_item_units_conversion.from_code"        "_item_units_list.code"  
+     "_item_units_conversion.to_code"          "_item_units_list.code"  
+     "_item_enumeration.rcsb_type_units_code"  "_item_units_list.code"  
+   #
+save_
+#
+save__item_units_list.detail
+   _item_description.name         "_item_units_list.detail"
+   _item_description.description  
+;
+     A description of the unit of measure.
+;
+
+   #
+   _item.name            "_item_units_list.detail"
+   _item.category_id     item_units_list
+   _item.mandatory_code  no
+   #
+   _item_type.name  "_item_units_list.detail"
+   _item_type.code  text
+   #
+save_
+#
+save_method_list
+   _category.description     
+;
+    Attributes specifying the list of methods applicable to data items,
+    sub-categories, and categories.
+;
+
+   _category.id              method_list
+   _category.mandatory_code  no
+   _category.implicit_key    mmcif_ddl.dic
+   #
+   _category_key.id    method_list
+   _category_key.name  "_method_list.id"
+   #
+   loop_
+   _category_group.id
+   _category_group.category_id
+     ddl_group       method_list  
+     item_group      method_list  
+     category_group  method_list  
+   #
+   _pdbx_category_context.category_id  method_list
+   _pdbx_category_context.type         DATA
+   #
+save_
+#
+save__method_list.id
+   _item_description.name         "_method_list.id"
+   _item_description.description  
+;
+     Identity of method in the list referenced by _method.id
+;
+
+   #
+   _item.name            "_method_list.id"
+   _item.category_id     method_list
+   _item.mandatory_code  yes
+   #
+   _item_type.name  "_method_list.id"
+   _item_type.code  idname
+   #
+   loop_
+   _item_linked.child_name
+   _item_linked.parent_name
+     "_item_methods.method_id"          "_method_list.id"  
+     "_category_methods.method_id"      "_method_list.id"  
+     "_sub_category_methods.method_id"  "_method_list.id"  
+     "_datablock_methods.method_id"     "_method_list.id"  
+   #
+save_
+#
+save__method_list.detail
+   _item_description.name         "_method_list.detail"
+   _item_description.description  
+;
+     Description of application method in _method_list.id
+;
+
+   #
+   _item.name            "_method_list.detail"
+   _item.category_id     method_list
+   _item.mandatory_code  no
+   #
+   _item_type.name  "_method_list.detail"
+   _item_type.code  text
+   #
+save_
+#
+save__method_list.implementation_source
+   _item_description.name         "_method_list.implementation_source"
+   _item_description.description  
+;
+     A code that describes the source of the method implementation.
+;
+
+   #
+   _item.name            "_method_list.implementation_source"
+   _item.category_id     method_list
+   _item.mandatory_code  yes
+   #
+   _item_type.name  "_method_list.implementation_source"
+   _item_type.code  code
+   #
+   loop_
+   _item_examples.name
+   _item_examples.case
+   _item_examples.detail
+     "_method_list.implementation_source"  inline     "inline method implementation"  
+     "_method_list.implementation_source"  reference  "reference to an external method implementation"  
+   #
+save_
+#
+save__method_list.inline
+   _item_description.name         "_method_list.inline"
+   _item_description.description  
+;
+     Inline text of the method implementation.
+;
+
+   #
+   _item.name            "_method_list.inline"
+   _item.category_id     method_list
+   _item.mandatory_code  no
+   #
+   _item_type.name  "_method_list.inline"
+   _item_type.code  text
+   #
+save_
+#
+save__method_list.implementation
+   _item_description.name         "_method_list.implementation"
+   _item_description.description  
+;
+     A language specific reference to the implementation of the method.
+;
+
+   #
+   _item.name            "_method_list.implementation"
+   _item.category_id     method_list
+   _item.mandatory_code  no
+   #
+   _item_type.name  "_method_list.implementation"
+   _item_type.code  text
+   #
+save_
+#
+save__method_list.code
+   _item_description.name         "_method_list.code"
+   _item_description.description  
+;
+     A code that describes the function of the method.
+;
+
+   #
+   _item.name            "_method_list.code"
+   _item.category_id     method_list
+   _item.mandatory_code  yes
+   #
+   _item_type.name  "_method_list.code"
+   _item_type.code  code
+   #
+   loop_
+   _item_examples.name
+   _item_examples.case
+   _item_examples.detail
+     "_method_list.code"  calculation     "method to calculate the item "  
+     "_method_list.code"  verification    "method to verify the data item "  
+     "_method_list.code"  cast            "method to provide cast conversion "  
+     "_method_list.code"  addition        "method to define item + item "  
+     "_method_list.code"  division        "method to define item / item "  
+     "_method_list.code"  multiplication  "method to define item * item "  
+     "_method_list.code"  equivalence     "method to define item = item "  
+     "_method_list.code"  other           "miscellaneous method "  
+   #
+save_
+#
+save__method_list.language
+   _item_description.name         "_method_list.language"
+   _item_description.description  
+;
+     Implementation language in which the method is expressed.
+;
+
+   #
+   _item.name            "_method_list.language"
+   _item.category_id     method_list
+   _item.mandatory_code  yes
+   #
+   _item_type.name  "_method_list.language"
+   _item_type.code  code
+   #
+   loop_
+   _item_examples.name
+   _item_examples.case
+   _item_examples.detail
+     "_method_list.language"  C           ?  
+     "_method_list.language"  C++         ?  
+     "_method_list.language"  Python      ?  
+     "_method_list.language"  Ruby        ?  
+     "_method_list.language"  Java        ?  
+     "_method_list.language"  Javascript  ?  
+     "_method_list.language"  other       ?  
+   #
+save_
+#
+save_dictionary
+   _category.description     
+;
+     Attributes for specifying the dictionary title, version and
+     data block identifier.
+;
+
+   _category.id              dictionary
+   _category.mandatory_code  yes
+   _category.implicit_key    mmcif_ddl.dic
+   #
+   _category_key.id    dictionary
+   _category_key.name  "_dictionary.datablock_id"
+   #
+   loop_
+   _category_group.id
+   _category_group.category_id
+     ddl_group         dictionary  
+     datablock_group   dictionary  
+     dictionary_group  dictionary  
+   #
+   _pdbx_category_context.category_id  dictionary
+   _pdbx_category_context.type         DATA
+   #
+save_
+#
+save__dictionary.datablock_id
+   _item_description.name         "_dictionary.datablock_id"
+   _item_description.description  
+;
+     The identifier for the data block containing the dictionary.
+;
+
+   #
+   _item.name            "_dictionary.datablock_id"
+   _item.category_id     dictionary
+   _item.mandatory_code  implicit
+   #
+   _item_type.name  "_dictionary.datablock_id"
+   _item_type.code  code
+   #
+save_
+#
+save__dictionary.title
+   _item_description.name         "_dictionary.title"
+   _item_description.description  
+;
+     Title identification of the dictionary.
+;
+
+   #
+   _item.name            "_dictionary.title"
+   _item.category_id     dictionary
+   _item.mandatory_code  yes
+   #
+   _item_type.name  "_dictionary.title"
+   _item_type.code  char
+   #
+save_
+#
+save__dictionary.version
+   _item_description.name         "_dictionary.version"
+   _item_description.description  
+;
+     A unique version identifier for the dictionary.
+;
+
+   #
+   _item.name            "_dictionary.version"
+   _item.category_id     dictionary
+   _item.mandatory_code  yes
+   #
+   _item_type.name  "_dictionary.version"
+   _item_type.code  char
+   #
+save_
+#
+save_dictionary_history
+   _category.description     
+;
+   Attributes for specifying the revision history of the dictionary.
+;
+
+   _category.id              dictionary_history
+   _category.mandatory_code  no
+   _category.implicit_key    mmcif_ddl.dic
+   #
+   _category_key.id    dictionary_history
+   _category_key.name  "_dictionary_history.version"
+   #
+   loop_
+   _category_group.id
+   _category_group.category_id
+     ddl_group         dictionary_history  
+     dictionary_group  dictionary_history  
+   #
+   _pdbx_category_context.category_id  dictionary_history
+   _pdbx_category_context.type         DATA
+   #
+save_
+#
+save__dictionary_history.version
+   _item_description.name         "_dictionary_history.version"
+   _item_description.description  
+;
+     A unique version identifier for the dictionary revision.
+;
+
+   #
+   _item.name            "_dictionary_history.version"
+   _item.category_id     dictionary_history
+   _item.mandatory_code  yes
+   #
+   _item_type.name  "_dictionary_history.version"
+   _item_type.code  char
+   #
+   _item_linked.child_name   "_dictionary.version"
+   _item_linked.parent_name  "_dictionary_history.version"
+   #
+save_
+#
+save__dictionary_history.update
+   _item_description.name         "_dictionary_history.update"
+   _item_description.description  
+;
+     The date that the last dictionary revision took place.
+;
+
+   #
+   _item.name            "_dictionary_history.update"
+   _item.category_id     dictionary_history
+   _item.mandatory_code  yes
+   #
+   _item_type.name  "_dictionary_history.update"
+   _item_type.code  yyyy-mm-dd
+   #
+save_
+#
+save__dictionary_history.revision
+   _item_description.name         "_dictionary_history.revision"
+   _item_description.description  
+;
+     Text description of the dictionary revision.
+;
+
+   #
+   _item.name            "_dictionary_history.revision"
+   _item.category_id     dictionary_history
+   _item.mandatory_code  yes
+   #
+   _item_type.name  "_dictionary_history.revision"
+   _item_type.code  text
+   #
+save_
+#
+save__category.NX_mapping_details
+   _item_description.name         "_category.NX_mapping_details"
+   _item_description.description  
+;
+     Records data correspondences between the items in this data category and
+     and related data items in Nexus data dictionary.
+;
+
+   #
+   _item.name            "_category.NX_mapping_details"
+   _item.category_id     category
+   _item.mandatory_code  no
+   #
+   _item_type.name  "_category.NX_mapping_details"
+   _item_type.code  text
+   #
+save_
+#
+save_ndb_category_description
+   _category.description     
+;
+     Alternate description of data items in this category.
+;
+
+   _category.id              ndb_category_description
+   _category.mandatory_code  no
+   _category.implicit_key    mmcif_ddl.dic
+   #
+   loop_
+   _category_key.id
+   _category_key.name
+     ndb_category_description  "_ndb_category_description.id"  
+     ndb_category_description  "_ndb_category_description.description"  
+   #
+   loop_
+   _category_group.id
+   _category_group.category_id
+     ddl_group        ndb_category_description  
+     category_group   ndb_category_description  
+     extension_group  ndb_category_description  
+   #
+   _pdbx_category_context.category_id  ndb_category_description
+   _pdbx_category_context.type         DEFINITION
+   #
+save_
+#
+save__ndb_category_description.id
+   _item.name            "_ndb_category_description.id"
+   _item.category_id     ndb_category_description
+   _item.mandatory_code  implicit
+   #
+   _item_type.name  "_ndb_category_description.id"
+   _item_type.code  idname
+   #
+   _item_linked.child_name   "_ndb_category_description.id"
+   _item_linked.parent_name  "_category.id"
+   #
+save_
+#
+save__ndb_category_description.description
+   _item_description.name         "_ndb_category_description.description"
+   _item_description.description  
+;
+     Alternate text description of a category.
+;
+
+   #
+   _item.name            "_ndb_category_description.description"
+   _item.category_id     ndb_category_description
+   _item.mandatory_code  yes
+   #
+   _item_type.name  "_ndb_category_description.description"
+   _item_type.code  text
+   #
+save_
+#
+save_ndb_category_examples
+   _category.description     
+;
+     Alternate example applications and descriptions of data items in this
+category.
+;
+
+   _category.id              ndb_category_examples
+   _category.mandatory_code  no
+   _category.implicit_key    mmcif_ddl.dic
+   #
+   loop_
+   _category_key.id
+   _category_key.name
+     ndb_category_examples  "_ndb_category_examples.id"  
+     ndb_category_examples  "_ndb_category_examples.case"  
+   #
+   loop_
+   _category_group.id
+   _category_group.category_id
+     ddl_group        ndb_category_examples  
+     category_group   ndb_category_examples  
+     extension_group  ndb_category_examples  
+   #
+   _pdbx_category_context.category_id  ndb_category_examples
+   _pdbx_category_context.type         DEFINITION
+   #
+save_
+#
+save__ndb_category_examples.id
+   _item.name            "_ndb_category_examples.id"
+   _item.category_id     ndb_category_examples
+   _item.mandatory_code  implicit
+   #
+   _item_type.name  "_ndb_category_examples.id"
+   _item_type.code  idname
+   #
+   _item_linked.child_name   "_ndb_category_examples.id"
+   _item_linked.parent_name  "_category.id"
+   #
+save_
+#
+save__ndb_category_examples.case
+   _item_description.name         "_ndb_category_examples.case"
+   _item_description.description  
+;
+     Alternate case of examples involving items in this category.
+;
+
+   #
+   _item.name            "_ndb_category_examples.case"
+   _item.category_id     ndb_category_examples
+   _item.mandatory_code  yes
+   #
+   _item_type.name  "_ndb_category_examples.case"
+   _item_type.code  text
+   #
+save_
+#
+save__ndb_category_examples.detail
+   _item_description.name         "_ndb_category_examples.detail"
+   _item_description.description  
+;
+     Alternate description of an example _category_examples.case
+;
+
+   #
+   _item.name            "_ndb_category_examples.detail"
+   _item.category_id     ndb_category_examples
+   _item.mandatory_code  no
+   #
+   _item_type.name  "_ndb_category_examples.detail"
+   _item_type.code  text
+   #
+save_
+#
+save_ndb_item_description
+   _category.description     
+;
+     This category holds the alternate descriptions of each data item.
+;
+
+   _category.id              ndb_item_description
+   _category.mandatory_code  no
+   _category.implicit_key    mmcif_ddl.dic
+   #
+   loop_
+   _category_key.id
+   _category_key.name
+     ndb_item_description  "_ndb_item_description.name"  
+     ndb_item_description  "_ndb_item_description.description"  
+   #
+   loop_
+   _category_group.id
+   _category_group.category_id
+     ddl_group        ndb_item_description  
+     item_group       ndb_item_description  
+     extension_group  ndb_item_description  
+   #
+   _pdbx_category_context.category_id  ndb_item_description
+   _pdbx_category_context.type         DEFINITION
+   #
+save_
+#
+save__ndb_item_description.name
+   _item_description.name         "_ndb_item_description.name"
+   _item_description.description  
+;
+     Data name of the defined item.
+;
+
+   #
+   _item.name            "_ndb_item_description.name"
+   _item.category_id     ndb_item_description
+   _item.mandatory_code  implicit
+   #
+   _item_type.name  "_ndb_item_description.name"
+   _item_type.code  name
+   #
+   _item_linked.child_name   "_ndb_item_description.name"
+   _item_linked.parent_name  "_item.name"
+   #
+save_
+#
+save__ndb_item_description.description
+   _item_description.name         "_ndb_item_description.description"
+   _item_description.description  
+;
+     Alternate text description of the defined data item.
+;
+
+   #
+   _item.name            "_ndb_item_description.description"
+   _item.category_id     ndb_item_description
+   _item.mandatory_code  yes
+   #
+   _item_type.name  "_ndb_item_description.description"
+   _item_type.code  text
+   #
+save_
+#
+save_ndb_item_enumeration
+   _category.description     
+;
+     Attributes which specify the permitted enumeration of the items.
+;
+
+   _category.id              ndb_item_enumeration
+   _category.mandatory_code  no
+   _category.implicit_key    mmcif_ddl.dic
+   #
+   loop_
+   _category_key.id
+   _category_key.name
+     ndb_item_enumeration  "_ndb_item_enumeration.name"  
+     ndb_item_enumeration  "_ndb_item_enumeration.value"  
+   #
+   loop_
+   _category_group.category_id
+   _category_group.id
+     ndb_item_enumeration  ddl_group        
+     ndb_item_enumeration  item_group       
+     ndb_item_enumeration  extension_group  
+   #
+   _pdbx_category_context.category_id  ndb_item_enumeration
+   _pdbx_category_context.type         DEFINITION
+   #
+save_
+#
+save__ndb_item_enumeration.name
+   _item.name            "_ndb_item_enumeration.name"
+   _item.category_id     ndb_item_enumeration
+   _item.mandatory_code  implicit
+   #
+   _item_type.name  "_ndb_item_enumeration.name"
+   _item_type.code  name
+   #
+   _item_linked.child_name   "_ndb_item_enumeration.name"
+   _item_linked.parent_name  "_item.name"
+   #
+save_
+#
+save__ndb_item_enumeration.value
+   _item_description.name         "_ndb_item_enumeration.value"
+   _item_description.description  
+;
+     A permissible value, character or number, for the defined item.
+;
+
+   #
+   _item.name            "_ndb_item_enumeration.value"
+   _item.category_id     ndb_item_enumeration
+   _item.mandatory_code  yes
+   #
+   _item_type.name  "_ndb_item_enumeration.value"
+   _item_type.code  any
+   #
+save_
+#
+save__ndb_item_enumeration.detail
+   _item_description.name         "_ndb_item_enumeration.detail"
+   _item_description.description  
+;
+     A description of a permissible value for the defined item.
+;
+
+   #
+   _item.name            "_ndb_item_enumeration.detail"
+   _item.category_id     ndb_item_enumeration
+   _item.mandatory_code  no
+   #
+   _item_type.name  "_ndb_item_enumeration.detail"
+   _item_type.code  text
+   #
+save_
+#
+save_ndb_item_examples
+   _category.description     
+;
+    Attributes for describing application examples of the data item.
+;
+
+   _category.id              ndb_item_examples
+   _category.mandatory_code  no
+   _category.implicit_key    mmcif_ddl.dic
+   #
+   loop_
+   _category_key.id
+   _category_key.name
+     ndb_item_examples  "_ndb_item_examples.name"  
+     ndb_item_examples  "_ndb_item_examples.case"  
+   #
+   loop_
+   _category_group.id
+   _category_group.category_id
+     ddl_group        ndb_item_examples  
+     item_group       ndb_item_examples  
+     extension_group  ndb_item_examples  
+   #
+   _pdbx_category_context.category_id  ndb_item_examples
+   _pdbx_category_context.type         DEFINITION
+   #
+save_
+#
+save__ndb_item_examples.case
+   _item_description.name         "_ndb_item_examples.case"
+   _item_description.description  
+;
+     Alternate example application of the defined data item.
+;
+
+   #
+   _item.name            "_ndb_item_examples.case"
+   _item.category_id     ndb_item_examples
+   _item.mandatory_code  yes
+   #
+   _item_type.name  "_ndb_item_examples.case"
+   _item_type.code  text
+   #
+save_
+#
+save__ndb_item_examples.detail
+   _item_description.name         "_ndb_item_examples.detail"
+   _item_description.description  
+;
+     Alternate description of an example specified in _ndb_item_example.case
+;
+
+   #
+   _item.name            "_ndb_item_examples.detail"
+   _item.category_id     ndb_item_examples
+   _item.mandatory_code  no
+   #
+   _item_type.name  "_ndb_item_examples.detail"
+   _item_type.code  text
+   #
+save_
+#
+save__ndb_item_examples.name
+   _item.name            "_ndb_item_examples.name"
+   _item.category_id     ndb_item_examples
+   _item.mandatory_code  implicit
+   #
+   _item_type.name  "_ndb_item_examples.name"
+   _item_type.code  name
+   #
+   _item_linked.child_name   "_ndb_item_examples.name"
+   _item_linked.parent_name  "_item.name"
+   #
+save_
+#
+save_ndb_item_range
+   _category.description     
+;
+     An alternative set of permissible range values of a data item.
+     When multiple ranges are specified they are interpreted sequentially
+     using a logical OR.  To specify that an item value may be
+     equal to a boundary value,  specify an item range where the
+     maximum and minimum values equal the boundary value.
+;
+
+   _category.id              ndb_item_range
+   _category.mandatory_code  no
+   _category.implicit_key    mmcif_ddl.dic
+   #
+   _category_key.id    ndb_item_range
+   _category_key.name  "_ndb_item_range.ordinal"
+   #
+   loop_
+   _category_group.id
+   _category_group.category_id
+     ddl_group        ndb_item_range  
+     item_group       ndb_item_range  
+     extension_group  ndb_item_range  
+   #
+   _pdbx_category_context.category_id  ndb_item_range
+   _pdbx_category_context.type         DEFINITION
+   #
+save_
+#
+save__ndb_item_range.ordinal
+   _item_description.name         "_ndb_item_range.ordinal"
+   _item_description.description  
+;
+     Name of data item ...
+;
+
+   #
+   _item.name            "_ndb_item_range.ordinal"
+   _item.category_id     ndb_item_range
+   _item.mandatory_code  implicit-ordinal
+   #
+   _item_type.name  "_ndb_item_range.ordinal"
+   _item_type.code  int
+   #
+save_
+#
+save__ndb_item_range.name
+   _item_description.name         "_ndb_item_range.name"
+   _item_description.description  
+;
+     Name of data item ...
+;
+
+   #
+   _item.name            "_ndb_item_range.name"
+   _item.category_id     ndb_item_range
+   _item.mandatory_code  implicit
+   #
+   _item_type.name  "_ndb_item_range.name"
+   _item_type.code  name
+   #
+   _item_linked.child_name   "_ndb_item_range.name"
+   _item_linked.parent_name  "_item.name"
+   #
+save_
+#
+save__ndb_item_range.minimum
+   _item_description.name         "_ndb_item_range.minimum"
+   _item_description.description  
+;
+     Alternate minimum permissible value of a data item or the lower bound
+     of a permissible range.  ( minimum value <  data value)
+;
+
+   #
+   _item.name            "_ndb_item_range.minimum"
+   _item.category_id     ndb_item_range
+   _item.mandatory_code  yes
+   #
+   _item_type.name  "_ndb_item_range.minimum"
+   _item_type.code  any
+   #
+save_
+#
+save__ndb_item_range.maximum
+   _item_description.name         "_ndb_item_range.maximum"
+   _item_description.description  
+;
+     Alternate maximum permissible value of a data item or the upper bound
+     of a permissible range.  ( maximum value >  data value)
+;
+
+   #
+   _item.name            "_ndb_item_range.maximum"
+   _item.category_id     ndb_item_range
+   _item.mandatory_code  yes
+   #
+   _item_type.name  "_ndb_item_range.maximum"
+   _item_type.code  any
+   #
+save_
+#
+save_ndb_item_type
+   _category.description     
+;
+     Attributes for specifying an alternate data type code for each data item.
+;
+
+   _category.id              ndb_item_type
+   _category.mandatory_code  no
+   _category.implicit_key    mmcif_ddl.dic
+   #
+   _category_key.id    ndb_item_type
+   _category_key.name  "_ndb_item_type.name"
+   #
+   loop_
+   _category_group.id
+   _category_group.category_id
+     ddl_group        ndb_item_type  
+     item_group       ndb_item_type  
+     extension_group  ndb_item_type  
+   #
+   _pdbx_category_context.category_id  ndb_item_type
+   _pdbx_category_context.type         DEFINITION
+   #
+save_
+#
+save__ndb_item_type.name
+   _item_description.name         "_ndb_item_type.name"
+   _item_description.description  
+;
+    The name of data item
+;
+
+   #
+   _item.name            "_ndb_item_type.name"
+   _item.category_id     ndb_item_type
+   _item.mandatory_code  implicit
+   #
+   _item_type.name  "_ndb_item_type.name"
+   _item_type.code  name
+   #
+save_
+#
+save__ndb_item_type.code
+   _item_description.name         "_ndb_item_type.code"
+   _item_description.description  
+;
+    Alternate data type of defined data item
+;
+
+   #
+   _item.name            "_ndb_item_type.code"
+   _item.category_id     ndb_item_type
+   _item.mandatory_code  yes
+   #
+   _item_type.name  "_ndb_item_type.code"
+   _item_type.code  code
+   #
+save_
+#
+save_ndb_item
+   _category.description     
+;
+     Attributes for specifying an alternate mandatory  code for each data item.
+;
+
+   _category.id              ndb_item
+   _category.mandatory_code  no
+   _category.implicit_key    mmcif_ddl.dic
+   #
+   _category_key.id    ndb_item
+   _category_key.name  "_ndb_item.name"
+   #
+   loop_
+   _category_group.id
+   _category_group.category_id
+     ddl_group        ndb_item  
+     item_group       ndb_item  
+     extension_group  ndb_item  
+   #
+   _pdbx_category_context.category_id  ndb_item
+   _pdbx_category_context.type         DEFINITION
+   #
+save_
+#
+save__ndb_item.name
+   _item_description.name         "_ndb_item.name"
+   _item_description.description  
+;
+    The name of data item
+;
+
+   #
+   _item.name            "_ndb_item.name"
+   _item.category_id     ndb_item
+   _item.mandatory_code  implicit
+   #
+   _item_type.name  "_ndb_item.name"
+   _item_type.code  name
+   #
+save_
+#
+save__ndb_item.mandatory_code
+   _item_description.name         "_ndb_item.mandatory_code"
+   _item_description.description  
+;
+    Alternate mandatory code for defined data item
+;
+
+   #
+   _item.name            "_ndb_item.mandatory_code"
+   _item.category_id     ndb_item
+   _item.mandatory_code  yes
+   #
+   _item_type.name  "_ndb_item.mandatory_code"
+   _item_type.code  code
+   #
+save_
+#
+save_pdbx_category_context
+   _category.description     
+;
+      Category definition context describing the scope of usage and
+      distribution for the category.
+;
+
+   _category.id              pdbx_category_context
+   _category.mandatory_code  no
+   _category.implicit_key    mmcif_ddl.dic
+   #
+   _category_key.id    pdbx_category_context
+   _category_key.name  "_pdbx_category_context.category_id"
+   #
+   loop_
+   _category_group.id
+   _category_group.category_id
+     ddl_group        pdbx_category_context  
+     category_group   pdbx_category_context  
+     extension_group  pdbx_category_context  
+   #
+   _pdbx_category_context.category_id  pdbx_category_context
+   _pdbx_category_context.type         DEFINITION
+   #
+save_
+#
+save__pdbx_category_context.category_id
+   _item.name            "_pdbx_category_context.category_id"
+   _item.category_id     pdbx_category_context
+   _item.mandatory_code  implicit
+   #
+   _item_type.name  "_pdbx_category_context.category_id"
+   _item_type.code  idname
+   #
+   _item_linked.child_name   "_pdbx_category_context.category_id"
+   _item_linked.parent_name  "_category.id"
+   #
+save_
+#
+save__pdbx_category_context.type
+   _item_description.name         "_pdbx_category_context.type"
+   _item_description.description  
+;
+     Category context type
+;
+
+   #
+   _item.name            "_pdbx_category_context.type"
+   _item.category_id     pdbx_category_context
+   _item.mandatory_code  yes
+   #
+   _item_type.name  "_pdbx_category_context.type"
+   _item_type.code  char
+   #
+   _item_examples.name    "_pdbx_category_context.type"
+   _item_examples.case    WWPDB_LOCAL
+   _item_examples.detail  "An category used internally by the wwPDB and not distributed in archival entries"
+   #
+save_
+#
+save_pdbx_item_context
+   _category.description     
+;
+      Item definition context describing the scope of usage and
+      distribution for the category.
+;
+
+   _category.id              pdbx_item_context
+   _category.mandatory_code  no
+   _category.implicit_key    mmcif_ddl.dic
+   #
+   _category_key.id    pdbx_item_context
+   _category_key.name  "_pdbx_item_context.item_name"
+   #
+   loop_
+   _category_group.id
+   _category_group.category_id
+     ddl_group        pdbx_item_context  
+     item_group       pdbx_item_context  
+     extension_group  pdbx_item_context  
+   #
+   _pdbx_category_context.category_id  pdbx_item_context
+   _pdbx_category_context.type         DEFINITION
+   #
+save_
+#
+save__pdbx_item_context.item_name
+   _item.name            "_pdbx_item_context.item_name"
+   _item.category_id     pdbx_item_context
+   _item.mandatory_code  implicit
+   #
+   _item_type.name  "_pdbx_item_context.item_name"
+   _item_type.code  name
+   #
+   _item_linked.child_name   "_pdbx_item_context.item_name"
+   _item_linked.parent_name  "_item.name"
+   #
+save_
+#
+save__pdbx_item_context.type
+   _item_description.name         "_pdbx_item_context.type"
+   _item_description.description  
+;
+     Item definition context type
+;
+
+   #
+   _item.name            "_pdbx_item_context.type"
+   _item.category_id     pdbx_item_context
+   _item.mandatory_code  yes
+   #
+   _item_type.name  "_pdbx_item_context.type"
+   _item_type.code  char
+   #
+   _item_examples.name    "_pdbx_item_context.type"
+   _item_examples.case    WWPDB_LOCAL
+   _item_examples.detail  "An item used internally by the wwPDB and not distributed in archival entries"
+   #
+save_
+#
+save_pdbx_item_enumeration_details
+   _category.id              pdbx_item_enumeration_details
+   _category.mandatory_code  no
+   _category.description     
+;
+      Attributes describing the additional details about the enumeration of the data item.
+;
+
+   _category.implicit_key    mmcif_ddl.dic
+   #
+   _category_key.id    pdbx_item_enumeration_details
+   _category_key.name  "_pdbx_item_enumeration_details.name"
+   #
+   loop_
+   _category_group.id
+   _category_group.category_id
+     ddl_group        pdbx_item_enumeration_details  
+     item_group       pdbx_item_enumeration_details  
+     extension_group  pdbx_item_enumeration_details  
+   #
+   _pdbx_category_context.category_id  pdbx_item_enumeration_details
+   _pdbx_category_context.type         DEFINITION
+   #
+save_
+#
+save__pdbx_item_enumeration_details.name
+   _item.name            "_pdbx_item_enumeration_details.name"
+   _item.category_id     pdbx_item_enumeration_details
+   _item.mandatory_code  implicit
+   #
+   _item_description.name         "_pdbx_item_enumeration_details.name"
+   _item_description.description  
+;
+     Data name of the defined item.
+;
+
+   #
+   _item_type.name  "_pdbx_item_enumeration_details.name"
+   _item_type.code  name
+   #
+   _item_linked.child_name   "_pdbx_item_enumeration_details.name"
+   _item_linked.parent_name  "_item.name"
+   #
+save_
+#
+save__pdbx_item_enumeration_details.closed_flag
+   _item.name            "_pdbx_item_enumeration_details.closed_flag"
+   _item.category_id     pdbx_item_enumeration_details
+   _item.mandatory_code  no
+   #
+   _item_description.name         "_pdbx_item_enumeration_details.closed_flag"
+   _item_description.description  
+;
+     A flag to indicate that this item may assume values outside of its specified enumeration list at deposition.
+;
+
+   #
+   _item_type.name  "_pdbx_item_enumeration_details.closed_flag"
+   _item_type.code  code
+   #
+   _item_examples.name    "_pdbx_item_enumeration_details.closed_flag"
+   _item_examples.case    no
+   _item_examples.detail  "An item which may assume values outside of defined enumeration values at deposition"
+   #
+   loop_
+   _item_enumeration.name
+   _item_enumeration.value
+   _item_enumeration.detail
+     "_pdbx_item_enumeration_details.closed_flag"  no   "The item may assume values outside of defined enumeration values at deposition"  
+     "_pdbx_item_enumeration_details.closed_flag"  yes  "The item may only assume enumeration values at deposition"  
+   #
+save_
+#
+save_pdbx_item_linked_group
+   _category.description     
+;
+    Attributes describing logical groups among item link relationships.
+;
+
+   _category.id              pdbx_item_linked_group
+   _category.mandatory_code  no
+   _category.implicit_key    mmcif_ddl.dic
+   #
+   loop_
+   _category_key.id
+   _category_key.name
+     pdbx_item_linked_group  "_pdbx_item_linked_group.category_id"  
+     pdbx_item_linked_group  "_pdbx_item_linked_group.link_group_id"  
+   #
+   loop_
+   _category_group.id
+   _category_group.category_id
+     ddl_group        pdbx_item_linked_group  
+     category_group   pdbx_item_linked_group  
+     extension_group  pdbx_item_linked_group  
+   #
+   _pdbx_category_context.category_id  pdbx_item_linked_group
+   _pdbx_category_context.type         DATA
+   #
+save_
+#
+save__pdbx_item_linked_group.category_id
+   _item_description.name         "_pdbx_item_linked_group.category_id"
+   _item_description.description  
+;
+     The category containing the item link group.
+;
+
+   #
+   _item.name            "_pdbx_item_linked_group.category_id"
+   _item.category_id     pdbx_item_linked_group
+   _item.mandatory_code  yes
+   #
+   _item_type.name  "_pdbx_item_linked_group.category_id"
+   _item_type.code  idname
+   #
+   _item_linked.child_name   "_pdbx_item_linked_group.category_id"
+   _item_linked.parent_name  "_category.id"
+   #
+save_
+#
+save__pdbx_item_linked_group.link_group_id
+   _item_description.name         "_pdbx_item_linked_group.link_group_id"
+   _item_description.description  
+;
+     The unique identifier for the link group within the category.
+;
+
+   #
+   _item.name            "_pdbx_item_linked_group.link_group_id"
+   _item.category_id     pdbx_item_linked_group
+   _item.mandatory_code  yes
+   #
+   _item_type.name  "_pdbx_item_linked_group.link_group_id"
+   _item_type.code  code
+   #
+save_
+#
+save__pdbx_item_linked_group.label
+   _item.name            "_pdbx_item_linked_group.label"
+   _item.category_id     pdbx_item_linked_group
+   _item.mandatory_code  yes
+   #
+   _item_type.name  "_pdbx_item_linked_group.label"
+   _item_type.code  text
+   #
+save_
+#
+save__pdbx_item_linked_group.context
+   _item.name            "_pdbx_item_linked_group.context"
+   _item.category_id     pdbx_item_linked_group
+   _item.mandatory_code  no
+   #
+   _item_type.name  "_pdbx_item_linked_group.context"
+   _item_type.code  text
+   #
+save_
+#
+save__pdbx_item_linked_group.condition_id
+   _item.name            "_pdbx_item_linked_group.condition_id"
+   _item.category_id     pdbx_item_linked_group
+   _item.mandatory_code  no
+   #
+   _item_type.name  "_pdbx_item_linked_group.condition_id"
+   _item_type.code  code
+   #
+save_
+#
+save_pdbx_item_linked_group_list
+   _category.description     
+;
+    Enumeration of item link membership within each item linked group.
+;
+
+   _category.id              pdbx_item_linked_group_list
+   _category.mandatory_code  no
+   _category.implicit_key    mmcif_ddl.dic
+   #
+   loop_
+   _category_key.id
+   _category_key.name
+     pdbx_item_linked_group_list  "_pdbx_item_linked_group_list.child_category_id"  
+     pdbx_item_linked_group_list  "_pdbx_item_linked_group_list.link_group_id"  
+     pdbx_item_linked_group_list  "_pdbx_item_linked_group_list.child_name"  
+     pdbx_item_linked_group_list  "_pdbx_item_linked_group_list.parent_name"  
+     pdbx_item_linked_group_list  "_pdbx_item_linked_group_list.parent_category_id"  
+   #
+   loop_
+   _category_group.id
+   _category_group.category_id
+     ddl_group        pdbx_item_linked_group_list  
+     item_group       pdbx_item_linked_group_list  
+     extension_group  pdbx_item_linked_group_list  
+   #
+   _pdbx_category_context.category_id  pdbx_item_linked_group_list
+   _pdbx_category_context.type         DATA
+   #
+save_
+#
+save__pdbx_item_linked_group_list.child_category_id
+   _item_description.name         "_pdbx_item_linked_group_list.child_category_id"
+   _item_description.description  
+;
+     The child category containing the item link group.
+;
+
+   #
+   _item.name            "_pdbx_item_linked_group_list.child_category_id"
+   _item.category_id     pdbx_item_linked_group_list
+   _item.mandatory_code  yes
+   #
+   _item_type.name  "_pdbx_item_linked_group_list.child_category_id"
+   _item_type.code  idname
+   #
+   _item_linked.child_name   "_pdbx_item_linked_group_list.child_category_id"
+   _item_linked.parent_name  "_pdbx_item_linked_group.category_id"
+   #
+save_
+#
+save__pdbx_item_linked_group_list.link_group_id
+   _item_description.name         "_pdbx_item_linked_group_list.link_group_id"
+   _item_description.description  
+;
+     The unique identifier for the link group within the category.
+;
+
+   #
+   _item.name            "_pdbx_item_linked_group_list.link_group_id"
+   _item.category_id     pdbx_item_linked_group_list
+   _item.mandatory_code  yes
+   #
+   _item_type.name  "_pdbx_item_linked_group_list.link_group_id"
+   _item_type.code  code
+   #
+   _item_linked.child_name   "_pdbx_item_linked_group_list.link_group_id"
+   _item_linked.parent_name  "_pdbx_item_linked_group.link_group_id"
+   #
+save_
+#
+save__pdbx_item_linked_group_list.child_name
+   _item_description.name         "_pdbx_item_linked_group_list.child_name"
+   _item_description.description  
+;
+     The item name of the child item in the item linked relationship.
+;
+
+   #
+   _item.name            "_pdbx_item_linked_group_list.child_name"
+   _item.category_id     pdbx_item_linked_group_list
+   _item.mandatory_code  yes
+   #
+   _item_type.name  "_pdbx_item_linked_group_list.child_name"
+   _item_type.code  name
+   #
+   _item_linked.child_name   "_pdbx_item_linked_group_list.child_name"
+   _item_linked.parent_name  "_item.name"
+   #
+save_
+#
+save__pdbx_item_linked_group_list.parent_name
+   _item_description.name         "_pdbx_item_linked_group_list.parent_name"
+   _item_description.description  
+;
+     The item name of the parent item in the item linked relationship.
+;
+
+   #
+   _item.name            "_pdbx_item_linked_group_list.parent_name"
+   _item.category_id     pdbx_item_linked_group_list
+   _item.mandatory_code  yes
+   #
+   _item_type.name  "_pdbx_item_linked_group_list.parent_name"
+   _item_type.code  name
+   #
+   _item_linked.child_name   "_pdbx_item_linked_group_list.parent_name"
+   _item_linked.parent_name  "_item.name"
+   #
+save_
+#
+save__pdbx_item_linked_group_list.parent_category_id
+   _item_description.name         "_pdbx_item_linked_group_list.parent_category_id"
+   _item_description.description  
+;
+     The parent category containing the target of the item link relationship.
+;
+
+   #
+   _item.name            "_pdbx_item_linked_group_list.parent_category_id"
+   _item.category_id     pdbx_item_linked_group_list
+   _item.mandatory_code  yes
+   #
+   _item_type.name  "_pdbx_item_linked_group_list.parent_category_id"
+   _item_type.code  idname
+   #
+   _item_linked.child_name   "_pdbx_item_linked_group_list.parent_category_id"
+   _item_linked.parent_name  "_item.category_id"
+   #
+save_
+#
+save_pdbx_item_range
+   _category.description     
+;
+     An alternative set of permissible range values of a data item.
+     When multiple ranges are specified they are interpreted sequentially
+     using a logical OR.  To specify that an item value may be
+     equal to a boundary value,  specify an item range where the
+     maximum and minimum values equal the boundary value.
+;
+
+   _category.id              pdbx_item_range
+   _category.mandatory_code  no
+   _category.implicit_key    mmcif_ddl.dic
+   #
+   _category_key.id    pdbx_item_range
+   _category_key.name  "_pdbx_item_range.ordinal"
+   #
+   loop_
+   _category_group.id
+   _category_group.category_id
+     ddl_group        pdbx_item_range  
+     item_group       pdbx_item_range  
+     extension_group  pdbx_item_range  
+   #
+   _pdbx_category_context.category_id  pdbx_item_range
+   _pdbx_category_context.type         DEFINITION
+   #
+save_
+#
+save__pdbx_item_range.ordinal
+   _item_description.name         "_pdbx_item_range.ordinal"
+   _item_description.description  
+;
+     Name of data item ...
+;
+
+   #
+   _item.name            "_pdbx_item_range.ordinal"
+   _item.category_id     pdbx_item_range
+   _item.mandatory_code  implicit-ordinal
+   #
+   _item_type.name  "_pdbx_item_range.ordinal"
+   _item_type.code  int
+   #
+save_
+#
+save__pdbx_item_range.name
+   _item_description.name         "_pdbx_item_range.name"
+   _item_description.description  
+;
+     Name of data item ...
+;
+
+   #
+   _item.name            "_pdbx_item_range.name"
+   _item.category_id     pdbx_item_range
+   _item.mandatory_code  implicit
+   #
+   _item_type.name  "_pdbx_item_range.name"
+   _item_type.code  name
+   #
+   _item_linked.child_name   "_pdbx_item_range.name"
+   _item_linked.parent_name  "_item.name"
+   #
+save_
+#
+save__pdbx_item_range.minimum
+   _item_description.name         "_pdbx_item_range.minimum"
+   _item_description.description  
+;
+     Alternate minimum permissible value of a data item or the lower bound
+     of a permissible range.  ( minimum value <  data value)
+;
+
+   #
+   _item.name            "_pdbx_item_range.minimum"
+   _item.category_id     pdbx_item_range
+   _item.mandatory_code  yes
+   #
+   _item_type.name  "_pdbx_item_range.minimum"
+   _item_type.code  any
+   #
+save_
+#
+save__pdbx_item_range.maximum
+   _item_description.name         "_pdbx_item_range.maximum"
+   _item_description.description  
+;
+     Alternate maximum permissible value of a data item or the upper bound
+     of a permissible range.  ( maximum value >  data value)
+;
+
+   #
+   _item.name            "_pdbx_item_range.maximum"
+   _item.category_id     pdbx_item_range
+   _item.mandatory_code  yes
+   #
+   _item_type.name  "_pdbx_item_range.maximum"
+   _item_type.code  any
+   #
+save_
+#
+save_pdbx_item_type
+   _category.description     
+;
+     Attributes for specifying an alternate data type code for each data item.
+;
+
+   _category.id              pdbx_item_type
+   _category.mandatory_code  no
+   _category.implicit_key    mmcif_ddl.dic
+   #
+   _category_key.id    pdbx_item_type
+   _category_key.name  "_pdbx_item_type.name"
+   #
+   loop_
+   _category_group.id
+   _category_group.category_id
+     ddl_group        pdbx_item_type  
+     item_group       pdbx_item_type  
+     extension_group  pdbx_item_type  
+   #
+   _pdbx_category_context.category_id  pdbx_item_type
+   _pdbx_category_context.type         DEFINITION
+   #
+save_
+#
+save__pdbx_item_type.name
+   _item_description.name         "_pdbx_item_type.name"
+   _item_description.description  
+;
+    The name of data item
+;
+
+   #
+   _item.name            "_pdbx_item_type.name"
+   _item.category_id     pdbx_item_type
+   _item.mandatory_code  implicit
+   #
+   _item_type.name  "_pdbx_item_type.name"
+   _item_type.code  name
+   #
+save_
+#
+save__pdbx_item_type.code
+   _item_description.name         "_pdbx_item_type.code"
+   _item_description.description  
+;
+    Alternate data type of defined data item
+;
+
+   #
+   _item.name            "_pdbx_item_type.code"
+   _item.category_id     pdbx_item_type
+   _item.mandatory_code  yes
+   #
+   _item_type.name  "_pdbx_item_type.code"
+   _item_type.code  code
+   #
+save_
+#
+save_pdbx_item
+   _category.description     
+;
+     Attributes for specifying an alternate mandatory  code for each data item.
+;
+
+   _category.id              pdbx_item
+   _category.mandatory_code  no
+   _category.implicit_key    mmcif_ddl.dic
+   #
+   _category_key.id    pdbx_item
+   _category_key.name  "_pdbx_item.name"
+   #
+   loop_
+   _category_group.id
+   _category_group.category_id
+     ddl_group        pdbx_item  
+     item_group       pdbx_item  
+     extension_group  pdbx_item  
+   #
+   _pdbx_category_context.category_id  pdbx_item
+   _pdbx_category_context.type         DEFINITION
+   #
+save_
+#
+save__pdbx_item.name
+   _item_description.name         "_pdbx_item.name"
+   _item_description.description  
+;
+    The name of data item
+;
+
+   #
+   _item.name            "_pdbx_item.name"
+   _item.category_id     pdbx_item
+   _item.mandatory_code  implicit
+   #
+   _item_type.name  "_pdbx_item.name"
+   _item_type.code  name
+   #
+save_
+#
+save__pdbx_item.mandatory_code
+   _item_description.name         "_pdbx_item.mandatory_code"
+   _item_description.description  
+;
+    Alternate mandatory code for defined data item
+;
+
+   #
+   _item.name            "_pdbx_item.mandatory_code"
+   _item.category_id     pdbx_item
+   _item.mandatory_code  yes
+   #
+   _item_type.name  "_pdbx_item.mandatory_code"
+   _item_type.code  code
+   #
+save_
+#
+save__pdbx_item.category_id
+   _item_description.name         "_pdbx_item.category_id"
+   _item_description.description  
+;
+     This is category id of the item.
+;
+
+   #
+   _item.name            "_pdbx_item.category_id"
+   _item.category_id     pdbx_item
+   _item.mandatory_code  implicit
+   #
+   _item_type.name  "_pdbx_item.category_id"
+   _item_type.code  idname
+   #
+save_
+#
+save_pdbx_category_description
+   _category.description     
+;
+     Alternate description of data items in this category.
+;
+
+   _category.id              pdbx_category_description
+   _category.mandatory_code  no
+   _category.implicit_key    mmcif_ddl.dic
+   #
+   loop_
+   _category_key.id
+   _category_key.name
+     pdbx_category_description  "_pdbx_category_description.id"  
+     pdbx_category_description  "_pdbx_category_description.description"  
+   #
+   loop_
+   _category_group.id
+   _category_group.category_id
+     ddl_group        pdbx_category_description  
+     category_group   pdbx_category_description  
+     extension_group  pdbx_category_description  
+   #
+   _pdbx_category_context.category_id  pdbx_category_description
+   _pdbx_category_context.type         DEFINITION
+   #
+save_
+#
+save__pdbx_category_description.id
+   _item.name            "_pdbx_category_description.id"
+   _item.category_id     pdbx_category_description
+   _item.mandatory_code  implicit
+   #
+   _item_type.name  "_pdbx_category_description.id"
+   _item_type.code  idname
+   #
+   _item_linked.child_name   "_pdbx_category_description.id"
+   _item_linked.parent_name  "_category.id"
+   #
+save_
+#
+save__pdbx_category_description.description
+   _item_description.name         "_pdbx_category_description.description"
+   _item_description.description  
+;
+     Alternate text description of a category.
+;
+
+   #
+   _item.name            "_pdbx_category_description.description"
+   _item.category_id     pdbx_category_description
+   _item.mandatory_code  yes
+   #
+   _item_type.name  "_pdbx_category_description.description"
+   _item_type.code  text
+   #
+save_
+#
+save_pdbx_category_examples
+   _category.description     
+;
+     Alternate example applications and descriptions of data items in this
+category.
+;
+
+   _category.id              pdbx_category_examples
+   _category.mandatory_code  no
+   _category.implicit_key    mmcif_ddl.dic
+   #
+   loop_
+   _category_key.id
+   _category_key.name
+     pdbx_category_examples  "_pdbx_category_examples.id"  
+     pdbx_category_examples  "_pdbx_category_examples.case"  
+   #
+   loop_
+   _category_group.id
+   _category_group.category_id
+     ddl_group        pdbx_category_examples  
+     category_group   pdbx_category_examples  
+     extension_group  pdbx_category_examples  
+   #
+save_
+#
+save__pdbx_category_examples.id
+   _item.name            "_pdbx_category_examples.id"
+   _item.category_id     pdbx_category_examples
+   _item.mandatory_code  implicit
+   #
+   _item_type.name  "_pdbx_category_examples.id"
+   _item_type.code  idname
+   #
+   _item_linked.child_name   "_pdbx_category_examples.id"
+   _item_linked.parent_name  "_category.id"
+   #
+save_
+#
+save__pdbx_category_examples.case
+   _item_description.name         "_pdbx_category_examples.case"
+   _item_description.description  
+;
+     Alternate case of examples involving items in this category.
+;
+
+   #
+   _item.name            "_pdbx_category_examples.case"
+   _item.category_id     pdbx_category_examples
+   _item.mandatory_code  yes
+   #
+   _item_type.name  "_pdbx_category_examples.case"
+   _item_type.code  text
+   #
+save_
+#
+save__pdbx_category_examples.detail
+   _item_description.name         "_pdbx_category_examples.detail"
+   _item_description.description  
+;
+     Alternate description of an example _category_examples.case
+;
+
+   #
+   _item.name            "_pdbx_category_examples.detail"
+   _item.category_id     pdbx_category_examples
+   _item.mandatory_code  no
+   #
+   _item_type.name  "_pdbx_category_examples.detail"
+   _item_type.code  text
+   #
+save_
+#
+save_pdbx_item_description
+   _category.description     
+;
+     This category holds the alternate descriptions of each data item.
+;
+
+   _category.id              pdbx_item_description
+   _category.mandatory_code  no
+   _category.implicit_key    mmcif_ddl.dic
+   #
+   loop_
+   _category_key.id
+   _category_key.name
+     pdbx_item_description  "_pdbx_item_description.name"  
+     pdbx_item_description  "_pdbx_item_description.description"  
+   #
+   loop_
+   _category_group.id
+   _category_group.category_id
+     ddl_group        pdbx_item_description  
+     item_group       pdbx_item_description  
+     extension_group  pdbx_item_description  
+   #
+   _pdbx_category_context.category_id  pdbx_item_description
+   _pdbx_category_context.type         DEFINITION
+   #
+save_
+#
+save__pdbx_item_description.name
+   _item_description.name         "_pdbx_item_description.name"
+   _item_description.description  
+;
+     Data name of the defined item.
+;
+
+   #
+   _item.name            "_pdbx_item_description.name"
+   _item.category_id     pdbx_item_description
+   _item.mandatory_code  implicit
+   #
+   _item_type.name  "_pdbx_item_description.name"
+   _item_type.code  name
+   #
+   _item_linked.child_name   "_pdbx_item_description.name"
+   _item_linked.parent_name  "_item.name"
+   #
+save_
+#
+save__pdbx_item_description.description
+   _item_description.name         "_pdbx_item_description.description"
+   _item_description.description  
+;
+     Alternate text description of the defined data item.
+;
+
+   #
+   _item.name            "_pdbx_item_description.description"
+   _item.category_id     pdbx_item_description
+   _item.mandatory_code  yes
+   #
+   _item_type.name  "_pdbx_item_description.description"
+   _item_type.code  text
+   #
+save_
+#
+save_pdbx_item_enumeration
+   _category.description     
+;
+     Attributes which specify the permitted enumeration of the items.
+;
+
+   _category.id              pdbx_item_enumeration
+   _category.mandatory_code  no
+   _category.implicit_key    mmcif_ddl.dic
+   #
+   loop_
+   _category_key.id
+   _category_key.name
+     pdbx_item_enumeration  "_pdbx_item_enumeration.name"  
+     pdbx_item_enumeration  "_pdbx_item_enumeration.value"  
+   #
+   loop_
+   _category_group.category_id
+   _category_group.id
+     pdbx_item_enumeration  ddl_group        
+     pdbx_item_enumeration  item_group       
+     pdbx_item_enumeration  extension_group  
+   #
+   _pdbx_category_context.category_id  pdbx_item_enumeration
+   _pdbx_category_context.type         DEFINITION
+   #
+save_
+#
+save__pdbx_item_enumeration.name
+   _item.name            "_pdbx_item_enumeration.name"
+   _item.category_id     pdbx_item_enumeration
+   _item.mandatory_code  implicit
+   #
+   _item_type.name  "_pdbx_item_enumeration.name"
+   _item_type.code  name
+   #
+   _item_linked.child_name   "_pdbx_item_enumeration.name"
+   _item_linked.parent_name  "_item.name"
+   #
+save_
+#
+save__pdbx_item_enumeration.value
+   _item_description.name         "_pdbx_item_enumeration.value"
+   _item_description.description  
+;
+     A permissible value, character or number, for the defined item.
+;
+
+   #
+   _item.name            "_pdbx_item_enumeration.value"
+   _item.category_id     pdbx_item_enumeration
+   _item.mandatory_code  yes
+   #
+   _item_type.name  "_pdbx_item_enumeration.value"
+   _item_type.code  any
+   #
+save_
+#
+save__pdbx_item_enumeration.detail
+   _item_description.name         "_pdbx_item_enumeration.detail"
+   _item_description.description  
+;
+     A description of a permissible value for the defined item.
+;
+
+   #
+   _item.name            "_pdbx_item_enumeration.detail"
+   _item.category_id     pdbx_item_enumeration
+   _item.mandatory_code  no
+   #
+   _item_type.name  "_pdbx_item_enumeration.detail"
+   _item_type.code  text
+   #
+save_
+#
+save__pdbx_item_enumeration.value_display
+   _item_description.name         "_pdbx_item_enumeration.value_display"
+   _item_description.description  
+;
+     An alternative form of the permissible value for display purposes.
+;
+
+   #
+   _item.name            "_pdbx_item_enumeration.value_display"
+   _item.category_id     pdbx_item_enumeration
+   _item.mandatory_code  no
+   #
+   _item_type.name  "_pdbx_item_enumeration.value_display"
+   _item_type.code  any
+   #
+save_
+#
+save__item_enumeration.pdbx_value_display
+   _item_description.name         "_item_enumeration.pdbx_value_display"
+   _item_description.description  
+;
+     An alternative form of the permissible value for display purposes.
+;
+
+   #
+   _item.name            "_item_enumeration.pdbx_value_display"
+   _item.category_id     item_enumeration
+   _item.mandatory_code  no
+   #
+   _item_type.name  "_item_enumeration.pdbx_value_display"
+   _item_type.code  any
+   #
+save_
+#
+save_pdbx_item_examples
+   _category.description     
+;
+    Attributes for describing application examples of the data item.
+;
+
+   _category.id              pdbx_item_examples
+   _category.mandatory_code  no
+   _category.implicit_key    mmcif_ddl.dic
+   #
+   loop_
+   _category_key.id
+   _category_key.name
+     pdbx_item_examples  "_pdbx_item_examples.name"  
+     pdbx_item_examples  "_pdbx_item_examples.case"  
+   #
+   loop_
+   _category_group.id
+   _category_group.category_id
+     ddl_group        pdbx_item_examples  
+     item_group       pdbx_item_examples  
+     extension_group  pdbx_item_examples  
+   #
+   _pdbx_category_context.category_id  pdbx_item_examples
+   _pdbx_category_context.type         DEFINITION
+   #
+save_
+#
+save__pdbx_item_examples.case
+   _item_description.name         "_pdbx_item_examples.case"
+   _item_description.description  
+;
+     Alternate example application of the defined data item.
+;
+
+   #
+   _item.name            "_pdbx_item_examples.case"
+   _item.category_id     pdbx_item_examples
+   _item.mandatory_code  yes
+   #
+   _item_type.name  "_pdbx_item_examples.case"
+   _item_type.code  text
+   #
+save_
+#
+save__pdbx_item_examples.detail
+   _item_description.name         "_pdbx_item_examples.detail"
+   _item_description.description  
+;
+     Alternate description of an example specified in _pdbx_item_example.case
+;
+
+   #
+   _item.name            "_pdbx_item_examples.detail"
+   _item.category_id     pdbx_item_examples
+   _item.mandatory_code  no
+   #
+   _item_type.name  "_pdbx_item_examples.detail"
+   _item_type.code  text
+   #
+save_
+#
+save__pdbx_item_examples.name
+   _item.name            "_pdbx_item_examples.name"
+   _item.category_id     pdbx_item_examples
+   _item.mandatory_code  implicit
+   #
+   _item_type.name  "_pdbx_item_examples.name"
+   _item_type.code  name
+   #
+   _item_linked.child_name   "_pdbx_item_examples.name"
+   _item_linked.parent_name  "_item.name"
+   #
+save_
+#
+save__item_sub_category.pdbx_label
+   _item_description.name         "_item_sub_category.pdbx_label"
+   _item_description.description  
+;
+    An optional label for an instance of a subcategory within a category
+;
+
+   #
+   _item.name            "_item_sub_category.pdbx_label"
+   _item.category_id     item_sub_category
+   _item.mandatory_code  no
+   #
+   _item_type.name  "_item_sub_category.pdbx_label"
+   _item_type.code  code
+   #
+save_
+#
+save_pdbx_item_set
+   _category.description     
+;
+      Attributes assigning membership in sets of data items.
+;
+
+   _category.id              pdbx_item_set
+   _category.mandatory_code  no
+   _category.implicit_key    mmcif_ddl.dic
+   #
+   loop_
+   _category_key.id
+   _category_key.name
+     pdbx_item_set  "_pdbx_item_set.item_name"  
+     pdbx_item_set  "_pdbx_item_set.set_id"  
+   #
+   loop_
+   _category_group.id
+   _category_group.category_id
+     ddl_group        pdbx_item_set  
+     item_group       pdbx_item_set  
+     extension_group  pdbx_item_set  
+   #
+   _pdbx_category_context.category_id  pdbx_item_set
+   _pdbx_category_context.type         DEFINITION
+   #
+save_
+#
+save__pdbx_item_set.item_name
+   _item.name            "_pdbx_item_set.item_name"
+   _item.category_id     pdbx_item_set
+   _item.mandatory_code  implicit
+   #
+   _item_type.name  "_pdbx_item_set.item_name"
+   _item_type.code  name
+   #
+   _item_linked.child_name   "_pdbx_item_set.item_name"
+   _item_linked.parent_name  "_item.name"
+   #
+save_
+#
+save__pdbx_item_set.set_id
+   _item_description.name         "_pdbx_item_set.set_id"
+   _item_description.description  
+;
+     An item set identifier.
+;
+
+   #
+   _item.name            "_pdbx_item_set.set_id"
+   _item.category_id     pdbx_item_set
+   _item.mandatory_code  yes
+   #
+   _item_type.name  "_pdbx_item_set.set_id"
+   _item_type.code  code
+   #
+   _item_examples.name    "_pdbx_item_set.set_id"
+   _item_examples.case    RVALUE_ITEM_SET
+   _item_examples.detail  "The set of data items defining R-value statistics"
+   #
+   _item_linked.child_name   "_pdbx_item_set.set_id"
+   _item_linked.parent_name  "_pdbx_item_set_type_list.set_id"
+   #
+save_
+#
+save_pdbx_item_set_type_list
+   _category.description     
+;
+      Attributes defining the properties of item sets.
+;
+
+   _category.id              pdbx_item_set_type_list
+   _category.mandatory_code  no
+   _category.implicit_key    mmcif_ddl.dic
+   #
+   _category_key.id    pdbx_item_set_type_list
+   _category_key.name  "_pdbx_item_set_type_list.set_id"
+   #
+   loop_
+   _category_group.id
+   _category_group.category_id
+     ddl_group        pdbx_item_set_type_list  
+     item_group       pdbx_item_set_type_list  
+     extension_group  pdbx_item_set_type_list  
+   #
+   _pdbx_category_context.category_id  pdbx_item_set_type_list
+   _pdbx_category_context.type         DEFINITION
+   #
+save_
+#
+save__pdbx_item_set_type_list.set_id
+   _item_description.name         "_pdbx_item_set_type_list.set_id"
+   _item_description.description  
+;
+     An item set identifier.
+;
+
+   #
+   _item.name            "_pdbx_item_set_type_list.set_id"
+   _item.category_id     pdbx_item_set_type_list
+   _item.mandatory_code  yes
+   #
+   _item_type.name  "_pdbx_item_set_type_list.set_id"
+   _item_type.code  code
+   #
+   _item_examples.name    "_pdbx_item_set_type_list.set_id"
+   _item_examples.case    RVALUE_ITEM_SET
+   _item_examples.detail  "The set of data items defining R-value statistics"
+   #
+save_
+#
+save__pdbx_item_set_type_list.set_type
+   _item_description.name         "_pdbx_item_set_type_list.set_type"
+   _item_description.description  
+;
+     The item set type.
+;
+
+   #
+   _item.name            "_pdbx_item_set_type_list.set_type"
+   _item.category_id     pdbx_item_set_type_list
+   _item.mandatory_code  yes
+   #
+   _item_type.name  "_pdbx_item_set_type_list.set_type"
+   _item_type.code  char
+   #
+   _item_examples.name    "_pdbx_item_set_type_list.set_type"
+   _item_examples.case    if_one_then_all_required
+   _item_examples.detail  "If one member of the item set is provided then all members are required"
+   #
+   loop_
+   _item_enumeration.name
+   _item_enumeration.value
+   _item_enumeration.detail
+     "_pdbx_item_set_type_list.set_type"  if_one_then_all_required  "If one member of the item set is provided then all members are required"  
+     "_pdbx_item_set_type_list.set_type"  one_member_required       "One member of the item set must be provided"  
+     "_pdbx_item_set_type_list.set_type"  all_members_recommended   "It is recommended to provide all members of the item set"  
+   #
+save_
+#
+save__pdbx_item_set_type_list.validation_level
+   _item_description.name         "_pdbx_item_set_type_list.validation_level"
+   _item_description.description  
+;
+     The exception level associated with failure to satisfy the requirements of the item set type.
+;
+
+   #
+   _item.name            "_pdbx_item_set_type_list.validation_level"
+   _item.category_id     pdbx_item_set_type_list
+   _item.mandatory_code  yes
+   #
+   _item_type.name  "_pdbx_item_set_type_list.validation_level"
+   _item_type.code  char
+   #
+   _item_examples.name    "_pdbx_item_set_type_list.validation_level"
+   _item_examples.case    error
+   _item_examples.detail  "Exceptions are considered errors"
+   #
+   loop_
+   _item_enumeration.name
+   _item_enumeration.value
+   _item_enumeration.detail
+     "_pdbx_item_set_type_list.validation_level"  error   "Exceptions are considered errors"  
+     "_pdbx_item_set_type_list.validation_level"  warn    "Exceptions are considered warnings"  
+     "_pdbx_item_set_type_list.validation_level"  inform  "Exceptions are considered informational"  
+   #
+save_
+#
+save__pdbx_item_set_type_list.details
+   _item_description.name         "_pdbx_item_set_type_list.details"
+   _item_description.description  
+;
+     Additional details describing the item set.
+;
+
+   #
+   _item.name            "_pdbx_item_set_type_list.details"
+   _item.category_id     pdbx_item_set_type_list
+   _item.mandatory_code  no
+   #
+   _item_type.name  "_pdbx_item_set_type_list.details"
+   _item_type.code  text
+   #
+save_
+#
+save_pdbx_include_dictionary
+   _category.description     
+;
+      Category describing the details of dictionary composition achieved through
+      dictionary-level content inclusion from external sources.
+
+      Inclusion directives in this category may be used to include the
+      contents of complete dictionary text files.  A finer level of
+      control may be obtained by combining dictionary as well as category
+      item-level include directives in categories PDBX_INCLUDE_CATEGORY
+      and PDBX_INCLUDE_ITEM.
+;
+
+   _category.id              pdbx_include_dictionary
+   _category.mandatory_code  no
+   _category.implicit_key    mmcif_ddl.dic
+   #
+   loop_
+   _category_key.id
+   _category_key.name
+     pdbx_include_dictionary  "_pdbx_include_dictionary.datablock_id"  
+     pdbx_include_dictionary  "_pdbx_include_dictionary.dictionary_id"  
+   #
+   loop_
+   _category_group.id
+   _category_group.category_id
+     ddl_group         pdbx_include_dictionary  
+     dictionary_group  pdbx_include_dictionary  
+     extension_group   pdbx_include_dictionary  
+   #
+   _pdbx_category_context.category_id  pdbx_include_dictionary
+   _pdbx_category_context.type         DATA
+   #
+save_
+#
+save__pdbx_include_dictionary.datablock_id
+   _item_description.name         "_pdbx_include_dictionary.datablock_id"
+   _item_description.description  
+;
+     Identifier of data block.
+;
+
+   #
+   _item.name            "_pdbx_include_dictionary.datablock_id"
+   _item.category_id     pdbx_include_dictionary
+   _item.mandatory_code  implicit
+   #
+   _item_type.name  "_pdbx_include_dictionary.datablock_id"
+   _item_type.code  code
+   #
+save_
+#
+save__pdbx_include_dictionary.dictionary_id
+   _item_description.name         "_pdbx_include_dictionary.dictionary_id"
+   _item_description.description  
+;
+    Unique identifier for the included dictionary or dictionary component.
+;
+
+   #
+   _item.name            "_pdbx_include_dictionary.dictionary_id"
+   _item.category_id     pdbx_include_dictionary
+   _item.mandatory_code  yes
+   #
+   _item_type.name  "_pdbx_include_dictionary.dictionary_id"
+   _item_type.code  code
+   #
+save_
+#
+save__pdbx_include_dictionary.dictionary_locator
+   _item_description.name         "_pdbx_include_dictionary.dictionary_locator"
+   _item_description.description  
+;
+    Network accessible locator for the included dictionary text.
+;
+
+   #
+   _item.name            "_pdbx_include_dictionary.dictionary_locator"
+   _item.category_id     pdbx_include_dictionary
+   _item.mandatory_code  yes
+   #
+   _item_type.name  "_pdbx_include_dictionary.dictionary_locator"
+   _item_type.code  url
+   #
+   _item_examples.name    "_pdbx_include_dictionary.dictionary_locator"
+   _item_examples.case    http://mmcif.wwpdb.org/dictionaries/ascii/mmcif_pdbx_v40.dic
+   _item_examples.detail  "URL linking to the PDBx/mmCIF dictionary"
+   #
+save_
+#
+save__pdbx_include_dictionary.include_mode
+   _item_description.name         "_pdbx_include_dictionary.include_mode"
+   _item_description.description  
+;
+     Item definition describing the action undertaken to resolve name category name conflicts on including dictionary content.
+;
+
+   #
+   _item.name            "_pdbx_include_dictionary.include_mode"
+   _item.category_id     pdbx_include_dictionary
+   _item.mandatory_code  yes
+   #
+   _item_type.name  "_pdbx_include_dictionary.include_mode"
+   _item_type.code  char
+   #
+   loop_
+   _item_enumeration.name
+   _item_enumeration.value
+   _item_enumeration.detail
+     "_pdbx_include_dictionary.include_mode"  replace  "Content of included categories replaces any exiting category content of the same name"  
+     "_pdbx_include_dictionary.include_mode"  extend   "Content of included categories extends any exiting category content of the same name"  
+   #
+save_
+#
+save__pdbx_include_dictionary.dictionary_namespace_prefix
+   _item_description.name         "_pdbx_include_dictionary.dictionary_namespace_prefix"
+   _item_description.description  
+;
+    The namespace prefix used in the included source dictionary.
+;
+
+   #
+   _item.name            "_pdbx_include_dictionary.dictionary_namespace_prefix"
+   _item.category_id     pdbx_include_dictionary
+   _item.mandatory_code  no
+   #
+   _item_type.name  "_pdbx_include_dictionary.dictionary_namespace_prefix"
+   _item_type.code  code
+   #
+   _item_examples.name    "_pdbx_include_dictionary.dictionary_namespace_prefix"
+   _item_examples.case    pdbx_
+   _item_examples.detail  "Namespace prefix used by the wwPDB in the PDBx/mmCIF dictionary"
+   #
+save_
+#
+save__pdbx_include_dictionary.dictionary_namespace_prefix_replace
+   _item_description.name         "_pdbx_include_dictionary.dictionary_namespace_prefix"
+   _item_description.description  
+;
+    The namespace prefix used in the destination dictionary. Definitions with the source namespace
+    are replaced by this namespace prefix.
+;
+
+   #
+   _item.name            "_pdbx_include_dictionary.dictionary_namespace_prefix_replace"
+   _item.category_id     pdbx_include_dictionary
+   _item.mandatory_code  no
+   #
+   _item_type.name  "_pdbx_include_dictionary.dictionary_namespace_prefix_replace"
+   _item_type.code  code
+   #
+   _item_examples.name    "_pdbx_include_dictionary.dictionary_namespace_prefix_replace"
+   _item_examples.case    lcl_
+   _item_examples.detail  "Replacement namespace prefix."
+   #
+save_
+#
+save_pdbx_include_category
+   _category.description     
+;
+      Category describing the details of dictionary composition achieved through
+      category-level content inclusion from external dictionary sources.
+
+      Inclusion directives in this category take precedence over any
+      dictionary-level include directives in category PDBX_INCLUDE_DICTIONARY.
+;
+
+   _category.id              pdbx_include_category
+   _category.mandatory_code  no
+   _category.implicit_key    mmcif_ddl.dic
+   #
+   loop_
+   _category_key.id
+   _category_key.name
+     pdbx_include_category  "_pdbx_include_category.category_id"  
+     pdbx_include_category  "_pdbx_include_category.dictionary_id"  
+   #
+   loop_
+   _category_group.id
+   _category_group.category_id
+     ddl_group        pdbx_include_category  
+     category_group   pdbx_include_category  
+     extension_group  pdbx_include_category  
+   #
+   _pdbx_category_context.category_id  pdbx_include_category
+   _pdbx_category_context.type         DATA
+   #
+save_
+#
+save__pdbx_include_category.category_id
+   _item_description.name         "_pdbx_include_category.category_id"
+   _item_description.description  
+;
+    Unique identifier for a source category within the included dictionary.
+;
+
+   #
+   _item.name            "_pdbx_include_category.category_id"
+   _item.category_id     pdbx_include_category
+   _item.mandatory_code  yes
+   #
+   _item_type.name  "_pdbx_include_category.category_id"
+   _item_type.code  idname
+   #
+save_
+#
+save__pdbx_include_category.dictionary_id
+   _item_description.name         "_pdbx_include_category.dictionary_id"
+   _item_description.description  
+;
+    Unique identifier for the included dictionary.
+;
+
+   #
+   _item.name            "_pdbx_include_category.dictionary_id"
+   _item.category_id     pdbx_include_category
+   _item.mandatory_code  yes
+   #
+   _item_type.name  "_pdbx_include_category.dictionary_id"
+   _item_type.code  code
+   #
+   _item_linked.child_name   "_pdbx_include_category.dictionary_id"
+   _item_linked.parent_name  "_pdbx_include_dictionary.dictionary_id"
+   #
+save_
+#
+save__pdbx_include_category.include_as_category_id
+   _item_description.name         "_pdbx_include_category.include_as_category_id"
+   _item_description.description  
+;
+    The identifier for the target category within the destination dictionary.
+;
+
+   #
+   _item.name            "_pdbx_include_category.include_as_category_id"
+   _item.category_id     pdbx_include_category
+   _item.mandatory_code  no
+   #
+   _item_type.name  "_pdbx_include_category.include_as_category_id"
+   _item_type.code  idname
+   #
+save_
+#
+save__pdbx_include_category.include_mode
+   _item_description.name         "_pdbx_include_category.include_mode"
+   _item_description.description  
+;
+     The action undertaken to resolve category name conflicts subject to the
+     current category-level include directive.
+;
+
+   #
+   _item.name            "_pdbx_include_category.include_mode"
+   _item.category_id     pdbx_include_category
+   _item.mandatory_code  yes
+   #
+   _item_type.name  "_pdbx_include_category.include_mode"
+   _item_type.code  char
+   #
+   loop_
+   _item_enumeration.name
+   _item_enumeration.value
+   _item_enumeration.detail
+     "_pdbx_include_category.include_mode"  replace  "Content of included categories replaces any exiting category content of the same name"  
+     "_pdbx_include_category.include_mode"  extend   "Content of included categories extends any exiting category content of the same name"  
+   #
+save_
+#
+save_pdbx_include_item
+   _category.description     
+;
+      Category describing the details of dictionary composition achieved through
+      item-level content inclusion from external sources.
+
+      Item inclusion directives in this category take precedence over any
+      category-level include directives in category PDBX_INCLUDE_CATEGORY.
+;
+
+   _category.id              pdbx_include_item
+   _category.mandatory_code  no
+   _category.implicit_key    mmcif_ddl.dic
+   #
+   loop_
+   _category_key.id
+   _category_key.name
+     pdbx_include_item  "_pdbx_include_item.item_name"  
+     pdbx_include_item  "_pdbx_include_item.dictionary_id"  
+   #
+   loop_
+   _category_group.id
+   _category_group.category_id
+     ddl_group        pdbx_include_item  
+     item_group       pdbx_include_item  
+     extension_group  pdbx_include_item  
+   #
+   _pdbx_category_context.category_id  pdbx_include_item
+   _pdbx_category_context.type         DATA
+   #
+save_
+#
+save__pdbx_include_item.item_name
+   _item_description.name         "_pdbx_include_item.item_name"
+   _item_description.description  
+;
+    Unique identifier for a target item within the included dictionary.
+;
+
+   #
+   _item.name            "_pdbx_include_item.item_name"
+   _item.category_id     pdbx_include_item
+   _item.mandatory_code  yes
+   #
+   _item_type.name  "_pdbx_include_item.item_name"
+   _item_type.code  name
+   #
+save_
+#
+save__pdbx_include_item.dictionary_id
+   _item_description.name         "_pdbx_include_item.dictionary_id"
+   _item_description.description  
+;
+    Unique identifier for included dictionary.
+;
+
+   #
+   _item.name            "_pdbx_include_item.dictionary_id"
+   _item.category_id     pdbx_include_item
+   _item.mandatory_code  yes
+   #
+   _item_type.name  "_pdbx_include_item.dictionary_id"
+   _item_type.code  code
+   #
+   _item_linked.child_name   "_pdbx_include_item.dictionary_id"
+   _item_linked.parent_name  "_pdbx_include_dictionary.dictionary_id"
+   #
+save_
+#
+save__pdbx_include_item.include_as_item_name
+   _item_description.name         "_pdbx_include_item.include_as_item_name"
+   _item_description.description  
+;
+    The identifier for the target item within the destination dictionary.
+;
+
+   #
+   _item.name            "_pdbx_include_item.include_as_item_name"
+   _item.category_id     pdbx_include_item
+   _item.mandatory_code  no
+   #
+   _item_type.name  "_pdbx_include_item.include_as_item_name"
+   _item_type.code  name
+   #
+save_
+#
+save__pdbx_include_item.include_mode
+   _item_description.name         "_pdbx_include_item.include_mode"
+   _item_description.description  
+;
+     The action of taken to resolve item name conflicts subject to the current item-level include directive.
+;
+
+   #
+   _item.name            "_pdbx_include_item.include_mode"
+   _item.category_id     pdbx_include_item
+   _item.mandatory_code  yes
+   #
+   _item_type.name  "_pdbx_include_item.include_mode"
+   _item_type.code  char
+   #
+   loop_
+   _item_enumeration.name
+   _item_enumeration.value
+   _item_enumeration.detail
+     "_pdbx_include_item.include_mode"  replace  "Content of included items replaces any exiting item content of the same name"  
+     "_pdbx_include_item.include_mode"  extend   "Content of included items extends any exiting item content of the same name"  
+   #
+save_
+#
+save_pdbx_dictionary_component
+   _category.description     
+;
+     Attributes for specifying a component dictionary title, version and
+     data block identifier.
+;
+
+   _category.id              pdbx_dictionary_component
+   _category.mandatory_code  no
+   _category.implicit_key    mmcif_ddl.dic
+   #
+   loop_
+   _category_key.id
+   _category_key.name
+     pdbx_dictionary_component  "_pdbx_dictionary_component.datablock_id"  
+     pdbx_dictionary_component  "_pdbx_dictionary_component.dictionary_component_id"  
+   #
+   loop_
+   _category_group.id
+   _category_group.category_id
+     ddl_group        pdbx_dictionary_component  
+     datablock_group  pdbx_dictionary_component  
+     extension_group  pdbx_dictionary_component  
+   #
+   _pdbx_category_context.category_id  pdbx_dictionary_component
+   _pdbx_category_context.type         DATA
+   #
+save_
+#
+save__pdbx_dictionary_component.datablock_id
+   _item_description.name         "_pdbx_dictionary_component.datablock_id"
+   _item_description.description  
+;
+     The identifier for the data block containing the dictionary component.
+;
+
+   #
+   _item.name            "_pdbx_dictionary_component.datablock_id"
+   _item.category_id     pdbx_dictionary_component
+   _item.mandatory_code  implicit
+   #
+   _item_type.name  "_pdbx_dictionary_component.datablock_id"
+   _item_type.code  code
+   #
+save_
+#
+save__pdbx_dictionary_component.dictionary_component_id
+   _item_description.name         "_pdbx_dictionary_component.dictionary_component_id"
+   _item_description.description  
+;
+     The identifier for the dictionary component.
+;
+
+   #
+   _item.name            "_pdbx_dictionary_component.dictionary_component_id"
+   _item.category_id     pdbx_dictionary_component
+   _item.mandatory_code  yes
+   #
+   _item_type.name  "_pdbx_dictionary_component.dictionary_component_id"
+   _item_type.code  char
+   #
+save_
+#
+save__pdbx_dictionary_component.title
+   _item_description.name         "_pdbx_dictionary_component.title"
+   _item_description.description  
+;
+     Title identification of the dictionary component.
+;
+
+   #
+   _item.name            "_pdbx_dictionary_component.title"
+   _item.category_id     pdbx_dictionary_component
+   _item.mandatory_code  yes
+   #
+   _item_type.name  "_pdbx_dictionary_component.title"
+   _item_type.code  char
+   #
+save_
+#
+save__pdbx_dictionary_component.version
+   _item_description.name         "_pdbx_dictionary_component.version"
+   _item_description.description  
+;
+     A unique version identifier for the dictionary component version.
+;
+
+   #
+   _item.name            "_pdbx_dictionary_component.version"
+   _item.category_id     pdbx_dictionary_component
+   _item.mandatory_code  yes
+   #
+   _item_type.name  "_pdbx_dictionary_component.version"
+   _item_type.code  char
+   #
+save_
+#
+save_pdbx_dictionary_component_history
+   _category.description     
+;
+   Attributes for specifying the revision history for a dictionary component.
+;
+
+   _category.id              pdbx_dictionary_component_history
+   _category.mandatory_code  no
+   _category.implicit_key    mmcif_ddl.dic
+   #
+   loop_
+   _category_key.id
+   _category_key.name
+     pdbx_dictionary_component_history  "_pdbx_dictionary_component_history.version"  
+     pdbx_dictionary_component_history  "_pdbx_dictionary_component_history.dictionary_component_id"  
+   #
+   loop_
+   _category_group.id
+   _category_group.category_id
+     ddl_group         pdbx_dictionary_component_history  
+     dictionary_group  pdbx_dictionary_component_history  
+     extension_group   pdbx_dictionary_component_history  
+   #
+   _pdbx_category_context.category_id  pdbx_dictionary_component_history
+   _pdbx_category_context.type         DATA
+   #
+save_
+#
+save__pdbx_dictionary_component_history.version
+   _item_description.name         "_pdbx_dictionary_component_history.version"
+   _item_description.description  
+;
+     A unique version identifier for the dictionary component revision.
+;
+
+   #
+   _item.name            "_pdbx_dictionary_component_history.version"
+   _item.category_id     pdbx_dictionary_component_history
+   _item.mandatory_code  yes
+   #
+   _item_type.name  "_pdbx_dictionary_component_history.version"
+   _item_type.code  char
+   #
+   _item_linked.parent_name  "_pdbx_dictionary_component_history.version"
+   _item_linked.child_name   "_pdbx_dictionary_component.version"
+   #
+save_
+#
+save__pdbx_dictionary_component_history.dictionary_component_id
+   _item_description.name         "_pdbx_dictionary_component_history.dictionary_component_id"
+   _item_description.description  
+;
+     A unique dictionary component identifier for the dictionary component.
+;
+
+   #
+   _item.name            "_pdbx_dictionary_component_history.dictionary_component_id"
+   _item.category_id     pdbx_dictionary_component_history
+   _item.mandatory_code  yes
+   #
+   _item_type.name  "_pdbx_dictionary_component_history.dictionary_component_id"
+   _item_type.code  char
+   #
+   _item_linked.child_name   "_pdbx_dictionary_component_history.dictionary_component_id"
+   _item_linked.parent_name  "_pdbx_dictionary_component.dictionary_component_id"
+   #
+save_
+#
+save__pdbx_dictionary_component_history.update
+   _item_description.name         "_pdbx_dictionary_component_history.update"
+   _item_description.description  
+;
+     The date that the last dictionary component revision took place.
+;
+
+   #
+   _item.name            "_pdbx_dictionary_component_history.update"
+   _item.category_id     pdbx_dictionary_component_history
+   _item.mandatory_code  yes
+   #
+   _item_type.name  "_pdbx_dictionary_component_history.update"
+   _item_type.code  yyyy-mm-dd
+   #
+save_
+#
+save__pdbx_dictionary_component_history.revision
+   _item_description.name         "_pdbx_dictionary_component_history.revision"
+   _item_description.description  
+;
+     Text description of the dictionary component revision.
+;
+
+   #
+   _item.name            "_pdbx_dictionary_component_history.revision"
+   _item.category_id     pdbx_dictionary_component_history
+   _item.mandatory_code  yes
+   #
+   _item_type.name  "_pdbx_dictionary_component_history.revision"
+   _item_type.code  text
+   #
+save_
+#
+save_pdbx_item_value_condition_list
+   _category.description     
+;
+     Attributes which define value conditions among dependent items.
+;
+
+   _category.id              pdbx_item_value_condition_list
+   _category.mandatory_code  no
+   _category.implicit_key    mmcif_ddl.dic
+   #
+   _category_key.id    pdbx_item_value_condition_list
+   _category_key.name  "_pdbx_item_value_condition_list.cond_id"
+   #
+   loop_
+   _category_group.id
+   _category_group.category_id
+     ddl_group        pdbx_item_value_condition_list  
+     item_group       pdbx_item_value_condition_list  
+     extension_group  pdbx_item_value_condition_list  
+   #
+   _pdbx_category_context.category_id  pdbx_item_value_condition_list
+   _pdbx_category_context.type         DATA
+   #
+save_
+#
+save__pdbx_item_value_condition_list.cond_id
+   _item_description.name         "_pdbx_item_value_condition_list.cond_id"
+   _item_description.description  
+;
+     The unique identifier for each value condition.
+;
+
+   #
+   _item.name            "_pdbx_item_value_condition_list.cond_id"
+   _item.category_id     pdbx_item_value_condition_list
+   _item.mandatory_code  yes
+   #
+   _item_type.name  "_pdbx_item_value_condition_list.cond_id"
+   _item_type.code  int
+   #
+save_
+#
+save__pdbx_item_value_condition_list.target_item_name
+   _item_description.name         "_pdbx_item_value_condition_list.target_item_name"
+   _item_description.description  
+;
+     Name of the target data item for the value condition.
+;
+
+   #
+   _item.name            "_pdbx_item_value_condition_list.target_item_name"
+   _item.category_id     pdbx_item_value_condition_list
+   _item.mandatory_code  yes
+   #
+   _item_type.name  "_pdbx_item_value_condition_list.target_item_name"
+   _item_type.code  name
+   #
+   _item_linked.child_name   "_pdbx_item_value_condition_list.target_item_name"
+   _item_linked.parent_name  "_item.name"
+   #
+save_
+#
+save__pdbx_item_value_condition_list.target_item_value
+   _item_description.name         "_pdbx_item_value_condition_list.target_item_value"
+   _item_description.description  
+;
+     Value of the dependent data item for the value condition.
+;
+
+   #
+   _item.name            "_pdbx_item_value_condition_list.target_item_value"
+   _item.category_id     pdbx_item_value_condition_list
+   _item.mandatory_code  yes
+   #
+   _item_type.name  "_pdbx_item_value_condition_list.target_item_value"
+   _item_type.code  any
+   #
+save_
+#
+save__pdbx_item_value_condition_list.dependent_item_name
+   _item_description.name         "_pdbx_item_value_condition_list.dependent_item_name"
+   _item_description.description  
+;
+     Name of the dependent data item for the value condition.
+;
+
+   #
+   _item.name            "_pdbx_item_value_condition_list.dependent_item_name"
+   _item.category_id     pdbx_item_value_condition_list
+   _item.mandatory_code  yes
+   #
+   _item_type.name  "_pdbx_item_value_condition_list.dependent_item_name"
+   _item_type.code  name
+   #
+   _item_linked.child_name   "_pdbx_item_value_condition_list.dependent_item_name"
+   _item_linked.parent_name  "_item.name"
+   #
+save_
+#
+save__pdbx_item_value_condition_list.dependent_item_value
+   _item_description.name         "_pdbx_item_value_condition_list.dependent_item_value"
+   _item_description.description  
+;
+     Value of the dependent data item for the value condition.
+;
+
+   #
+   _item.name            "_pdbx_item_value_condition_list.dependent_item_value"
+   _item.category_id     pdbx_item_value_condition_list
+   _item.mandatory_code  yes
+   #
+   _item_type.name  "_pdbx_item_value_condition_list.dependent_item_value"
+   _item_type.code  any
+   #
+save_
+#
+save__pdbx_item_value_condition_list.dependent_item_cmp_op
+   _item_description.name         "_pdbx_item_value_condition_list.dependent_item_cmp_op"
+   _item_description.description  
+;
+     Comparison operation for the value condition.
+;
+
+   #
+   _item.name            "_pdbx_item_value_condition_list.dependent_item_cmp_op"
+   _item.category_id     pdbx_item_value_condition_list
+   _item.mandatory_code  yes
+   #
+   _item_type.name  "_pdbx_item_value_condition_list.dependent_item_cmp_op"
+   _item_type.code  char
+   #
+   _item_linked.child_name   "_pdbx_item_value_condition_list.dependent_item_cmp_op"
+   _item_linked.parent_name  "_pdbx_comparison_operator_list.code"
+   #
+save_
+#
+save__pdbx_item_value_condition_list.log_op
+   _item_description.name         "_pdbx_item_value_condition_list.log_op"
+   _item_description.description  
+;
+     The logical conjunction for combining multiple conditions.
+;
+
+   #
+   _item.name            "_pdbx_item_value_condition_list.log_op"
+   _item.category_id     pdbx_item_value_condition_list
+   _item.mandatory_code  no
+   #
+   _item_type.name  "_pdbx_item_value_condition_list.log_op"
+   _item_type.code  code
+   #
+   _item_default.name   "_pdbx_item_value_condition_list.log_op"
+   _item_default.value  and
+   #
+   loop_
+   _item_enumeration.value
+   _item_enumeration.detail
+     and  "conditions are satisfied simultaneously"  
+     or   "any condition is satisfied"  
+   #
+save_
+#
+save_pdbx_item_value_condition
+   _category.description     
+;
+     Attributes which describe those items sharing conditional dependency relationship
+     where the value of a target item depends on the values of its dependent partner items.
+;
+
+   _category.id              pdbx_item_value_condition
+   _category.mandatory_code  no
+   _category.implicit_key    mmcif_ddl.dic
+   #
+   loop_
+   _category_key.id
+   _category_key.name
+     pdbx_item_value_condition  "_pdbx_item_value_condition.item_name"  
+     pdbx_item_value_condition  "_pdbx_item_value_condition.dependent_item_name"  
+   #
+   loop_
+   _category_group.id
+   _category_group.category_id
+     ddl_group        pdbx_item_value_condition  
+     item_group       pdbx_item_value_condition  
+     extension_group  pdbx_item_value_condition  
+   #
+   _pdbx_category_context.category_id  pdbx_item_value_condition
+   _pdbx_category_context.type         DEFINITION
+   #
+save_
+#
+save__pdbx_item_value_condition.item_name
+   _item_description.name         "_pdbx_item_value_condition.item_name"
+   _item_description.description  
+;
+     Name of the target data item.
+;
+
+   #
+   _item.name            "_pdbx_item_value_condition.item_name"
+   _item.category_id     pdbx_item_value_condition
+   _item.mandatory_code  implicit
+   #
+   _item_type.name  "_pdbx_item_value_condition.item_name"
+   _item_type.code  name
+   #
+   _item_linked.child_name   "_pdbx_item_value_condition.item_name"
+   _item_linked.parent_name  "_pdbx_item_value_condition_list.target_item_name"
+   #
+save_
+#
+save__pdbx_item_value_condition.dependent_item_name
+   _item_description.name         "_pdbx_item_value_condition.dependent_item_name"
+   _item_description.description  
+;
+     Name of a dependent data item.
+;
+
+   #
+   _item.name            "_pdbx_item_value_condition.dependent_item_name"
+   _item.category_id     pdbx_item_value_condition
+   _item.mandatory_code  yes
+   #
+   _item_type.name  "_pdbx_item_value_condition.dependent_item_name"
+   _item_type.code  name
+   #
+   _item_linked.child_name   "_pdbx_item_value_condition.dependent_item_name"
+   _item_linked.parent_name  "_pdbx_item_value_condition_list.dependent_item_name"
+   #
+save_
+#
+save_pdbx_item_linked
+   _category.description     
+;
+     Attributes which describe how equivalent data items are linked
+     within categories and across different categories subject to
+     value conditions within the child data category.
+;
+
+   _category.id              pdbx_item_linked
+   _category.mandatory_code  no
+   _category.implicit_key    mmcif_ddl.dic
+   #
+   _category_key.id    pdbx_item_linked
+   _category_key.name  "_pdbx_item_linked.id"
+   #
+   loop_
+   _category_group.id
+   _category_group.category_id
+     ddl_group        pdbx_item_linked  
+     item_group       pdbx_item_linked  
+     extension_group  pdbx_item_linked  
+   #
+   _pdbx_category_context.category_id  pdbx_item_linked
+   _pdbx_category_context.type         DEFINITION
+   #
+save_
+#
+save__pdbx_item_linked.id
+   _item_description.name         "_pdbx_item_linked.id"
+   _item_description.description  
+;
+     A unique identifier for each record.
+;
+
+   #
+   _item.name            "_pdbx_item_linked.id"
+   _item.category_id     pdbx_item_linked
+   _item.mandatory_code  yes
+   #
+   _item_type.name  "_pdbx_item_linked.id"
+   _item_type.code  int
+   #
+save_
+#
+save__pdbx_item_linked.child_name
+   _item_description.name         "_pdbx_item_linked.child_name"
+   _item_description.description  
+;
+     Name of the child data item.
+;
+
+   #
+   _item.name            "_pdbx_item_linked.child_name"
+   _item.category_id     pdbx_item_linked
+   _item.mandatory_code  yes
+   #
+   _item_type.name  "_pdbx_item_linked.child_name"
+   _item_type.code  name
+   #
+   _item_linked.child_name   "_pdbx_item_linked.child_name"
+   _item_linked.parent_name  "_item.name"
+   #
+save_
+#
+save__pdbx_item_linked.parent_name
+   _item_description.name         "_pdbx_item_linked.parent_name"
+   _item_description.description  
+;
+     Name of the parent data item.
+;
+
+   #
+   _item.name            "_pdbx_item_linked.parent_name"
+   _item.category_id     pdbx_item_linked
+   _item.mandatory_code  yes
+   #
+   _item_type.name  "_pdbx_item_linked.parent_name"
+   _item_type.code  name
+   #
+   _item_linked.child_name   "_pdbx_item_linked.parent_name"
+   _item_linked.parent_name  "_item.name"
+   #
+save_
+#
+save__pdbx_item_linked.condition_id
+   _item_description.name         "_pdbx_item_linked.condition_id"
+   _item_description.description  
+;
+     An identifier for each value condition. A condition may span multiple
+     item and value pairs.
+;
+
+   #
+   _item.name            "_pdbx_item_linked.condition_id"
+   _item.category_id     pdbx_item_linked
+   _item.mandatory_code  no
+   #
+   _item_type.name  "_pdbx_item_linked.condition_id"
+   _item_type.code  int
+   #
+save_
+#
+save__pdbx_item_linked.condition_child_name
+   _item_description.name         "_pdbx_item_linked.condition_child_name"
+   _item_description.description  
+;
+     Name of the child data item subject to the value condition.
+;
+
+   #
+   _item.name            "_pdbx_item_linked.condition_child_name"
+   _item.category_id     pdbx_item_linked
+   _item.mandatory_code  no
+   #
+   _item_type.name  "_pdbx_item_linked.condition_child_name"
+   _item_type.code  name
+   #
+   _item_linked.child_name   "_pdbx_item_linked.condition_child_name"
+   _item_linked.parent_name  "_item.name"
+   #
+save_
+#
+save__pdbx_item_linked.condition_child_value
+   _item_description.name         "_pdbx_item_linked.condition_child_value"
+   _item_description.description  
+;
+     The data value for the child value condition.
+;
+
+   #
+   _item.name            "_pdbx_item_linked.condition_child_value"
+   _item.category_id     pdbx_item_linked
+   _item.mandatory_code  no
+   #
+   _item_type.name  "_pdbx_item_linked.condition_child_value"
+   _item_type.code  any
+   #
+save_
+#
+save__pdbx_item_linked.condition_child_target_name
+   _item_description.name         "_pdbx_item_linked.condition_child_target_name"
+   _item_description.description  
+;
+     Name of the data item which is the target of the value condition.
+;
+
+   #
+   _item.name            "_pdbx_item_linked.condition_child_target_name"
+   _item.category_id     pdbx_item_linked
+   _item.mandatory_code  no
+   #
+   _item_type.name  "_pdbx_item_linked.condition_child_target_name"
+   _item_type.code  name
+   #
+   _item_linked.child_name   "_pdbx_item_linked.condition_child_target_name"
+   _item_linked.parent_name  "_item.name"
+   #
+save_
+#
+save__pdbx_item_linked.condition_child_cmp_op
+   _item_description.name         "_pdbx_item_linked.condition_child_cmp_op"
+   _item_description.description  
+;
+     The comparison operation for the child value condition
+;
+
+   #
+   _item.name            "_pdbx_item_linked.condition_child_cmp_op"
+   _item.category_id     pdbx_item_linked
+   _item.mandatory_code  no
+   #
+   _item_type.name  "_pdbx_item_linked.condition_child_cmp_op"
+   _item_type.code  char
+   #
+   _item_linked.child_name   "_pdbx_item_linked.condition_child_cmp_op"
+   _item_linked.parent_name  "_pdbx_comparison_operator_list.code"
+   #
+save_
+#
+save__pdbx_item_linked.condition_child_log_op
+   _item_description.name         "_pdbx_item_linked.condition_child_log_op"
+   _item_description.description  
+;
+     The logical conjunction for combining multiple conditions.
+;
+
+   #
+   _item.name            "_pdbx_item_linked.condition_child_log_op"
+   _item.category_id     pdbx_item_linked
+   _item.mandatory_code  no
+   #
+   _item_type.name  "_pdbx_item_linked.condition_child_log_op"
+   _item_type.code  code
+   #
+   _item_default.name   "_pdbx_item_linked.condition_child_log_op"
+   _item_default.value  and
+   #
+   loop_
+   _item_enumeration.value
+   _item_enumeration.detail
+     and  "conditions are satisfied simultaneously"  
+     or   "any condition is satisfied"  
+   #
+save_
+#
+save_pdbx_comparison_operator_list
+   _category.description     
+;
+     Specifies the operators available for value condition comparisons.
+;
+
+   _category.id              pdbx_comparison_operator_list
+   _category.mandatory_code  no
+   _category.implicit_key    mmcif_ddl.dic
+   #
+   _category_key.id    pdbx_comparison_operator_list
+   _category_key.name  "_pdbx_comparison_operator_list.code"
+   #
+   loop_
+   _category_group.id
+   _category_group.category_id
+     ddl_group   pdbx_comparison_operator_list  
+     item_group  pdbx_comparison_operator_list  
+   #
+   _pdbx_category_context.category_id  pdbx_comparison_operator_list
+   _pdbx_category_context.type         DATA
+   #
+save_
+#
+save__pdbx_comparison_operator_list.code
+   _item_description.name         "_pdbx_comparison_operator_list.code"
+   _item_description.description  
+;
+     A code for the comparison operator.
+;
+
+   #
+   _item.name            "_pdbx_comparison_operator_list.code"
+   _item.category_id     pdbx_comparison_operator_list
+   _item.mandatory_code  yes
+   #
+   _item_type.name  "_pdbx_comparison_operator_list.code"
+   _item_type.code  char
+   #
+save_
+#
+save__pdbx_comparison_operator_list.description
+   _item_description.name         "_pdbx_comparison_operator_list.description"
+   _item_description.description  
+;
+     Description of the comparison operator.
+;
+
+   #
+   _item.name            "_pdbx_comparison_operator_list.description"
+   _item.category_id     pdbx_comparison_operator_list
+   _item.mandatory_code  yes
+   #
+   _item_type.name  "_pdbx_comparison_operator_list.description"
+   _item_type.code  text
+   #
+save_
+#
+save_pdbx_category_conditional_context
+   _category.description     
+;
+      Category definition conditional context describing the scope of usage and
+      distribution for the category.
+;
+
+   _category.id              pdbx_category_conditional_context
+   _category.mandatory_code  no
+   _category.implicit_key    mmcif_ddl.dic
+   #
+   _category_key.id    pdbx_category_conditional_context
+   _category_key.name  "_pdbx_category_conditional_context.category_id"
+   #
+   loop_
+   _category_group.id
+   _category_group.category_id
+     ddl_group        pdbx_category_conditional_context  
+     category_group   pdbx_category_conditional_context  
+     extension_group  pdbx_category_conditional_context  
+   #
+   _pdbx_category_context.category_id  pdbx_category_conditional_context
+   _pdbx_category_context.type         DEFINITION
+   #
+save_
+#
+save__pdbx_category_conditional_context.category_id
+   _item.name            "_pdbx_category_conditional_context.category_id"
+   _item.category_id     pdbx_category_conditional_context
+   _item.mandatory_code  implicit
+   #
+   _item_type.name  "_pdbx_category_conditional_context.category_id"
+   _item_type.code  idname
+   #
+   _item_linked.child_name   "_pdbx_category_conditional_context.category_id"
+   _item_linked.parent_name  "_category.id"
+   #
+save_
+#
+save__pdbx_category_conditional_context.context_id
+   _item_description.name         "_pdbx_category_conditional_context.context_id"
+   _item_description.description  
+;
+     Category conditional context identifier
+;
+
+   #
+   _item.name            "_pdbx_category_conditional_context.context_id"
+   _item.category_id     pdbx_category_conditional_context
+   _item.mandatory_code  yes
+   #
+   _item_type.name  "_pdbx_category_conditional_context.context_id"
+   _item_type.code  code
+   #
+   _item_examples.name    "_pdbx_category_conditional_context.context_id"
+   _item_examples.case    WWPDB_ACCEPT_GDPR_TERMS_CONDITIONS
+   _item_examples.detail  "A category context that depends on acceptance of GDPR terms and conditions"
+   #
+   _item_linked.child_name   "_pdbx_category_conditional_context.context_id"
+   _item_linked.parent_name  "_pdbx_conditional_context_list.context_id"
+   #
+save_
+#
+save__pdbx_category_conditional_context.action
+   _item_description.name         "_pdbx_category_conditional_context.action"
+   _item_description.description  
+;
+     Category context action.
+;
+
+   #
+   _item.name            "_pdbx_category_conditional_context.action"
+   _item.category_id     pdbx_category_conditional_context
+   _item.mandatory_code  yes
+   #
+   _item_type.name  "_pdbx_category_conditional_context.action"
+   _item_type.code  char
+   #
+   _item_examples.name    "_pdbx_category_conditional_context.action"
+   _item_examples.case    suppress
+   _item_examples.detail  "The action to suppress the release of data the category with this context"
+   #
+save_
+#
+save_pdbx_item_conditional_context
+   _category.description     
+;
+      Category definition conditional context describing the scope of usage and
+      distribution for the category.
+;
+
+   _category.id              pdbx_item_conditional_context
+   _category.mandatory_code  no
+   _category.implicit_key    mmcif_ddl.dic
+   #
+   _category_key.id    pdbx_item_conditional_context
+   _category_key.name  "_pdbx_item_conditional_context.item_name"
+   #
+   loop_
+   _category_group.id
+   _category_group.category_id
+     ddl_group        pdbx_item_conditional_context  
+     category_group   pdbx_item_conditional_context  
+     extension_group  pdbx_item_conditional_context  
+   #
+   _pdbx_category_context.category_id  pdbx_item_conditional_context
+   _pdbx_category_context.type         DEFINITION
+   #
+save_
+#
+save__pdbx_item_conditional_context.item_name
+   _item.name            "_pdbx_item_conditional_context.item_name"
+   _item.category_id     pdbx_item_conditional_context
+   _item.mandatory_code  implicit
+   #
+   _item_type.name  "_pdbx_item_conditional_context.item_name"
+   _item_type.code  name
+   #
+   _item_linked.child_name   "_pdbx_item_conditional_context.item_name"
+   _item_linked.parent_name  "_item.name"
+   #
+save_
+#
+save__pdbx_item_conditional_context.context_id
+   _item_description.name         "_pdbx_item_conditional_context.context_id"
+   _item_description.description  
+;
+     Item conditional context identifier
+;
+
+   #
+   _item.name            "_pdbx_item_conditional_context.context_id"
+   _item.category_id     pdbx_item_conditional_context
+   _item.mandatory_code  yes
+   #
+   _item_type.name  "_pdbx_item_conditional_context.context_id"
+   _item_type.code  code
+   #
+   _item_examples.name    "_pdbx_item_conditional_context.context_id"
+   _item_examples.case    WWPDB_ACCEPT_GDPR_TERMS_CONDITIONS
+   _item_examples.detail  "An item context that depends on acceptance of GDPR terms and conditions"
+   #
+   _item_linked.child_name   "_pdbx_item_conditional_context.context_id"
+   _item_linked.parent_name  "_pdbx_conditional_context_list.context_id"
+   #
+save_
+#
+save__pdbx_item_conditional_context.action
+   _item_description.name         "_pdbx_item_conditional_context.action"
+   _item_description.description  
+;
+     Item context action.
+;
+
+   #
+   _item.name            "_pdbx_item_conditional_context.action"
+   _item.category_id     pdbx_item_conditional_context
+   _item.mandatory_code  yes
+   #
+   _item_type.name  "_pdbx_item_conditional_context.action"
+   _item_type.code  char
+   #
+   _item_examples.case    suppress-item
+   _item_examples.detail  "The action to suppress the release of the data item with this context"
+   #
+   loop_
+   _item_enumeration.value
+   _item_enumeration.detail
+     suppress-item   "The action to suppress the release of the data item with this context"  
+     suppress-value  "The action to suppress the release of the data item value with this context"  
+     suppress-row    "The action to suppress the release of the row of item values with this context"  
+   #
+save_
+#
+save_pdbx_conditional_context_list
+   _category.description     
+;
+     Attributes which define contextual conditions among target items.
+;
+
+   _category.id              pdbx_conditional_context_list
+   _category.mandatory_code  no
+   _category.implicit_key    mmcif_ddl.dic
+   #
+   loop_
+   _category_key.id
+   _category_key.name
+     pdbx_conditional_context_list  "_pdbx_conditional_context_list.context_id"  
+     pdbx_conditional_context_list  "_pdbx_conditional_context_list.ordinal_id"  
+   #
+   loop_
+   _category_group.id
+   _category_group.category_id
+     ddl_group        pdbx_conditional_context_list  
+     item_group       pdbx_conditional_context_list  
+     extension_group  pdbx_conditional_context_list  
+   #
+   _pdbx_category_context.category_id  pdbx_conditional_context_list
+   _pdbx_category_context.type         DATA
+   #
+save_
+#
+save__pdbx_conditional_context_list.context_id
+   _item_description.name         "_pdbx_conditional_context_list.context_id"
+   _item_description.description  
+;
+     The an identifier for each conditional context.
+;
+
+   #
+   _item.name            "_pdbx_conditional_context_list.context_id"
+   _item.category_id     pdbx_conditional_context_list
+   _item.mandatory_code  yes
+   #
+   _item_type.name  "_pdbx_conditional_context_list.context_id"
+   _item_type.code  code
+   #
+save_
+#
+save__pdbx_conditional_context_list.ordinal_id
+   _item_description.name         "_pdbx_conditional_context_list.ordinal_id"
+   _item_description.description  
+;
+     The ordinal identifier for each condition within a context.
+;
+
+   #
+   _item.name            "_pdbx_conditional_context_list.ordinal_id"
+   _item.category_id     pdbx_conditional_context_list
+   _item.mandatory_code  yes
+   #
+   _item_type.name  "_pdbx_conditional_context_list.ordinal_id"
+   _item_type.code  int
+   #
+save_
+#
+save__pdbx_conditional_context_list.target_item_name
+   _item_description.name         "_pdbx_conditional_context_list.target_item_name"
+   _item_description.description  
+;
+     Name of the target data item for the condition.
+;
+
+   #
+   _item.name            "_pdbx_conditional_context_list.target_item_name"
+   _item.category_id     pdbx_conditional_context_list
+   _item.mandatory_code  yes
+   #
+   _item_type.name  "_pdbx_conditional_context_list.target_item_name"
+   _item_type.code  name
+   #
+   _item_linked.child_name   "_pdbx_conditional_context_list.target_item_name"
+   _item_linked.parent_name  "_item.name"
+   #
+save_
+#
+save__pdbx_conditional_context_list.target_item_value
+   _item_description.name         "_pdbx_conditional_context_list.target_item_value"
+   _item_description.description  
+;
+     Value of the value data item for the condition.
+;
+
+   #
+   _item.name            "_pdbx_conditional_context_list.target_item_value"
+   _item.category_id     pdbx_conditional_context_list
+   _item.mandatory_code  no
+   #
+   _item_type.name  "_pdbx_conditional_context_list.target_item_value"
+   _item_type.code  any
+   #
+save_
+#
+save__pdbx_conditional_context_list.dependent_item_name
+   _item_description.name         "_pdbx_conditional_context_list.dependent_item_name"
+   _item_description.description  
+;
+     Name of the dependent data item for the condition.
+;
+
+   #
+   _item.name            "_pdbx_conditional_context_list.dependent_item_name"
+   _item.category_id     pdbx_conditional_context_list
+   _item.mandatory_code  no
+   #
+   _item_type.name  "_pdbx_conditional_context_list.dependent_item_name"
+   _item_type.code  name
+   #
+   _item_linked.child_name   "_pdbx_conditional_context_list.dependent_item_name"
+   _item_linked.parent_name  "_item.name"
+   #
+save_
+#
+save__pdbx_conditional_context_list.cmp_op
+   _item_description.name         "_pdbx_conditional_context_list.cmp_op"
+   _item_description.description  
+;
+     Comparison operation for the condition applied to either the target item value or
+     to the value of the dependent item.
+;
+
+   #
+   _item.name            "_pdbx_conditional_context_list.cmp_op"
+   _item.category_id     pdbx_conditional_context_list
+   _item.mandatory_code  yes
+   #
+   _item_type.name  "_pdbx_conditional_context_list.cmp_op"
+   _item_type.code  char
+   #
+   _item_linked.child_name   "_pdbx_conditional_context_list.cmp_op"
+   _item_linked.parent_name  "_pdbx_comparison_operator_list.code"
+   #
+save_
+#
+save__pdbx_conditional_context_list.log_op
+   _item_description.name         "_pdbx_conditional_context_list.log_op"
+   _item_description.description  
+;
+     The logical conjunction for combining multiple conditions.
+;
+
+   #
+   _item.name            "_pdbx_conditional_context_list.log_op"
+   _item.category_id     pdbx_conditional_context_list
+   _item.mandatory_code  no
+   #
+   _item_type.name  "_pdbx_conditional_context_list.log_op"
+   _item_type.code  code
+   #
+   _item_default.name   "_pdbx_conditional_context_list.log_op"
+   _item_default.value  and
+   #
+   loop_
+   _item_enumeration.value
+   _item_enumeration.detail
+     and  "conditions are satisfied simultaneously"  
+     or   "any condition is satisfied"  
+   #
+save_
+#
+save__item_enumeration.rcsb_detail_brief
+   _item_description.name         "_item_enumeration.rcsb_detail_brief"
+   _item_description.description  
+;
+     A brief description of a permissible value for the defined item.
+;
+
+   #
+   _item.name            "_item_enumeration.rcsb_detail_brief"
+   _item.category_id     item_enumeration
+   _item.mandatory_code  no
+   #
+   _item_type.name  "_item_enumeration.rcsb_detail_brief"
+   _item_type.code  text
+   #
+save_
+#
+save__item_enumeration.rcsb_type_units_code
+   _item_description.name         "_item_enumeration.rcsb_type_units_code"
+   _item_description.description  
+;
+     Where the enumeration refers to a type, the code for the units of expression for this type.
+;
+
+   #
+   _item.name            "_item_enumeration.rcsb_type_units_code"
+   _item.category_id     item_enumeration
+   _item.mandatory_code  no
+   #
+   _item_type.name  "_item_enumeration.rcsb_type_units_code"
+   _item_type.code  code
+   #
+save_
+#

--- a/dictionaries/multi_block_core.dic
+++ b/dictionaries/multi_block_core.dic
@@ -1,0 +1,907 @@
+#\#CIF_2.0
+##########################################################################
+#                                                                        #
+#  MULTIBLOCK CIF CORE DICTIONARY                                        #
+#                                                                        #
+##########################################################################
+
+data_MULTIBLOCK_DIC
+
+    _dictionary.title             MULTIBLOCK_DIC
+    _dictionary.class             Instance
+    _dictionary.version           1.1.0
+    _dictionary.date              2025-04-14
+    _dictionary.uri
+        https://raw.githubusercontent.com/COMCIFS/MultiBlock_Dictionary/main/multi_block_core.dic
+    _dictionary.ddl_conformance   4.2.0
+    _dictionary.namespace         CifCore
+    _description.text
+;
+    The multi block dictionary adds data names to the core dictionary which
+    allow description of data spread over multiple data units (blocks).
+
+    Under the default schema, all data names in Set categories must be
+    single-valued in any given data block. If these Set categories are
+    provided with one or more key data names, information in these
+    categories spread over multiple data blocks can be combined
+    together.
+
+    When key data names are specified, all child data names in other
+    categories should be specified at the same time, as well as data
+    names that reference items in the given Set category.
+
+    This dictionary redefines Set categories to include the new
+    key data names, adds the key data name definitions, and defines
+    any linked and child data names.
+;
+
+save_MULTIBLOCK_CORE
+
+    _definition.id                MULTIBLOCK_CORE
+    _definition.scope             Category
+    _definition.class             Head
+    _definition.update            2024-05-15
+    _description.text
+;
+    The MULTIBLOCK_CORE category becomes the overarching category
+    for all core data names used in one or more data units.
+;
+    _name.category_id             MULTIBLOCK_DIC
+    _name.object_id               MULTIBLOCK_CORE
+
+    _import.get
+        [
+         {'dupl':Ignore  'file':cif_core.dic  'mode':Full  'save':CIF_CORE_HEAD}
+        ]
+
+save_
+
+save_AUDIT_DATASET
+
+    _definition.id                AUDIT_DATASET
+    _definition.scope             Category
+    _definition.class             Loop
+    _definition.update            2025-04-14
+    _description.text
+;
+    The CATEGORY of data items used for linking data blocks to aid in grouping
+    blocks which contain information which are interrelated.
+
+    Data blocks which should be interpreted together are identified with the
+    same unique _audit_dataset.id.
+;
+    _name.category_id             AUDIT
+    _name.object_id               AUDIT_DATASET
+    _category_key.name            '_audit_dataset.id'
+
+    loop_
+      _description_example.case
+      _description_example.detail
+;
+         data_structure1
+         _audit_dataset.id  82c0a1e2-29ad-47b8-ace1-01e653e1cae8
+         _pd_phase.name "First phase"
+         #cell parameters and atom positions
+         #...
+
+         data_structure2
+         _audit_dataset.id  82c0a1e2-29ad-47b8-ace1-01e653e1cae8
+         _pd_phase.id "Second phase"
+         #cell parameters and atom positions
+         #...
+
+         data_diffraction_data1
+         _audit_dataset.id  82c0a1e2-29ad-47b8-ace1-01e653e1cae8
+         _pd_diffractogram.id "First dataset"
+         #diffracted intensities vs angle
+         #...
+
+         data_information
+         _audit_dataset.id  82c0a1e2-29ad-47b8-ace1-01e653e1cae8
+         #wavelength, specimen preparation, temperature, pressure...
+         #...
+;
+;
+         Four data blocks for a powder diffraction experiment.
+         By the presence of an identical _audit_dataset.id value, it is made
+         clear that all four data blocks are to be interpreted together as
+         a whole. It is clear that there are two crystal structures, one
+         diffractogram, and a block containing other experimental information.
+
+         These blocks may be contained in the same file, or many files, but
+         the presence of an _audit_dataset.id value removes doubt as to their
+         relationship to each other.
+;
+;
+         data_structure1
+         _pd_phase.name "First phase"
+         #cell parameters and atom positions
+         #...
+
+         data_structure2
+         _pd_phase.id "Second phase"
+         #cell parameters and atom positions
+         #...
+
+         data_diffraction_data1
+         _pd_diffractogram.id "First dataset"
+         #diffracted intensities vs angle
+         #...
+
+         data_information
+         #wavelength, specimen preparation, temperature, pressure...
+         #...
+;
+;
+         Four data blocks for a powder diffraction experiment.
+         The absence of an _audit_dataset.id value does not preclude that all
+         or some of the four data blocks may to be interpretted together. The
+         consumer of the information may be able to infer that they belong
+         together due to the presence of other information, such as other CIF
+         data names, multiple blocks contained in a single CIF file, or how
+         files are stored in directories.
+;
+;
+         data_structure1
+         _audit_dataset.id  first_experiment-1f52e5a9a3b9
+         _pd_phase.name "First phase"
+         #cell parameters and atom positions
+         #...
+
+         data_calibration_structure
+         loop_
+           _audit_dataset.id
+           first_experiment-1f52e5a9a3b9
+           1997-07-24|LaSNbS2|G.M.
+           255bb051-a3d5-43f0-8384-fa8ccb2ce3c7
+         _pd_phase.id "Calibration phase"
+         #cell parameters and atom positions
+         #...
+
+         data_diffraction_data
+         _audit_dataset.id  first_experiment-1f52e5a9a3b9
+         _pd_diffractogram.id "First dataset"
+         #diffracted intensities vs angle
+         #...
+;
+;
+         Three data blocks for a powder diffraction experiment.
+         By the presence of an identical _audit_dataset.id value, it is made
+         clear that all data blocks are to be interpretted together as
+         a whole. The presence of multiple _audit_dataset.id values for the
+         second data block enables it to be included in more than one dataset.
+
+         Additionally, it is clear from the presence of different
+         _audit_dataset.id values, that the diffractogram _pd_diffractogram.id
+         "First dataset" in the first example is different to the diffractogram
+         _pd_diffractogram.id "First dataset" in this example.
+;
+
+save_
+
+save_audit_dataset.id
+
+    _definition.id                '_audit_dataset.id'
+    _definition.update            2025-04-14
+    _description.text
+;
+    Globally unique identifier for data blocks that are meant to be interpreted
+    together as a whole.
+
+    Data blocks which belong together, for instance, as they form part of the
+    same experiment, are given an identical _audit_dataset.id value.
+
+    Data blocks, such as calibration information, can be designated with more
+    than one _audit_dataset.id value.
+
+    Data blocks which do not contain the same unique _audit_dataset.id may still
+    be related, depending on the presence of other data names and values. Data
+    blocks which contain different _audit_dataset.id values are not related in
+    a CIF-sense.
+
+    It is recommended to select an universally unique ID, such as a UUID.
+;
+    _name.category_id             audit_dataset
+    _name.object_id               id
+    _type.purpose                 Key
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Word
+
+save_
+
+save_DIFFRN
+
+    _definition.id                DIFFRN
+    _definition.scope             Category
+    _definition.class             Set
+    _definition.update            2022-05-09
+    _description.text
+;
+    The CATEGORY of data items used to describe the diffraction experiment.
+;
+    _name.category_id             DIFFRACTION
+    _name.object_id               DIFFRN
+    _category_key.name            '_diffrn.id'
+
+save_
+
+save_diffrn.crystal_id
+
+    _definition.id                '_diffrn.crystal_id'
+    _definition.update            2022-05-09
+    _description.text
+;
+    Identifier for the crystal from which diffraction data were
+    collected. This is a pointer to _exptl_crystal.id.
+;
+    _name.category_id             diffrn
+    _name.object_id               crystal_id
+    _name.linked_item_id          '_exptl_crystal.id'
+    _type.purpose                 Link
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Word
+
+save_
+
+save_diffrn.id
+
+    _definition.id                '_diffrn.id'
+    _definition.update            2022-05-09
+    _description.text
+;
+    Unique identifier for a diffraction data set collected under
+    particular diffraction conditions.
+;
+    _name.category_id             diffrn
+    _name.object_id               id
+    _type.purpose                 Key
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Word
+
+save_
+
+save_DIFFRN_RADIATION
+
+    _definition.id                DIFFRN_RADIATION
+    _definition.scope             Category
+    _definition.class             Set
+    _definition.update            2024-10-17
+    _description.text
+;
+    The CATEGORY of data items which specify the wavelength of the
+    radiation used in measuring diffraction intensities. To identify
+    and assign weights to distinct wavelength components from a
+    polychromatic beam, see DIFFRN_RADIATION_WAVELENGTH.
+;
+    _name.category_id             DIFFRACTION
+    _name.object_id               DIFFRN_RADIATION
+    _category_key.name            '_diffrn_radiation.diffrn_id'
+
+save_
+
+save_diffrn_radiation.diffrn_id
+
+    _definition.id                '_diffrn_radiation.diffrn_id'
+    _definition.update            2024-10-17
+    _description.text
+;
+    Unique identifier for a diffraction data set collected under
+    particular diffraction conditions. This item is a pointer to
+    _diffrn.id. Hello world
+;
+    _name.category_id             diffrn_radiation
+    _name.object_id               diffrn_id
+    _name.linked_item_id          '_diffrn.id'
+    _type.purpose                 Link
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Word
+
+save_
+
+save_CELL
+
+    _definition.id                CELL
+    _definition.scope             Category
+    _definition.class             Set
+    _definition.update            2023-03-02
+    _description.text
+;
+    The CATEGORY of data items used to describe the parameters of
+    the crystal unit cell.
+;
+    _name.category_id             DIFFRN
+    _name.object_id               CELL
+    _category_key.name            '_cell.structure_id'
+
+save_
+
+save_cell.structure_id
+
+    _definition.id                '_cell.structure_id'
+    _definition.update            2024-02-05
+    _description.text
+;
+    A code identifying the crystallographic structure associated with this cell
+    description.
+;
+    _name.category_id             cell
+    _name.object_id               structure_id
+    _name.linked_item_id          '_structure.id'
+    _type.purpose                 Link
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Word
+
+save_
+
+save_CELL_MEASUREMENT
+
+    _definition.id                CELL_MEASUREMENT
+    _definition.scope             Category
+    _definition.class             Set
+    _definition.update            2022-05-25
+    _description.text
+;
+    The CATEGORY of data items used to describe the measurement of
+    the cell parameters.
+;
+    _name.category_id             CELL
+    _name.object_id               CELL_MEASUREMENT
+    _category_key.name            '_cell_measurement.structure_id'
+
+save_
+
+save_cell_measurement.condition_id
+
+    _definition.id                '_cell_measurement.condition_id'
+    _definition.update            2023-02-01
+    _description.text
+;
+    A pointer to the diffraction conditions used for cell measurement,
+    where different to the diffraction conditions used for data
+    collection.
+;
+    _name.category_id             cell_measurement
+    _name.object_id               condition_id
+    _name.linked_item_id          '_diffrn.id'
+    _type.purpose                 Link
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Word
+    _method.purpose               Definition
+    _method.expression
+;
+    _enumeration.default = _cell_measurement.diffrn_id
+;
+
+save_
+
+save_cell_measurement.diffrn_id
+
+    _definition.id                '_cell_measurement.diffrn_id'
+    _definition.update            2023-10-26
+    _description.text
+;
+    A pointer to the diffraction experiment to which the measured cell
+    has been applied.
+;
+    _name.category_id             cell_measurement
+    _name.object_id               diffrn_id
+    _name.linked_item_id          '_diffrn.id'
+    _type.purpose                 Link
+    _type.source                  Related
+    _type.container               Single
+    _type.contents                Word
+
+save_
+
+save_cell_measurement.structure_id
+
+    _definition.id                '_cell_measurement.structure_id'
+    _definition.update            2024-02-05
+    _description.text
+;
+    A code identifying the structure to which the cell being measured belongs.
+;
+    _name.category_id             cell_measurement
+    _name.object_id               structure_id
+    _name.linked_item_id          '_structure.id'
+    _type.purpose                 Link
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Word
+
+save_
+
+save_CELL_MEASUREMENT_REFLN
+
+    _definition.id                CELL_MEASUREMENT_REFLN
+    _definition.scope             Category
+    _definition.class             Loop
+    _definition.update            2023-10-16
+    _description.text
+;
+    The CATEGORY of data items used to describe the reflection data
+    used in the measurement of the crystal unit cell.
+;
+    _name.category_id             CELL_MEASUREMENT
+    _name.object_id               CELL_MEASUREMENT_REFLN
+
+    loop_
+      _category_key.name
+         '_cell_measurement_refln.index_h'
+         '_cell_measurement_refln.index_k'
+         '_cell_measurement_refln.index_l'
+         '_cell_measurement_refln.structure_id'
+
+save_
+
+save_cell_measurement_refln.structure_id
+
+    _definition.id                '_cell_measurement_refln.structure_id'
+    _definition.update            2023-10-16
+    _description.text
+;
+    A code identifying the structure for which the reflections were measured.
+;
+    _name.category_id             cell_measurement_refln
+    _name.object_id               structure_id
+    _name.linked_item_id          '_structure.id'
+    _type.purpose                 Link
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Word
+
+save_
+
+save_EXPTL_CRYSTAL
+
+    _definition.id                EXPTL_CRYSTAL
+    _definition.scope             Category
+    _definition.class             Set
+    _definition.update            2022-05-09
+    _description.text
+;
+    The CATEGORY of data items used to specify information about
+    crystals used in the diffraction measurements.
+;
+    _name.category_id             EXPTL
+    _name.object_id               EXPTL_CRYSTAL
+    _category_key.name            '_exptl_crystal.id'
+
+save_
+
+save_exptl_crystal.id
+
+    _definition.id                '_exptl_crystal.id'
+    _alias.definition_id          '_exptl_crystal_id'
+    _definition.update            2022-05-09
+    _description.text
+;
+    Code identifying a crystal.
+;
+    _name.category_id             exptl_crystal
+    _name.object_id               id
+    _type.purpose                 Key
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Word
+
+save_
+
+save_SPACE_GROUP
+
+    _definition.id                SPACE_GROUP
+    _definition.scope             Category
+    _definition.class             Set
+    _definition.update            2023-10-16
+    _description.text
+;
+    The CATEGORY of data items used to specify space group
+    information about the crystal used in the diffraction measurements.
+
+    Space-group types are identified by their number as listed in
+    International Tables for Crystallography Volume A, or by their
+    Schoenflies symbol. Specific settings of the space groups can
+    be identified by their Hall symbol, by specifying their
+    symmetry operations or generators, or by giving the
+    transformation that relates the specific setting to the
+    reference setting based on International Tables Volume A and
+    stored in this dictionary.
+
+    The commonly used Hermann-Mauguin symbol determines the
+    space-group type uniquely, but several different Hermann-Mauguin
+    symbols may refer to the same space-group type. A
+    Hermann-Mauguin symbol contains information on the choice of
+    the basis, but not on the choice of origin.
+
+    Ref: International Tables for Crystallography (2002). Volume A,
+         Space-group symmetry, edited by Th. Hahn, 5th ed.
+         Dordrecht: Kluwer Academic Publishers.
+;
+    _name.category_id             EXPTL
+    _name.object_id               SPACE_GROUP
+    _category_key.name            '_space_group.id'
+
+save_
+
+save_space_group.id
+
+    _definition.id                '_space_group.id'
+    _definition.update            2023-10-25
+    _description.text
+;
+    Unique identifier for a space group.
+
+    Two space groups can share the same identifier if and only if they have
+    the same space group name, number, setting, and have their their symmetry
+    operations listed with the same symop ids (see SPACE_GROUP_SYMOP).
+;
+    _name.category_id             space_group
+    _name.object_id               id
+    _type.purpose                 Key
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Word
+
+save_
+
+save_SPACE_GROUP_GENERATOR
+
+    _definition.id                SPACE_GROUP_GENERATOR
+    _definition.scope             Category
+    _definition.class             Loop
+    _definition.update            2023-10-16
+    _description.text
+;
+    The CATEGORY of data items used to list generators for
+    the space group
+;
+    _name.category_id             SPACE_GROUP
+    _name.object_id               SPACE_GROUP_GENERATOR
+
+    loop_
+      _category_key.name
+         '_space_group_generator.key'
+         '_space_group_generator.space_group_id'
+
+save_
+
+save_space_group_generator.space_group_id
+
+    _definition.id                '_space_group_generator.space_group_id'
+    _definition.update            2023-01-17
+    _description.text
+;
+    A code which identifies the space group to which the generator belongs.
+;
+    _name.category_id             space_group_generator
+    _name.object_id               space_group_id
+    _name.linked_item_id          '_space_group.id'
+    _type.purpose                 Link
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Word
+
+save_
+
+save_SPACE_GROUP_SYMOP
+
+    _definition.id                SPACE_GROUP_SYMOP
+    _definition.scope             Category
+    _definition.class             Loop
+    _definition.update            2023-10-16
+    _description.text
+;
+    The CATEGORY of data items used to describe symmetry equivalent sites
+    in the crystal unit cell.
+;
+    _name.category_id             SPACE_GROUP
+    _name.object_id               SPACE_GROUP_SYMOP
+
+    loop_
+      _category_key.name
+         '_space_group_symop.id'
+         '_space_group_symop.space_group_id'
+
+save_
+
+save_space_group_symop.space_group_id
+
+    _definition.id                '_space_group_symop.space_group_id'
+    _definition.update            2023-01-17
+    _description.text
+;
+    A code which identifies the space group to which the symop belongs.
+;
+    _name.category_id             space_group_symop
+    _name.object_id               space_group_id
+    _name.linked_item_id          '_space_group.id'
+    _type.purpose                 Link
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Word
+
+save_
+
+save_SPACE_GROUP_WYCKOFF
+
+    _definition.id                SPACE_GROUP_WYCKOFF
+    _definition.scope             Category
+    _definition.class             Loop
+    _definition.update            2023-10-16
+    _description.text
+;
+    Contains information about Wyckoff positions of a space group.
+    Only one site can be given for each special position, but the
+    remainder can be generated by applying the symmetry operations
+    stored in _space_group_symop.operation_xyz.
+;
+    _name.category_id             SPACE_GROUP
+    _name.object_id               SPACE_GROUP_WYCKOFF
+
+    loop_
+      _category_key.name
+         '_space_group_Wyckoff.id'
+         '_space_group_Wyckoff.space_group_id'
+
+save_
+
+save_space_group_wyckoff.space_group_id
+
+    _definition.id                '_space_group_Wyckoff.space_group_id'
+    _definition.update            2023-01-17
+    _description.text
+;
+    A code which identifies the space group to which the Wyckoff position
+    belongs.
+;
+    _name.category_id             space_group_Wyckoff
+    _name.object_id               space_group_id
+    _name.linked_item_id          '_space_group.id'
+    _type.purpose                 Link
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Word
+
+save_
+
+save_STRUCTURE
+
+    _definition.id                STRUCTURE
+    _definition.scope             Category
+    _definition.class             Set
+    _definition.update            2023-10-25
+    _description.text
+;
+    A category for collecting information about a crystallographic structure.
+;
+    _name.category_id             MULTIBLOCK_CORE
+    _name.object_id               STRUCTURE
+    _category_key.name            '_structure.id'
+
+save_
+
+save_structure.diffrn_id
+
+    _definition.id                '_structure.diffrn_id'
+    _definition.update            2023-01-17
+    _description.text
+;
+    A code which identifies the diffraction conditions under which the data for
+    this structure were collected.
+;
+    _name.category_id             structure
+    _name.object_id               diffrn_id
+    _name.linked_item_id          '_diffrn.id'
+    _type.purpose                 Link
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Word
+
+save_
+
+save_structure.id
+
+    _definition.id                '_structure.id'
+    _definition.update            2023-10-16
+    _description.text
+;
+    Unique identifier for a structure.
+;
+    _name.category_id             structure
+    _name.object_id               id
+    _type.purpose                 Key
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Word
+
+save_
+
+save_structure.space_group_id
+
+    _definition.id                '_structure.space_group_id'
+    _definition.update            2023-01-17
+    _description.text
+;
+    A code which identifies the space group associated with the structure.
+;
+    _name.category_id             structure
+    _name.object_id               space_group_id
+    _name.linked_item_id          '_space_group.id'
+    _type.purpose                 Link
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Word
+
+save_
+
+save_ATOM_SITE
+
+    _definition.id                ATOM_SITE
+    _definition.scope             Category
+    _definition.class             Loop
+    _definition.update            2023-10-16
+    _description.text
+;
+    The CATEGORY of data items used to describe atom site information
+    used in crystallographic structure studies.
+;
+    _name.category_id             ATOM
+    _name.object_id               ATOM_SITE
+
+    loop_
+      _category_key.name
+         '_atom_site.label'
+         '_atom_site.structure_id'
+
+    loop_
+      _description_example.case
+      _description_example.detail
+;
+         loop_
+           _atom_site.label
+           _atom_site.occupancy
+           _atom_site.disorder_assembly
+           _atom_site.disorder_group
+            C1     1      .     .
+            H11A   .5     M     1
+            H12A   .5     M     1
+            H13A   .5     M     1
+            H11B   .5     M     2
+            H12B   .5     M     2
+            H13B   .5     M     2
+;
+;
+         A hypothetical example of a positional disorder description. Disorder
+         assembly 'M' describes a methyl group with two alternative
+         configurations '1' and '2':
+
+                            H11B    H11A      H13B
+                              .      |      .
+                                .    |    .
+                                  .  |  .
+                                     C1 --------C2---
+                                   / .  \
+                                 /   .    \
+                               /     .      \
+                            H12A    H12B    H13A
+;
+;
+         loop_
+           _atom_site.label
+           _atom_site.type_symbol
+           _atom_site.fract_x
+           _atom_site.fract_y
+           _atom_site.fract_z
+           _atom_site.occupancy
+           _atom_site.disorder_assembly
+           _atom_site.disorder_group
+            Cu1 Cu 0.78443(2) 0.88297(4) 0.37825(2)  1       . .
+            Co1 Co 0.77504(2) 0.66957(4) 0.54249(2)  0.78(3) A 1
+            Mn1 Mn 0.77504(2) 0.66957(4) 0.54249(2)  0.22(3) A 2
+            O1   O 0.85532(9) 0.95747(19) 0.28965(9) 1       . .
+            O2   O 0.84868(9) 0.94662(19) 0.14953(8) 1       . .
+            # ...
+;
+;
+         An example of a compositional disorder description. Disorder assembly
+         'A' describes a site that is simultaneously occupied by Co and Mn
+         atoms which are assigned to disorder group '1' and disorder group '2'
+         respectively.
+
+         The example was created based on data from:
+             Li, Ang et al. (2021). Dalton Transactions, 50(2), 681-688.
+             https://doi.org/10.1039/d0dt03269g
+;
+
+save_
+
+save_atom_site.structure_id
+
+    _definition.id                '_atom_site.structure_id'
+    _definition.update            2023-10-16
+    _description.text
+;
+    A code identifying the structure to which this atom site belongs.
+;
+    _name.category_id             atom_site
+    _name.object_id               structure_id
+    _name.linked_item_id          '_structure.id'
+    _type.purpose                 Link
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Word
+
+save_
+
+save_ATOM_SITE_ANISO
+
+    _definition.id                ATOM_SITE_ANISO
+    _definition.scope             Category
+    _definition.class             Loop
+    _definition.update            2023-10-16
+    _description.text
+;
+    The CATEGORY of data items used to describe the anisotropic atomic
+    displacement parameters of the atomic sites in a crystal structure.
+;
+    _name.category_id             ATOM_SITE
+    _name.object_id               ATOM_SITE_ANISO
+
+    loop_
+      _category_key.name
+         '_atom_site_aniso.label'
+         '_atom_site_aniso.structure_id'
+
+save_
+
+save_atom_site_aniso.structure_id
+
+    _definition.id                '_atom_site_aniso.structure_id'
+    _definition.update            2023-10-16
+    _description.text
+;
+    A code identifying the structure to which this atom site belongs.
+;
+    _name.category_id             atom_site_aniso
+    _name.object_id               structure_id
+    _name.linked_item_id          '_atom_site.structure_id'
+    _type.purpose                 Link
+    _type.source                  Assigned
+    _type.container               Single
+    _type.contents                Word
+
+save_
+
+    loop_
+      _dictionary_audit.version
+      _dictionary_audit.date
+      _dictionary_audit.revision
+         1.0.0                    2023-09-15
+;
+       All multi-block items from core 3.2.0 added.
+;
+         1.1.0                    2025-04-14
+;
+       # Update date above and add audit comments below. Remove
+       this comment when ready for release.
+
+       Add STRUCTURE and related data names and links.
+
+       Update definitions of _cell.structure_id and
+       _cell_measurement.structure_id. Removed _cell.diffrn_id.
+
+       Update the CIF_CORE dictionary import statement with the new Head
+       category name.
+
+       Added _diffrn_radiation.diffrn_id as key for diffrn_radiation
+       category.
+
+       Added AUDIT_DATASET
+;
+

--- a/dictionaries/templ_attr.cif
+++ b/dictionaries/templ_attr.cif
@@ -1,0 +1,1049 @@
+#\#CIF_2.0
+##############################################################################
+#                                                                            #
+#              TEMPLATE DEFINITION ATTRIBUTES DICTIONARY                     #
+#                                                                            #
+##############################################################################
+
+data_TEMPL_ATTR
+
+    _dictionary.title            TEMPL_ATTR
+    _dictionary.class            Template
+    _dictionary.version          1.4.11
+    _dictionary.date             2024-07-17
+    _dictionary.uri              https://raw.githubusercontent.com/COMCIFS/cif_core/master/templ_attr.cif
+    _dictionary.ddl_conformance  4.2.0
+    _description.text
+;
+     This dictionary contains definition attribute sets that are common
+     to other CIF dictionaries and is imported by them.
+;
+
+#---------------------------------------------------------------------------
+
+save_atom_site_label
+
+    _definition.update           2021-10-25
+    _description.text
+;
+     This label is a unique identifier for a particular site in the
+     asymmetric unit of the crystal unit cell. It is made up of
+     components, _atom_site.label_component_0 to *_6, which may be
+     specified as separate data items. Component 0 usually matches one
+     of the specified _atom_type.symbol codes. This is not mandatory
+     if an _atom_site.type_symbol item is included in the atom site
+     list. The _atom_site.type_symbol always takes precedence over
+     an _atom_site.label in the identification of the atom type. The
+     label components 1 to 6 are optional, and normally only
+     components 0 and 1 are used. Note that components 0 and 1 are
+     concatenated, while all other components, if specified, are
+     separated by an underline character. Underline separators are
+     only used if higher-order components exist. If an intermediate
+     component is not used it may be omitted provided the underline
+     separators are inserted. For example the label 'C233__ggg' is
+     acceptable and represents the components C, 233, '', and ggg.
+     Each label may have a different number of components.
+;
+    _type.purpose                Encode
+    _type.source                 Assigned
+    _type.container              Single
+    _type.contents               Word
+     loop_
+    _description_example.case   C12     Ca3g28     Fe3+17     H*251
+                                C_a_phe_83_a_0  Zn_Zn_301_A_0
+     save_
+
+save_restr_label
+
+    _definition.update           2021-10-25
+    _description.text
+;
+      Labels of atom sites subtending distance or angle. Atom 2 is the apex for
+      angular restraints.
+;
+    _name.linked_item_id       '_atom_site.label'
+    _type.purpose                Encode
+    _type.source                 Assigned
+    _type.container              Single
+    _type.contents               Word
+     save_
+
+
+save_atom_site_id
+
+    _definition.update           2021-10-25
+    _description.text
+;
+     This label is a unique identifier for a particular site in the
+     asymmetric unit of the crystal unit cell.
+;
+    _name.linked_item_id       '_atom_site.label'
+    _type.purpose                Link
+    _type.source                 Assigned
+    _type.container              Single
+    _type.contents               Word
+     save_
+
+
+save_rho_coeff
+
+    _definition.update           2024-03-28
+    _description.text
+;
+     Specifies a multipole population coefficient P(l,m) for
+     the atom identified in _atom_rho_multipole.atom_label.
+;
+    _type.purpose                Measurand
+    _type.source                 Derived
+    _type.container              Single
+    _type.contents               Real
+    _units.code                  none
+     save_
+
+
+save_rho_kappa
+
+    _definition.update           2024-03-28
+    _description.text
+;
+      A radial function expansion-contraction coefficient
+      (κ     = _atom_rho_multipole_kappa.base and
+       κ'(l) = _atom_rho_multipole_kappa.prime[l])
+      for the atom specified in _atom_rho_multipole.atom_label.
+;
+    _type.purpose                Measurand
+    _type.source                 Derived
+    _type.container              Single
+    _type.contents               Real
+    _units.code                  none
+     save_
+
+
+save_rho_slater
+
+    _definition.update           2024-03-28
+    _description.text
+;
+      Items used when the radial dependence of the valence
+      electron density, R(κ'(l),l,r), of the atom specified in
+      _atom_rho_multipole.atom_label is expressed as a Slater-type
+      function [Hansen & Coppens (1978), equation (3)]
+;
+    _type.purpose                Measurand
+    _type.source                 Derived
+    _type.container              Single
+    _type.contents               Real
+    _units.code                  none
+     save_
+
+
+save_matrix_pdb
+
+    _definition.update           2021-03-18
+    _description.text
+;
+     Element of the PDB ORIGX matrix or vector.
+;
+    _type.purpose                Number
+    _type.source                 Derived
+    _type.container              Single
+    _type.contents               Real
+    _units.code                  none
+     save_
+
+
+save_matrix_w
+
+    _definition.update           2023-09-11
+    _description.text
+;
+     Element of the matrix W defined by van Smaalen (1991); (1995)
+;
+    _type.purpose                Number
+    _type.source                 Assigned
+    _type.container              Single
+    _type.contents               Real
+    _enumeration.default         0.0
+    _units.code                  none
+     save_
+
+
+save_ms_index
+
+    _definition.update           2014-06-27
+    _description.text
+;
+     Additional Miller indices needed to write the reciprocal vector
+     in the definition of _diffrn_refln_index.m_list,
+     _diffrn_standard_refln.index_m_list, _exptl_crystal_face.index_m_list.
+;
+    _type.purpose                Number
+    _type.source                 Recorded
+    _type.container              Single
+    _type.contents               Integer
+     save_
+
+
+save_index_limit_max
+
+    _definition.update           2021-03-01
+    _description.text
+;
+     Maximum value of the additional Miller indices appearing in
+     _diffrn_reflns.index_m_* and _reflns.index_m_*.
+;
+    _type.purpose                Number
+    _type.source                 Recorded
+    _type.container              Single
+    _type.contents               Integer
+    _units.code                  none
+     save_
+
+
+save_index_limit_min
+
+    _definition.update           2021-03-01
+    _description.text
+;
+     Minimum value of the additional Miller indices appearing in
+     _diffrn_reflns.index_m_* and _reflns.index_m_*.
+;
+    _type.purpose                Number
+    _type.source                 Recorded
+    _type.container              Single
+    _type.contents               Integer
+    _units.code                  none
+     save_
+
+
+save_cell_angle
+
+    _definition.update           2023-07-01
+    _description.text
+;
+     The angle between the bounding cell axes.
+;
+    _type.purpose                Measurand
+    _type.source                 Derived
+    _type.container              Single
+    _type.contents               Real
+    _enumeration.range           0.0:180.0
+    _units.code                  degrees
+     save_
+
+
+save_cell_angle_su
+
+    _definition.update           2023-07-01
+    _description.text
+;
+     Standard uncertainty of the angle between the bounding cell axes.
+;
+    _type.purpose                SU
+    _type.source                 Related
+    _type.container              Single
+    _type.contents               Real
+    _units.code                  degrees
+     save_
+
+
+save_cell_length
+
+    _definition.update           2024-07-17
+    _description.text
+;
+     The length of each cell axis.
+;
+    _type.purpose                Measurand
+    _type.source                 Derived
+    _type.container              Single
+    _type.contents               Real
+    _enumeration.range           0.0:
+    _units.code                  angstroms
+     save_
+
+
+save_cell_length_su
+
+    _definition.update           2023-07-01
+    _description.text
+;
+     Standard uncertainty of the length of each cell axis.
+;
+    _type.purpose                SU
+    _type.source                 Related
+    _type.container              Single
+    _type.contents               Real
+    _units.code                  angstroms
+     save_
+
+
+save_site_symmetry
+
+    _definition.update           2023-06-19
+    _description.text
+;
+     Data item specifying the symmetry operation codes applied to the atom
+     sites involved in a specific geometric configuration.
+
+     The symmetry code of each atom site as the symmetry-equivalent position
+     number 'n' and the cell translation number 'pqr'. These numbers are
+     combined to form the code 'n pqr' or n_pqr.
+
+     The character string n_pqr is composed as follows:
+
+         n refers to the symmetry operation that is applied to the
+         coordinates stored in _atom_site.fract_xyz. It must match
+         a number given in _space_group_symop.id (or one of its
+         aliases, such as _symmetry_equiv_pos_site_id).
+
+         p, q and r refer to the translations that are subsequently
+         applied to the symmetry transformed coordinates to generate
+         the atom used in calculating the angle. These translations
+         (x,y,z) are related to (p,q,r) by the relations
+              p = 5 + x
+              q = 5 + y
+              r = 5 + z
+;
+    _type.purpose                Composite
+    _type.source                 Derived
+    _type.container              Single
+    _type.contents               Symop
+     loop_
+    _description_example.case
+    _description_example.detail '4'     '4th symmetry operation applied.'
+                                '7_645' '7th symm. posn.; +a on x; -b on y.'
+                                 .      'No symmetry or translation to site.'
+
+    _enumeration.default         1_555
+
+     save_
+
+save_cartn_coord
+
+    _definition.update           2012-05-07
+    _description.text
+;
+     The atom site coordinates in angstroms specified according to a
+     set of orthogonal Cartesian axes related to the cell axes as
+     specified by the _atom_sites_Cartn_transform.axes description.
+;
+    _type.purpose                Measurand
+    _type.source                 Derived
+    _type.container              Single
+    _type.contents               Real
+    _units.code                  angstroms
+     save_
+
+
+save_cartn_coord_su
+
+    _definition.update           2023-07-01
+    _description.text
+;
+     Standard uncertainty values of the atom site coordinates
+     in angstroms specified according to a
+     set of orthogonal Cartesian axes related to the cell axes as
+     specified by the _atom_sites_Cartn_transform.axes description.
+;
+    _type.purpose                SU
+    _type.source                 Related
+    _type.container              Single
+    _type.contents               Real
+    _units.code                  angstroms
+     save_
+
+
+save_fract_coord
+
+    _definition.update           2012-05-07
+    _description.text
+;
+     Atom site coordinates as fractions of the cell length values.
+;
+    _type.purpose                Measurand
+    _type.source                 Derived
+    _type.container              Single
+    _type.contents               Real
+    _units.code                  none
+     save_
+
+
+save_fract_coord_su
+
+    _definition.update           2023-07-01
+    _description.text
+;
+     Standard uncertainty value of the atom site coordinates
+     as fractions of the cell length values.
+;
+    _type.purpose                SU
+    _type.source                 Related
+    _type.container              Single
+    _type.contents               Real
+    _units.code                  none
+     save_
+
+
+save_label_component
+
+    _definition.update           2021-10-21
+    _description.text
+;
+     Component_0 is normally a code which matches identically with
+     one of the _atom_type.symbol codes. If this is the case then the
+     rules governing the _atom_type.symbol code apply. If, however,
+     the data item _atom_site.type_symbol is also specified in the
+     atom site list, component 0 need not match this symbol or adhere
+     to any of the _atom_type.symbol rules.
+     Component_1 is referred to as the "atom number". When component 0
+     is the atom type code, it is used to number the sites with the
+     same atom type. This component code must start with at least one
+     digit which is not followed by a + or - sign (to distinguish it
+     from the component 0 rules).
+     Components_2 to 6 contain the identifier, residue, sequence,
+     asymmetry identifier and alternate codes, respectively. These
+     codes may be composed of any characters except an underline.
+;
+    _type.purpose                Encode
+    _type.source                 Assigned
+    _type.container              Single
+    _type.contents               Word
+     save_
+
+save_label_comp
+
+    _definition.update           2021-10-21
+    _description.text
+;
+     See label_component_0 description.
+;
+    _type.purpose                Encode
+    _type.source                 Assigned
+    _type.container              Single
+    _type.contents               Word
+
+save_
+
+save_cartn_matrix
+
+    _definition.update            2021-07-21
+    _description.text
+;
+    Matrix used to transform fractional coordinates in the ATOM_SITE category
+    to Cartesian coordinates. The axial alignments of this transformation are
+    described in _atom_sites_Cartn_transform.axes. The 3x1 translation is
+    defined in _atom_sites_Cartn_transform.vector.
+
+      x'                  |11 12 13|     x                  | 1 |
+    ( y' )Cartesian  = mat|21 22 23| * ( y )fractional + vec| 2 |
+      z'                  |31 32 33|     z                  | 3 |
+
+    The default transformation matrix uses Rollet's axial assignments with
+    cell vectors a,b,c aligned with orthogonal axes X,Y,Z so that c||Z and
+    b in plane YZ.
+;
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _units.code                   angstroms
+
+save_
+
+save_cartn_vector
+
+    _definition.update            2021-07-21
+    _description.text
+;
+    The 3x1 translation that is used with _atom_sites_cartn_transform.matrix
+    to transform fractional coordinates in the ATOM_SITE category to Cartesian
+    coordinates. The axial alignments of this transformation are described
+    in _atom_sites_Cartn_transform.axes.
+;
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _units.code                   angstroms
+
+save_
+
+save_ncs_matrix_ij
+
+    _definition.update          2021-03-01
+    _description.text
+;
+     The [I][J] element of the 3x3 matrix component of a
+     non-crystallographic symmetry operation.
+;
+    _type.purpose               Number
+    _type.source                Derived
+    _type.container             Single
+    _type.contents              Real
+    _units.code                 none
+
+save_
+
+save_rot_matrix_ij
+
+    _definition.update          2021-03-01
+    _description.text
+;
+     The [I][J] element of the matrix used to rotate the subset of the
+     Cartesian coordinates in the ATOM_SITE category identified in the
+     STRUCT_BIOL_GEN category to give a view useful for describing the
+     structure. The conventions used in the rotation are described in
+     _struct_biol_view.details.
+
+     |x'|                         |11 12 13| |x|
+     |y'|~reoriented Cartesian~ = |21 22 23| |y|~Cartesian~
+     |z'|                         |31 32 33| |z|
+;
+    _type.purpose               Number
+    _type.source                Derived
+    _type.container             Single
+    _type.contents              Real
+    _units.code                 none
+
+save_
+
+save_fract_matrix
+
+    _definition.update            2021-07-21
+    _description.text
+;
+    Matrix used to transform Cartesian coordinates in the ATOM_SITE category
+    to fractional coordinates. The axial alignments of this transformation are
+    described in _atom_sites_fract_transform.axes. The 3x1 translation is
+    defined in _atom_sites_fract_transform.vector.
+
+      x'                  |11 12 13|     x                  | 1 |
+    ( y' )fractional = mat|21 22 23| * ( y )Cartesian +  vec| 2 |
+      z'                  |31 32 33|     z                  | 3 |
+
+    The default transformation matrix uses Rollet's axial assignments with
+    cell vectors a,b,c aligned with orthogonal axes X,Y,Z so that c||Z and
+    b in plane YZ.
+;
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _units.code                   reciprocal_angstroms
+
+save_
+
+save_fract_vector
+
+    _definition.update            2021-07-21
+    _description.text
+;
+    The 3x1 translation that is used with _atom_sites_fract_transform.matrix
+    to transform Cartesian coordinates in the ATOM_SITE category to fractional
+    coordinates. The axial alignments of this transformation are described
+    in _atom_sites_fract_transform.axes.
+;
+    _type.purpose                 Measurand
+    _type.source                  Derived
+    _type.container               Single
+    _type.contents                Real
+    _units.code                   none
+
+save_
+
+save_aniso_bij
+
+    _definition.update           2023-02-16
+    _description.text
+;
+     These are the standard anisotropic atomic displacement components, in
+     angstroms squared, which appear in the structure factor term:
+
+         T = exp{-1/4 sum~i~ [ sum~j~ (B^ij^ h~i~ h~j~ a*~i~ a*~j~) ] }
+
+     h = the Miller indices
+     a* = the reciprocal-space cell lengths
+
+     The unique elements of the real symmetric matrix are entered by row.
+
+     The IUCr Commission on Nomenclature recommends against the use of B for
+     reporting atomic displacement parameters. U, being directly proportional
+     to B, is preferred [1].
+
+     Note that U^ij^ = β^ij^/(2 π^2^ a*~i~ a*~j~) = B^ij^/(8 π^2^) [1].
+
+     [1] Trueblood, K. N. et al. (1996). Acta Crystallogr. A52(5), 770-781.
+;
+    _type.purpose                Measurand
+    _type.source                 Derived
+    _type.container              Single
+    _type.contents               Real
+    _units.code                  angstrom_squared
+     save_
+
+
+save_aniso_bij_su
+
+    _definition.update           2023-07-01
+    _description.text
+;
+     These are the standard uncertainty values (SU) for the standard
+     form of the B^ij^ anisotropic atomic displacement components (see
+     aniso_BIJ). Because these values are TYPE measurand, the su values
+     may in practice be auto generated as part of the B^ij^ calculation.
+;
+    _type.purpose                SU
+    _type.source                 Related
+    _type.container              Single
+    _type.contents               Real
+    _units.code                  angstrom_squared
+     save_
+
+
+save_aniso_betaij
+
+    _definition.update           2023-02-16
+    _description.text
+;
+     These are the standard unitless anisotropic atomic displacement components
+     which appear in the structure factor term:
+
+         T = exp{-1 sum~i~ [ sum~j~ (β^ij^ h~i~ h~j~) ] }
+
+     h = the Miller indices
+
+     The unique elements of the real symmetric matrix are entered by row.
+
+     The IUCr Commission on Nomenclature recommends against the use
+     of β for reporting atomic displacement parameters; U is preferred [1].
+
+     Note that U^ij^ = β^ij^/(2 π^2^ a*~i~ a*~j~) = B^ij^/(8 π^2^) [1].
+
+     [1] Trueblood, K. N. et al. (1996). Acta Crystallogr. A52(5), 770-781.
+;
+    _type.purpose                Measurand
+    _type.source                 Derived
+    _type.container              Single
+    _type.contents               Real
+    _units.code                  none
+     save_
+
+
+save_aniso_betaij_su
+
+    _definition.update           2023-02-15
+    _description.text
+;
+     These are the standard uncertainty values (SU) for the standard
+     form of the β^ij^ anisotropic atomic displacement components (see
+     aniso_betaIJ). Because these values are TYPE measurand, the su values
+     may in practice be auto generated as part of the β^ij^ calculation.
+;
+    _type.purpose                SU
+    _type.source                 Related
+    _type.container              Single
+    _type.contents               Real
+    _units.code                  none
+     save_
+
+
+save_aniso_uij
+
+    _definition.update           2023-02-16
+    _description.text
+;
+     These are the standard anisotropic atomic displacement components, in
+     angstroms squared, which appear in the structure factor term:
+
+        T = exp{ -2π^2^ sum~i~ [ sum~j~ (U^ij^ h~i~ h~j~ a*~i~ a*~j~) ] }
+
+     h = the Miller indices
+     a* = the reciprocal-space cell lengths
+
+     The unique elements of the real symmetric matrix are entered by row.
+
+     The IUCr Commission on Nomenclature recommends the use of U for reporting
+     atomic displacement parameters [1].
+
+     Note that U^ij^ = β^ij^/(2 π^2^ a*~i~ a*~j~) = B^ij^/(8 π^2^) [1].
+
+     [1] Trueblood, K. N. et al. (1996). Acta Crystallogr. A52(5), 770-781.
+;
+    _type.purpose                Measurand
+    _type.source                 Derived
+    _type.container              Single
+    _type.contents               Real
+    _units.code                  angstrom_squared
+     save_
+
+
+save_aniso_uij_su
+
+    _definition.update           2023-07-01
+    _description.text
+;
+     These are the standard uncertainty values (SU) for the standard
+     form of the U^ij^ anisotropic atomic displacement components (see
+     aniso_UIJ). Because these values are TYPE measurand, the su values
+     may in practice be auto generated as part of the U^ij^ calculation.
+;
+    _type.purpose                SU
+    _type.source                 Related
+    _type.container              Single
+    _type.contents               Real
+    _units.code                  angstrom_squared
+     save_
+
+save_general_su
+
+    _type.purpose                SU
+    _type.source                 Related
+    _type.container              Single
+    _type.contents               Real
+
+save_
+
+save_cromer_mann_coeff
+
+    _definition.update           2023-06-03
+    _description.text
+;
+    The set of data items used to define Cromer-Mann coefficients
+    for generation of (0.0 < s < 2.0 Å^-1^) X-ray scattering factors.
+
+    f(s) = c + Sum(a~i~ * exp(-b~i~ * s^2^), i=1:4)
+
+    where s = sin(θ)/λ and θ is the diffraction angle and λ is the wavelength
+    of the incident radiation in angstroms.
+
+        Ref: International Tables for X-ray Crystallography, Vol. IV
+             (1974) Table 2.2B
+        or   International Tables for Crystallography, Vol. C
+             (1991) Tables 6.1.1.4 and 6.1.1.5
+;
+    _type.purpose                Number
+    _type.source                 Assigned
+    _type.container              Single
+    _type.contents               Real
+    _enumeration.def_index_id  '_atom_type.symbol'
+     save_
+
+
+save_hi_ang_fox_coeffs
+
+    _definition.update           2023-06-03
+    _description.text
+;
+    The set of data items used to define Fox et al. coefficients
+    for generation of high angle (2.0 < s < 6.0 Å^-1^) X-ray scattering factors.
+
+    f(s) = exp(Sum(c~i~ * s^i^, i=0:3))
+
+    where s = sin(θ)/λ and θ is the diffraction angle and λ is the wavelength
+    of the incident radiation in angstroms.
+
+        Ref: International Tables for Crystallography, Vol. C
+             (1991) Table 6.1.1.5
+;
+    _type.purpose                Number
+    _type.source                 Assigned
+    _type.container              Single
+    _type.contents               Real
+    _enumeration.def_index_id  '_atom_type.symbol'
+     save_
+
+
+save_miller_index
+
+    _definition.update           2013-04-16
+    _description.text
+;
+     The index of a reciprocal space vector.
+;
+    _type.purpose                Number
+    _type.source                 Recorded
+    _type.container              Single
+    _type.contents               Integer
+    _units.code                  none
+     save_
+
+
+save_orient_matrix
+
+    _definition.update           2012-05-07
+    _description.text
+;
+     The set of data items which specify the elements of the matrix of
+     the orientation of the crystal axes to the diffractometer goniometer.
+;
+    _type.purpose                Number
+    _type.source                 Recorded
+    _type.container              Single
+    _type.contents               Real
+    _units.code                  none
+     save_
+
+
+save_transf_matrix
+
+    _definition.update           2012-05-07
+    _description.text
+;
+     The set of data items which specify the elements of the matrix
+     used to transform the reflection indices _diffrn_refln.hkl
+     into _refln.hkl.
+;
+    _type.purpose                Number
+    _type.source                 Recorded
+    _type.container              Single
+    _type.contents               Real
+    _units.code                  none
+     save_
+
+
+save_face_angle
+
+    _definition.update           2013-04-15
+    _description.text
+;
+    Diffractometer angle setting when the perpendicular to the specified
+    crystal face is aligned along a specified direction (e.g. the
+    bisector of the incident and reflected beams in an optical goniometer.
+;
+    _type.purpose                Measurand
+    _type.source                 Recorded
+    _type.container              Single
+    _type.contents               Real
+    _enumeration.range           -180.0:180.0
+    _units.code                  degrees
+     save_
+
+
+save_orient_angle
+
+    _definition.update           2013-04-15
+    _description.text
+;
+     Diffractometer angle of a reflection measured at the centre of the
+     diffraction peak and used to determine _diffrn_orient_matrix.UBIJ.
+;
+    _type.purpose                Measurand
+    _type.source                 Recorded
+    _type.container              Single
+    _type.contents               Real
+    _enumeration.range           -180.0:180.0
+    _units.code                  degrees
+     save_
+
+
+save_diffr_angle
+
+    _definition.update           2013-04-15
+    _description.text
+;
+     Diffractometer angle at which the intensity is measured. This was
+     calculated from the specified orientation matrix and the original
+     measured cell dimensions before any subsequent transformations.
+;
+    _type.purpose                Number
+    _type.source                 Derived
+    _type.container              Single
+    _type.contents               Real
+    _enumeration.range           -180.0:180.0
+    _units.code                  degrees
+     save_
+
+
+save_display_colour
+
+    _definition.update           2019-01-09
+    _description.text
+;
+     Integer value between 0 and 255 giving the intensity of a
+     specific colour component (red, green or blue) for the RGB
+     display colour code.
+;
+    _type.purpose                Number
+    _type.source                 Recorded
+    _type.container              Single
+    _type.contents               Integer
+    _enumeration.range           0:255
+    _units.code                  none
+     save_
+
+#=============================================================================
+#  The dictionary's attribute creation history.
+#============================================================================
+
+    loop_
+      _dictionary_audit.version
+      _dictionary_audit.date
+      _dictionary_audit.revision
+         1.0.0                    2005-12-12
+;
+       Initial version of the TEMPLATES dictionary created from the
+       definitions used in CORE_3 dictionary version 3.5.02
+;
+         1.0.1                    2006-02-12
+;
+       Remove dictionary attributes from a save frame.
+       Change category core_templates to template
+;
+         1.2.1                    2006-02-21
+;
+       File structure to conform with prototype version dictionaries.
+;
+         1.2.2                    2006-03-07
+;
+       Added the template _template.relational_id for the ddl3 dictionary.
+;
+         1.2.3                    2006-06-17
+;
+       Apply DDL 3.6.01 changes
+;
+         1.2.4                    2006-06-29
+;
+       Remove "_template" from the definition names.
+       Apply DDL 3.6.05 changes.
+       Change file name from templates.dic to com_att.dic
+;
+         1.2.5                    2006-09-07
+;
+       Apply DDL 3.6.08 changes
+;
+         1.2.6                    2006-11-13
+;
+       Apply DDL 3.6.10 changes
+;
+         1.2.7                    2006-12-14
+;
+       Apply DDL 3.7.01 changes
+;
+         1.2.8                    2008-06-18
+;
+       Change _type.purpose for Miller_index from Observed to Identify
+;
+         1.3.1                    2011-08-03
+;
+       Remove definition.id lines in keeping with nested imports.
+;
+         1.3.2                    2011-12-01
+;
+       Update the DDL version. No Matrix types present.
+;
+         1.3.3                    2012-05-07
+;
+       Apply changes of 3.10.01 DDL version.
+;
+         1.3.4                    2012-10-16
+;
+       Apply changes of 3.10.02 DDL version. "Label" becomes "Code".
+;
+         1.3.5                    2012-11-29
+;
+       Add "_enumeration.def_index_id  '_atom_type.symbol' "
+       to Cromer_Mann_coeff and hi_ang_Fox_coeffs.
+;
+         1.3.6                    2012-12-11
+;
+       Add the templates Cartn_matrix and fract_matrix
+;
+         1.4.1                    2013-03-08
+;
+       Changes arising from alerts issued by ALIGN.
+;
+         1.4.2                    2013-04-15
+;
+       Removed description.common from all defs; inconsistent invocations
+       Changed types for 'diffrn_angle'
+       Added new frame for 'orient_angle'
+;
+         1.4.3                    2013-04-16
+;
+       Changed type.source 'Measured' to 'Recorded'
+       Changed type.source 'Assigned' to 'Recorded' in Miller_index
+;
+         1.4.4                    2013-04-17
+;
+       Changed type.source 'Quantity' to 'Number' or 'Encode'
+;
+         1.4.5                    2014-06-08
+;
+       Added aniso_BIJ_su and aniso_UIJ_su
+       Added atom_site_fract_su and atom_site_cartn_su
+;
+         1.4.6                    2014-06-09
+;
+       dummy top line added to all frames; this is skipped on import.
+;
+         1.4.7                    2014-06-12
+;
+       Added attribute save frame "aniso_BIJ2"
+       Added attribute save frame "rot_matrix_IJ"
+       Added attribute save frame "ncs_matrix_IJ"
+       Added attribute save frame "atom_site_id"
+       Added attribute save frame "label_comp"
+;
+         1.4.8                    2014-06-27
+;
+       Added attribute save frame "ms_index"
+       Added attribute save frame "matrix_w"
+;
+         1.4.9                    2019-09-25
+;
+       Changed the '_type.purpose' from 'Encode' to 'Link' in the 'atom_site_id'
+       save frame.
+
+       Removed the '_name.linked_item_id' data item from the 'atom_site_label'
+       save frame.
+
+       Changed the data type in the 'diffr_counts' save frame from 'Count' to
+       'Integer'.
+;
+         1.4.10                   2023-01-13
+;
+       Corrected a few typos in the descriptions of several save frames.
+
+       Added the 'none' units of measurement to the 'rho_coeff',
+       'rho_kappa', 'rho_slater', 'matrix_pdb', 'matrix_w', 'index_limit_max',
+       'index_limit_min', 'ncs_matrix_IJ' and 'rot_matrix_IJ' save frames.
+
+       Changed the units of measurement in the 'Cartn_matrix' save frame
+       from 'reciprocal_angstroms' to 'angstroms'.
+
+       Changed the units of measurement in the 'fract_matrix' save frame
+       from 'none' to 'reciprocal_angstroms'.
+
+       Added the 'Cartn_vector' and 'fract_vector' save frames.
+
+       Changed the DDL conformance version number from 3.14.0 to 4.1.0.
+
+       Changed atomic labels to 'Word' for conformance with DDL1.
+
+       Updated description of _site_symmetry.
+;
+         1.4.11                   2024-07-17
+;
+       # Please update the date above and describe the change below until
+       # ready for the next release
+
+       Updated descriptions of cromer_mann_coeff and hi_ang_fox_coeffs.
+
+       Added the default value of '1_555' to the 'site_symmetry' save frame.
+
+       Added descriptions for aniso_betaIJ, and aniso_betaIJ_su.
+       Updated descriptions of aniso_BIJ and aniso_UIJ.
+
+       Removed the 'aniso_bij2' save frame.
+
+       Changed the _type.source attribute of all SU data items to 'Related'.
+
+       Removed the _name.category_id attribute from the 'matrix_w' save frame.
+
+       Corrected referenced data names (e.g. atom_rho_multipole.atom_label
+       -> _atom_rho_multipole.atom_label) in the save_rho_* saveframes (bm).
+
+       Changed the enumeration range of in the 'cell_length' save frame from
+       '1.0:' to '0.0:' (av).
+;

--- a/dictionaries/templ_enum.cif
+++ b/dictionaries/templ_enum.cif
@@ -1,0 +1,2393 @@
+#\#CIF_2.0
+##############################################################################
+#                                                                            #
+#         TEMPLATE DICTIONARY OF COMMONLY USED ENUMERATIONS                  #
+#                                                                            #
+##############################################################################
+
+data_COM_VAL
+
+    _dictionary.title            COM_VAL
+    _dictionary.class            Template
+    _dictionary.version          1.4.9
+    _dictionary.date             2024-12-18
+    _dictionary.uri              https://raw.githubusercontent.com/COMCIFS/cif_core/master/templ_enum.cif
+    _dictionary.ddl_conformance  4.2.0
+    _description.text
+;
+     This dictionary contains commonly used enumeration value sets that
+     are imported into CIF dictionaries.
+;
+
+#---------------------------------------------------------------------------
+
+save_h_m_ref
+
+    loop_
+        _enumeration_set.state
+        _enumeration_set.detail
+               'P 1'           '  1  C1.1'
+               'P -1'          '  2  Ci.1'
+               'P 2'           '  3  C2.1'
+               'P 21'          '  4  C2.2'
+               'C 2'           '  5  C2.3'
+               'P m'           '  6  Cs.1'
+               'P c'           '  7  Cs.2'
+               'C m'           '  8  Cs.3'
+               'C c'           '  9  Cs.4'
+               'P 2/m'         ' 10  C2h.1'
+               'P 21/m'        ' 11  C2h.2'
+               'C 2/m'         ' 12  C2h.3'
+               'P 2/c'         ' 13  C2h.4'
+               'P 21/c'        ' 14  C2h.5'
+               'C 2/c'         ' 15  C2h.6'
+               'P 2 2 2'       ' 16  D2.1'
+               'P 2 2 21'      ' 17  D2.2'
+               'P 21 21 2'     ' 18  D2.3'
+               'P 21 21 21'    ' 19  D2.4'
+               'C 2 2 21'      ' 20  D2.5'
+               'C 2 2 2'       ' 21  D2.6'
+               'F 2 2 2'       ' 22  D2.7'
+               'I 2 2 2'       ' 23  D2.8'
+               'I 21 21 21'    ' 24  D2.9'
+               'P m m 2'       ' 25  C2v.1'
+               'P m c 21'      ' 26  C2v.2'
+               'P c c 2'       ' 27  C2v.3'
+               'P m a 2'       ' 28  C2v.4'
+               'P c a 21'      ' 29  C2v.5'
+               'P n c 2'       ' 30  C2v.6'
+               'P m n 21'      ' 31  C2v.7'
+               'P b a 2'       ' 32  C2v.8'
+               'P n a 21'      ' 33  C2v.9'
+               'P n n 2'       ' 34  C2v.10'
+               'C m m 2'       ' 35  C2v.11'
+               'C m c 21'      ' 36  C2v.12'
+               'C c c 2'       ' 37  C2v.13'
+               'A m m 2'       ' 38  C2v.14'
+               'A e m 2'       ' 39  C2v.15'
+               'A m a 2'       ' 40  C2v.16'
+               'A e a 2'       ' 41  C2v.17'
+               'F m m 2'       ' 42  C2v.18'
+               'F d d 2'       ' 43  C2v.19'
+               'I m m 2'       ' 44  C2v.20'
+               'I b a 2'       ' 45  C2v.21'
+               'I m a 2'       ' 46  C2v.22'
+               'P m m m'       ' 47  D2h.1'
+               'P n n n'       ' 48  D2h.2'
+               'P c c m'       ' 49  D2h.3'
+               'P b a n'       ' 50  D2h.4'
+               'P m m a'       ' 51  D2h.5'
+               'P n n a'       ' 52  D2h.6'
+               'P m n a'       ' 53  D2h.7'
+               'P c c a'       ' 54  D2h.8'
+               'P b a m'       ' 55  D2h.9'
+               'P c c n'       ' 56  D2h.10'
+               'P b c m'       ' 57  D2h.11'
+               'P n n m'       ' 58  D2h.12'
+               'P m m n'       ' 59  D2h.13'
+               'P b c n'       ' 60  D2h.14'
+               'P b c a'       ' 61  D2h.15'
+               'P n m a'       ' 62  D2h.16'
+               'C m c m'       ' 63  D2h.17'
+               'C m c e'       ' 64  D2h.18'
+               'C m m m'       ' 65  D2h.19'
+               'C c c m'       ' 66  D2h.20'
+               'C m m e'       ' 67  D2h.21'
+               'C c c e'       ' 68  D2h.22'
+               'F m m m'       ' 69  D2h.23'
+               'F d d d'       ' 70  D2h.24'
+               'I m m m'       ' 71  D2h.25'
+               'I b a m'       ' 72  D2h.26'
+               'I b c a'       ' 73  D2h.27'
+               'I m m a'       ' 74  D2h.28'
+               'P 4'           ' 75  C4.1'
+               'P 41'          ' 76  C4.2'
+               'P 42'          ' 77  C4.3'
+               'P 43'          ' 78  C4.4'
+               'I 4'           ' 79  C4.5'
+               'I 41'          ' 80  C4.6'
+               'P -4'          ' 81  S4.1'
+               'I -4'          ' 82  S4.2'
+               'P 4/m'         ' 83  C4h.1'
+               'P 42/m'        ' 84  C4h.2'
+               'P 4/n'         ' 85  C4h.3'
+               'P 42/n'        ' 86  C4h.4'
+               'I 4/m'         ' 87  C4h.5'
+               'I 41/a'        ' 88  C4h.6'
+               'P 4 2 2'       ' 89  D4.1'
+               'P 4 21 2'      ' 90  D4.2'
+               'P 41 2 2'      ' 91  D4.3'
+               'P 41 21 2'     ' 92  D4.4'
+               'P 42 2 2'      ' 93  D4.5'
+               'P 42 21 2'     ' 94  D4.6'
+               'P 43 2 2'      ' 95  D4.7'
+               'P 43 21 2'     ' 96  D4.8'
+               'I 4 2 2'       ' 97  D4.9'
+               'I 41 2 2'      ' 98  D4.10'
+               'P 4 m m'       ' 99  C4v.1'
+               'P 4 b m'       '100  C4v.2'
+               'P 42 c m'      '101  C4v.3'
+               'P 42 n m'      '102  C4v.4'
+               'P 4 c c'       '103  C4v.5'
+               'P 4 n c'       '104  C4v.6'
+               'P 42 m c'      '105  C4v.7'
+               'P 42 b c'      '106  C4v.8'
+               'I 4 m m'       '107  C4v.9'
+               'I 4 c m'       '108  C4v.10'
+               'I 41 m d'      '109  C4v.11'
+               'I 41 c d'      '110  C4v.12'
+               'P -4 2 m'      '111  D2d.1'
+               'P -4 2 c'      '112  D2d.2'
+               'P -4 21 m'     '113  D2d.3'
+               'P -4 21 c'     '114  D2d.4'
+               'P -4 m 2'      '115  D2d.5'
+               'P -4 c 2'      '116  D2d.6'
+               'P -4 b 2'      '117  D2d.7'
+               'P -4 n 2'      '118  D2d.8'
+               'I -4 m 2'      '119  D2d.9'
+               'I -4 c 2'      '120  D2d.10'
+               'I -4 2 m'      '121  D2d.11'
+               'I -4 2 d'      '122  D2d.12'
+               'P 4/m m m'     '123  D4h.1'
+               'P 4/m c c'     '124  D4h.2'
+               'P 4/n b m'     '125  D4h.3'
+               'P 4/n n c'     '126  D4h.4'
+               'P 4/m b m'     '127  D4h.5'
+               'P 4/m n c'     '128  D4h.6'
+               'P 4/n m m'     '129  D4h.7'
+               'P 4/n c c'     '130  D4h.8'
+               'P 42/m m c'    '131  D4h.9'
+               'P 42/m c m'    '132  D4h.10'
+               'P 42/n b c'    '133  D4h.11'
+               'P 42/n n m'    '134  D4h.12'
+               'P 42/m b c'    '135  D4h.13'
+               'P 42/m n m'    '136  D4h.14'
+               'P 42/n m c'    '137  D4h.15'
+               'P 42/n c m'    '138  D4h.16'
+               'I 4/m m m'     '139  D4h.17'
+               'I 4/m c m'     '140  D4h.18'
+               'I 41/a m d'    '141  D4h.19'
+               'I 41/a c d'    '142  D4h.20'
+               'P 3'           '143  C3.1'
+               'P 31'          '144  C3.2'
+               'P 32'          '145  C3.3'
+               'R 3'           '146  C3.4'
+               'P -3'          '147  C3i.1'
+               'R -3'          '148  C3i.2'
+               'P 3 1 2'       '149  D3.1'
+               'P 3 2 1'       '150  D3.2'
+               'P 31 1 2'      '151  D3.3'
+               'P 31 2 1'      '152  D3.4'
+               'P 32 1 2'      '153  D3.5'
+               'P 32 2 1'      '154  D3.6'
+               'R 3 2'         '155  D3.7'
+               'P 3 m 1'       '156  C3v.1'
+               'P 3 1 m'       '157  C3v.2'
+               'P 3 c 1'       '158  C3v.3'
+               'P 3 1 c'       '159  C3v.4'
+               'R 3 m'         '160  C3v.5'
+               'R 3 c'         '161  C3v.6'
+               'P -3 1 m'      '162  D3d.1'
+               'P -3 1 c'      '163  D3d.2'
+               'P -3 m 1'      '164  D3d.3'
+               'P -3 c 1'      '165  D3d.4'
+               'R -3 m'        '166  D3d.5'
+               'R -3 c'        '167  D3d.6'
+               'P 6'           '168  C6.1'
+               'P 61'          '169  C6.2'
+               'P 65'          '170  C6.3'
+               'P 62'          '171  C6.4'
+               'P 64'          '172  C6.5'
+               'P 63'          '173  C6.6'
+               'P -6'          '174  C3h.1'
+               'P 6/m '        '175  C6h.1'
+               'P 63/m'        '176  C6h.2'
+               'P 6 2 2'       '177  D6.1'
+               'P 61 2 2'      '178  D6.2'
+               'P 65 2 2'      '179  D6.3'
+               'P 62 2 2'      '180  D6.4'
+               'P 64 2 2'      '181  D6.5'
+               'P 63 2 2'      '182  D6.6'
+               'P 6 m m'       '183  C6v.1'
+               'P 6 c c'       '184  C6v.2'
+               'P 63 c m'      '185  C6v.3'
+               'P 63 m c'      '186  C6v.4'
+               'P -6 m 2'      '187  D3h.1'
+               'P -6 c 2'      '188  D3h.2'
+               'P -6 2 m'      '189  D3h.3'
+               'P -6 2 c'      '190  D3h.4'
+               'P 6/m m m'     '191  D6h.1'
+               'P 6/m c c'     '192  D6h.2'
+               'P 63/m c m'    '193  D6h.3'
+               'P 63/m m c'    '194  D6h.4'
+               'P 2 3'         '195  T.1'
+               'F 2 3'         '196  T.2'
+               'I 2 3'         '197  T.3'
+               'P 21 3'        '198  T.4'
+               'I 21 3'        '199  T.5'
+               'P m -3'        '200  Th.1'
+               'P n -3'        '201  Th.2'
+               'F m -3'        '202  Th.3'
+               'F d -3'        '203  Th.4'
+               'I m -3'        '204  Th.5'
+               'P a -3'        '205  Th.6'
+               'I a -3'        '206  Th.7'
+               'P 4 3 2'       '207  O.1'
+               'P 42 3 2'      '208  O.2'
+               'F 4 3 2'       '209  O.3'
+               'F 41 3 2'      '210  O.4'
+               'I 4 3 2'       '211  O.5'
+               'P 43 3 2'      '212  O.6'
+               'P 41 3 2'      '213  O.7'
+               'I 41 3 2'      '214  O.8'
+               'P -4 3 m'      '215  Td.1'
+               'F -4 3 m'      '216  Td.2'
+               'I -4 3 m'      '217  Td.3'
+               'P -4 3 n'      '218  Td.4'
+               'F -4 3 c'      '219  Td.5'
+               'I -4 3 d'      '220  Td.6'
+               'P m -3 m'      '221  Oh.1'
+               'P n -3 n'      '222  Oh.2'
+               'P m -3 n'      '223  Oh.3'
+               'P n -3 m'      '224  Oh.4'
+               'F m -3 m'      '225  Oh.5'
+               'F m -3 c'      '226  Oh.6'
+               'F d -3 m'      '227  Oh.7'
+               'F d -3 c'      '228  Oh.8'
+               'I m -3 m'      '229  Oh.9'
+               'I a -3 d'      '230  Oh.10'
+    save_
+
+
+save_ref_set
+
+    loop_
+        _enumeration_set.state
+        _enumeration_set.detail
+               '001:P 1'             'C1.1   P 1'
+               '002:-P 1'            'Ci.1   P -1'
+               '003:P 2y'            'C2.1   P 1 2 1'
+               '004:P 2yb'           'C2.2   P 1 21 1'
+               '005:C 2y'            'C2.3   C 1 2 1'
+               '006:P -2y'           'Cs.1   P 1 m 1'
+               '007:P -2yc'          'Cs.2   P 1 c 1'
+               '008:C -2y'           'Cs.3   C 1 m 1'
+               '009:C -2yc'          'Cs.4   C 1 c 1'
+               '010:-P 2y'           'C2h.1  P 1 2/m 1'
+               '011:-P 2yb'          'C2h.2  P 1 21/m 1'
+               '012:-C 2y'           'C2h.3  C 1 2/m 1'
+               '013:-P 2yc'          'C2h.4  P 1 2/c 1'
+               '014:-P 2ybc'         'C2h.5  P 1 21/c 1'
+               '015:-C 2yc'          'C2h.6  C 1 2/c 1'
+               '016:P 2 2'           'D2.1   P 2 2 2'
+               '017:P 2c 2'          'D2.2   P 2 2 21'
+               '018:P 2 2ab'         'D2.3   P 21 21 2'
+               '019:P 2ac 2ab'       'D2.4   P 21 21 21'
+               '020:C 2c 2'          'D2.5   C 2 2 21'
+               '021:C 2 2'           'D2.6   C 2 2 2'
+               '022:F 2 2'           'D2.7   F 2 2 2'
+               '023:I 2 2'           'D2.8   I 2 2 2'
+               '024:I 2b 2c'         'D2.9   I 21 21 21'
+               '025:P 2 -2'          'C2v.1  P m m 2'
+               '026:P 2c -2'         'C2v.2  P m c 21'
+               '027:P 2 -2c'         'C2v.3  P c c 2'
+               '028:P 2 -2a'         'C2v.4  P m a 2'
+               '029:P 2c -2ac'       'C2v.5  P c a 21'
+               '030:P 2 -2bc'        'C2v.6  P n c 2'
+               '031:P 2ac -2'        'C2v.7  P m n 21'
+               '032:P 2 -2ab'        'C2v.8  P b a 2'
+               '033:P 2c -2n'        'C2v.9  P n a 21'
+               '034:P 2 -2n'         'C2v.10 P n n 2'
+               '035:C 2 -2'          'C2v.11 C m m 2'
+               '036:C 2c -2'         'C2v.12 C m c 21'
+               '037:C 2 -2c'         'C2v.13 C c c 2'
+               '038:A 2 -2'          'C2v.14 A m m 2'
+               '039:A 2 -2b'         'C2v.15 A e m 2'
+               '040:A 2 -2a'         'C2v.16 A m a 2'
+               '041:A 2 -2ab'        'C2v.17 A e a 2'
+               '042:F 2 -2'          'C2v.18 F m m 2'
+               '043:F 2 -2d'         'C2v.19 F d d 2'
+               '044:I 2 -2'          'C2v.20 I m m 2'
+               '045:I 2 -2c'         'C2v.21 I b a 2'
+               '046:I 2 -2a'         'C2v.22 I m a 2'
+               '047:-P 2 2'          'D2h.1  P m m m'
+               '048:-P 2ab 2bc'      'D2h.2  P n n n:2'
+               '049:-P 2 2c'         'D2h.3  P c c m'
+               '050:-P 2ab 2b'       'D2h.4  P b a n:2'
+               '051:-P 2a 2a'        'D2h.5  P m m a'
+               '052:-P 2a 2bc'       'D2h.6  P n n a'
+               '053:-P 2ac 2'        'D2h.7  P m n a'
+               '054:-P 2a 2ac'       'D2h.8  P c c a'
+               '055:-P 2 2ab'        'D2h.9  P b a m'
+               '056:-P 2ab 2ac'      'D2h.10 P c c n'
+               '057:-P 2c 2b'        'D2h.11 P b c m'
+               '058:-P 2 2n'         'D2h.12 P n n m'
+               '059:-P 2ab 2a'       'D2h.13 P m m n:2'
+               '060:-P 2n 2ab'       'D2h.14 P b c n'
+               '061:-P 2ac 2ab'      'D2h.15 P b c a'
+               '062:-P 2ac 2n'       'D2h.16 P n m a'
+               '063:-C 2c 2'         'D2h.17 C m c m'
+               '064:-C 2ac 2'        'D2h.18 C m c e'
+               '065:-C 2 2'          'D2h.19 C m m m'
+               '066:-C 2 2c'         'D2h.20 C c c m'
+               '067:-C 2a 2'         'D2h.21 C m m e'
+               '068:-C 2a 2ac'       'D2h.22 C c c e:2'
+               '069:-F 2 2'          'D2h.23 F m m m'
+               '070:-F 2uv 2vw'      'D2h.24 F d d d:2'
+               '071:-I 2 2'          'D2h.25 I m m m'
+               '072:-I 2 2c'         'D2h.26 I b a m'
+               '073:-I 2b 2c'        'D2h.27 I b c a'
+               '074:-I 2b 2'         'D2h.28 I m m a'
+               '075:P 4'             'C4.1   P 4'
+               '076:P 4w'            'C4.2   P 41'
+               '077:P 4c'            'C4.3   P 42'
+               '078:P 4cw'           'C4.4   P 43'
+               '079:I 4'             'C4.5   I 4'
+               '080:I 4bw'           'C4.6   I 41'
+               '081:P -4'            'S4.1   P -4'
+               '082:I -4'            'S4.2   I -4'
+               '083:-P 4'            'C4h.1  P 4/m'
+               '084:-P 4c'           'C4h.2  P 42/m'
+               '085:-P 4a'           'C4h.3  P 4/n:2'
+               '086:-P 4bc'          'C4h.4  P 42/n:2'
+               '087:-I 4'            'C4h.5  I 4/m'
+               '088:-I 4ad'          'C4h.6  I 41/a:2'
+               '089:P 4 2'           'D4.1   P 4 2 2'
+               '090:P 4ab 2ab'       'D4.2   P 4 21 2'
+               '091:P 4w 2c'         'D4.3   P 41 2 2'
+               '092:P 4abw 2nw'      'D4.4   P 41 21 2'
+               '093:P 4c 2'          'D4.5   P 42 2 2'
+               '094:P 4n 2n'         'D4.6   P 42 21 2'
+               '095:P 4cw 2c'        'D4.7   P 43 2 2'
+               '096:P 4nw 2abw'      'D4.8   P 43 21 2'
+               '097:I 4 2'           'D4.9   I 4 2 2'
+               '098:I 4bw 2bw'       'D4.10  I 41 2 2'
+               '099:P 4 -2'          'C4v.1  P 4 m m'
+               '100:P 4 -2ab'        'C4v.2  P 4 b m'
+               '101:P 4c -2c'        'C4v.3  P 42 c m'
+               '102:P 4n -2n'        'C4v.4  P 42 n m'
+               '103:P 4 -2c'         'C4v.5  P 4 c c'
+               '104:P 4 -2n'         'C4v.6  P 4 n c'
+               '105:P 4c -2'         'C4v.7  P 42 m c'
+               '106:P 4c -2ab'       'C4v.8  P 42 b c'
+               '107:I 4 -2'          'C4v.9  I 4 m m'
+               '108:I 4 -2c'         'C4v.10 I 4 c m'
+               '109:I 4bw -2'        'C4v.11 I 41 m d'
+               '110:I 4bw -2c'       'C4v.12 I 41 c d'
+               '111:P -4 2'          'D2d.1  P -4 2 m'
+               '112:P -4 2c'         'D2d.2  P -4 2 c'
+               '113:P -4 2ab'        'D2d.3  P -4 21 m'
+               '114:P -4 2n'         'D2d.4  P -4 21 c'
+               '115:P -4 -2'         'D2d.5  P -4 m 2'
+               '116:P -4 -2c'        'D2d.6  P -4 c 2'
+               '117:P -4 -2ab'       'D2d.7  P -4 b 2'
+               '118:P -4 -2n'        'D2d.8  P -4 n 2'
+               '119:I -4 -2'         'D2d.9  I -4 m 2'
+               '120:I -4 -2c'        'D2d.10 I -4 c 2'
+               '121:I -4 2'          'D2d.11 I -4 2 m'
+               '122:I -4 2bw'        'D2d.12 I -4 2 d'
+               '123:-P 4 2'          'D4h.1  P 4/m m m'
+               '124:-P 4 2c'         'D4h.2  P 4/m c c'
+               '125:-P 4a 2b'        'D4h.3  P 4/n b m:2'
+               '126:-P 4a 2bc'       'D4h.4  P 4/n n c:2'
+               '127:-P 4 2ab'        'D4h.5  P 4/m b m'
+               '128:-P 4 2n'         'D4h.6  P 4/m n c'
+               '129:-P 4a 2a'        'D4h.7  P 4/n m m:2'
+               '130:-P 4a 2ac'       'D4h.8  P 4/n c c:2'
+               '131:-P 4c 2'         'D4h.9  P 42/m m c'
+               '132:-P 4c 2c'        'D4h.10 P 42/m c m'
+               '133:-P 4ac 2b'       'D4h.11 P 42/n b c:2'
+               '134:-P 4ac 2bc'      'D4h.12 P 42/n n m:2'
+               '135:-P 4c 2ab'       'D4h.13 P 42/m b c'
+               '136:-P 4n 2n'        'D4h.14 P 42/m n m'
+               '137:-P 4ac 2a'       'D4h.15 P 42/n m c:2'
+               '138:-P 4ac 2ac'      'D4h.16 P 42/n c m:2'
+               '139:-I 4 2'          'D4h.17 I 4/m m m'
+               '140:-I 4 2c'         'D4h.18 I 4/m c m'
+               '141:-I 4bd 2'        'D4h.19 I 41/a m d:2'
+               '142:-I 4bd 2c'       'D4h.20 I 41/a c d:2'
+               '143:P 3'             'C3.1   P 3'
+               '144:P 31'            'C3.2   P 31'
+               '145:P 32'            'C3.3   P 32'
+               '146:R 3'             'C3.4   R 3:h'
+               '147:-P 3'            'C3i.1  P -3'
+               '148:-R 3'            'C3i.2  R -3:h'
+               '149:P 3 2'           'D3.1   P 3 1 2'
+               '150:P 3 2"'          'D3.2   P 3 2 1'
+               '151:P 31 2 (0 0 4)'  'D3.3   P 31 1 2'
+               '152:P 31 2"'         'D3.4   P 31 2 1'
+               '153:P 32 2 (0 0 2)'  'D3.5   P 32 1 2'
+               '154:P 32 2"'         'D3.6   P 32 2 1'
+               '155:R 3 2"'          'D3.7   R 3 2:h'
+               '156:P 3 -2"'         'C3v.1  P 3 m 1'
+               '157:P 3 -2'          'C3v.2  P 3 1 m'
+               '158:P 3 -2"c'        'C3v.3  P 3 c 1'
+               '159:P 3 -2c'         'C3v.4  P 3 1 c'
+               '160:R 3 -2"'         'C3v.5  R 3 m:h'
+               '161:R 3 -2"c'        'C3v.6  R 3 c:h'
+               '162:-P 3 2'          'D3d.1  P -3 1 m'
+               '163:-P 3 2c'         'D3d.2  P -3 1 c'
+               '164:-P 3 2"'         'D3d.3  P -3 m 1'
+               '165:-P 3 2"c'        'D3d.4  P -3 c 1'
+               '166:-R 3 2"'         'D3d.5  R -3 m:h'
+               '167:-R 3 2"c'        'D3d.6  R -3 c:h'
+               '168:P 6'             'C6.1   P 6'
+               '169:P 61'            'C6.2   P 61'
+               '170:P 65'            'C6.3   P 65'
+               '171:P 62'            'C6.4   P 62'
+               '172:P 64'            'C6.5   P 64'
+               '173:P 6c'            'C6.6   P 63'
+               '174:P -6'            'C3h.1  P -6'
+               '175:-P 6'            'C6h.1  P 6/m'
+               '176:-P 6c'           'C6h.2  P 63/m'
+               '177:P 6 2'           'D6.1   P 6 2 2'
+               '178:P 61 2 (0 0 5)'  'D6.2   P 61 2 2'
+               '179:P 65 2 (0 0 1)'  'D6.3   P 65 2 2'
+               '180:P 62 2 (0 0 4)'  'D6.4   P 62 2 2'
+               '181:P 64 2 (0 0 2)'  'D6.5   P 64 2 2'
+               '182:P 6c 2c'         'D6.6   P 63 2 2'
+               '183:P 6 -2'          'C6v.1  P 6 m m'
+               '184:P 6 -2c'         'C6v.2  P 6 c c'
+               '185:P 6c -2'         'C6v.3  P 63 c m'
+               '186:P 6c -2c'        'C6v.4  P 63 m c'
+               '187:P -6 2'          'D3h.1  P -6 m 2'
+               '188:P -6c 2'         'D3h.2  P -6 c 2'
+               '189:P -6 -2'         'D3h.3  P -6 2 m'
+               '190:P -6c -2c'       'D3h.4  P -6 2 c'
+               '191:-P 6 2'          'D6h.1  P 6/m m m'
+               '192:-P 6 2c'         'D6h.2  P 6/m c c'
+               '193:-P 6c 2'         'D6h.3  P 63/m c m'
+               '194:-P 6c 2c'        'D6h.4  P 63/m m c'
+               '195:P 2 2 3'         'T.1    P 2 3'
+               '196:F 2 2 3'         'T.2    F 2 3'
+               '197:I 2 2 3'         'T.3    I 2 3'
+               '198:P 2ac 2ab 3'     'T.4    P 21 3'
+               '199:I 2b 2c 3'       'T.5    I 21 3'
+               '200:-P 2 2 3'        'Th.1   P m -3'
+               '201:-P 2ab 2bc 3'    'Th.2   P n -3:2'
+               '202:-F 2 2 3'        'Th.3   F m -3'
+               '203:-F 2uv 2vw 3'    'Th.4   F d -3:2'
+               '204:-I 2 2 3'        'Th.5   I m -3'
+               '205:-P 2ac 2ab 3'    'Th.6   P a -3'
+               '206:-I 2b 2c 3'      'Th.7   I a -3'
+               '207:P 4 2 3'         'O.1    P 4 3 2'
+               '208:P 4n 2 3'        'O.2    P 42 3 2'
+               '209:F 4 2 3'         'O.3    F 4 3 2'
+               '210:F 4d 2 3'        'O.4    F 41 3 2'
+               '211:I 4 2 3'         'O.5    I 4 3 2'
+               '212:P 4acd 2ab 3'    'O.6    P 43 3 2'
+               '213:P 4bd 2ab 3'     'O.7    P 41 3 2'
+               '214:I 4bd 2c 3'      'O.8    I 41 3 2'
+               '215:P -4 2 3'        'Td.1   P -4 3 m'
+               '216:F -4 2 3'        'Td.2   F -4 3 m'
+               '217:I -4 2 3'        'Td.3   I -4 3 m'
+               '218:P -4n 2 3'       'Td.4   P -4 3 n'
+               '219:F -4a 2 3'       'Td.5   F -4 3 c'
+               '220:I -4bd 2c 3'     'Td.6   I -4 3 d'
+               '221:-P 4 2 3'        'Oh.1   P m -3 m'
+               '222:-P 4a 2bc 3'     'Oh.2   P n -3 n:2'
+               '223:-P 4n 2 3'       'Oh.3   P m -3 n'
+               '224:-P 4bc 2bc 3'    'Oh.4   P n -3 m:2'
+               '225:-F 4 2 3'        'Oh.5   F m -3 m'
+               '226:-F 4a 2 3'       'Oh.6   F m -3 c'
+               '227:-F 4vw 2vw 3'    'Oh.7   F d -3 m:2'
+               '228:-F 4ud 2vw 3'    'Oh.8   F d -3 c:2'
+               '229:-I 4 2 3'        'Oh.9   I m -3 m'
+               '230:-I 4bd 2c 3'     'Oh.10  I a -3 d'
+      save_
+
+save_schoenflies
+     loop_
+    _enumeration_set.state
+               C1.1 Ci.1
+               C2.1 C2.2 C2.3
+               Cs.1 Cs.2 Cs.3 Cs.4
+               C2h.1 C2h.2 C2h.3 C2h.4 C2h.5 C2h.6
+               D2.1 D2.2 D2.3 D2.4 D2.5 D2.6 D2.7 D2.8 D2.9
+               C2v.1 C2v.2 C2v.3 C2v.4 C2v.5 C2v.6 C2v.7 C2v.8 C2v.9 C2v.10
+               C2v.11 C2v.12 C2v.13 C2v.14 C2v.15 C2v.16 C2v.17 C2v.18 C2v.19
+               C2v.20 C2v.21 C2v.22
+               D2h.1 D2h.2 D2h.3 D2h.4 D2h.5 D2h.6 D2h.7 D2h.8 D2h.9 D2h.10
+               D2h.11 D2h.12 D2h.13 D2h.14 D2h.15 D2h.16 D2h.17 D2h.18 D2h.19
+               D2h.20 D2h.21 D2h.22 D2h.23 D2h.24 D2h.25 D2h.26 D2h.27 D2h.28
+               C4.1 C4.2 C4.3 C4.4 C4.5 C4.6
+               S4.1 S4.2
+               C4h.1 C4h.2 C4h.3 C4h.4 C4h.5 C4h.6
+               D4.1 D4.2 D4.3 D4.4 D4.5 D4.6 D4.7 D4.8 D4.9 D4.10
+               C4v.1 C4v.2 C4v.3 C4v.4 C4v.5 C4v.6 C4v.7 C4v.8 C4v.9 C4v.10
+               C4v.11 C4v.12
+               D2d.1 D2d.2 D2d.3 D2d.4 D2d.5 D2d.6 D2d.7 D2d.8 D2d.9 D2d.10
+               D2d.11 D2d.12
+               D4h.1 D4h.2 D4h.3 D4h.4 D4h.5 D4h.6 D4h.7 D4h.8 D4h.9 D4h.10
+               D4h.11 D4h.12 D4h.13 D4h.14 D4h.15 D4h.16 D4h.17 D4h.18 D4h.19
+               D4h.20
+               C3.1 C3.2 C3.3 C3.4
+               C3i.1 C3i.2
+               D3.1 D3.2 D3.3 D3.4 D3.5 D3.6 D3.7
+               C3v.1 C3v.2 C3v.3 C3v.4 C3v.5 C3v.6
+               D3d.1 D3d.2 D3d.3 D3d.4 D3d.5 D3d.6
+               C6.1 C6.2 C6.3 C6.4 C6.5 C6.6
+               C3h.1
+               C6h.1 C6h.2
+               D6.1 D6.2 D6.3 D6.4 D6.5 D6.6
+               C6v.1 C6v.2 C6v.3 C6v.4
+               D3h.1 D3h.2 D3h.3 D3h.4
+               D6h.1 D6h.2 D6h.3 D6h.4
+               T.1 T.2 T.3 T.4 T.5
+               Th.1 Th.2 Th.3 Th.4 Th.5 Th.6 Th.7
+               O.1 O.2 O.3 O.4 O.5 O.6 O.7 O.8
+               Td.1 Td.2 Td.3 Td.4 Td.5 Td.6
+               Oh.1 Oh.2 Oh.3 Oh.4 Oh.5 Oh.6 Oh.7 Oh.8 Oh.9 Oh.10
+
+save_
+
+save_colour_rgb
+
+    loop_
+      _enumeration_set.state
+      _enumeration_set.detail
+         black                    '[ 000, 000, 000 ]'
+         white                    '[ 255, 255, 255 ]'
+         grey                     '[ 192, 192, 192 ]'
+         gray                     '[ 192, 192, 192 ]' #prefer 'grey'
+         grey_light               '[ 211, 211, 211 ]'
+         grey_slate               '[ 112, 128, 144 ]'
+         grey_steel               '[ 136, 139, 141 ]'
+         blue                     '[ 000, 000, 255 ]'
+         blue_light               '[ 176, 224, 230 ]'
+         blue_medium              '[ 000, 000, 205 ]'
+         blue_dark                '[ 025, 025, 112 ]'
+         blue_navy                '[ 000, 000, 128 ]'
+         blue_royal               '[ 065, 105, 225 ]'
+         blue_sky                 '[ 135, 206, 235 ]'
+         blue_steel               '[ 070, 130, 180 ]'
+         turquoise                '[ 064, 224, 208 ]'
+         colourless               '[   .,   .,   . ]'
+         cyan                     '[ 000, 255, 255 ]'
+         cyan_light               '[ 224, 255, 255 ]'
+         green                    '[ 000, 255, 000 ]'
+         green_light              '[ 152, 251, 152 ]'
+         green_dark               '[ 000, 100, 000 ]'
+         green_sea                '[ 046, 139, 087 ]'
+         green_lime               '[ 050, 205, 050 ]'
+         green_olive              '[ 107, 142, 035 ]'
+         green_khaki              '[ 240, 230, 140 ]'
+         yellow                   '[ 255, 255, 000 ]'
+         yellow_light             '[ 255, 255, 224 ]'
+         yellow_gold              '[ 255, 215, 000 ]'
+         brown                    '[ 165, 042, 042 ]'
+         brown_sienna             '[ 160, 082, 045 ]'
+         brown_beige              '[ 245, 245, 220 ]'
+         brown_tan                '[ 210, 180, 140 ]'
+         salmon                   '[ 250, 128, 114 ]'
+         salmon_light             '[ 255, 160, 122 ]'
+         salmon_dark              '[ 233, 150, 122 ]'
+         orange                   '[ 255, 165, 000 ]'
+         orange_dark              '[ 255, 140, 000 ]'
+         red                      '[ 255, 000, 000 ]'
+         red_coral                '[ 255, 127, 080 ]'
+         red_tomato               '[ 255, 099, 071 ]'
+         red_orange               '[ 255, 069, 000 ]'
+         red_violet               '[ 219, 112, 147 ]'
+         red_maroon               '[ 176, 048, 096 ]'
+         pink                     '[ 255, 192, 203 ]'
+         pink_light               '[ 255, 182, 193 ]'
+         pink_deep                '[ 255, 020, 147 ]'
+         pink_hot                 '[ 255, 105, 180 ]'
+         violet                   '[ 238, 130, 238 ]'
+         violet_red               '[ 208, 032, 144 ]'
+         violet_magenta           '[ 255, 000, 255 ]'
+         violet_dark              '[ 148, 000, 211 ]'
+         violet_blue              '[ 138, 043, 226 ]'
+
+save_
+
+save_database_list
+loop_
+    _enumeration_set.state
+    _enumeration_set.detail
+    BIncStrDB    'Bilbao Modulated Structures Database'
+    CAS          'Chemical Abstracts'
+    COD          'Crystallography Open Database'
+    CSD          'Cambridge Structural Database'
+    ICSD         'Inorganic Crystal Structure Database'
+    MDF          'Metals Data File'
+    NDB          'Nucleic Acid Database'
+    PDB          'Protein Data Bank'
+    PDF          'Powder Diffraction File (JCPDS/ICDD)'
+    RCSB         'Research Collaboratory for Structural Bioinformatics'
+    EBI          'European Bioinformatics Institute'
+save_
+
+save_element_symbol
+
+    loop_
+      _enumeration_set.state
+      _enumeration_set.detail
+         Ac                       Actinium
+         Ag                       Silver
+         Al                       Aluminum
+         Am                       Americium
+         Ar                       Argon
+         As                       Arsenic
+         At                       Astatine
+         Au                       Gold
+         B                        Boron
+         Ba                       Barium
+         Be                       Beryllium
+         Bh                       Bohrium
+         Bi                       Bismuth
+         Bk                       Berkelium
+         Br                       Bromine
+         C                        Carbon
+         Ca                       Calcium
+         Cd                       Cadmium
+         Ce                       Cerium
+         Cf                       Californium
+         Cl                       Chlorine
+         Cm                       Curium
+         Cn                       Copernicium
+         Co                       Cobalt
+         Cr                       Chromium
+         Cs                       Cesium
+         Cu                       Copper
+         D                        Deuterium
+         Db                       Dubnium
+         Ds                       Darmstadtium
+         Dy                       Dysprosium
+         Er                       Erbium
+         Es                       Einsteinium
+         Eu                       Europium
+         F                        Fluorine
+         Fe                       Iron
+         Fl                       Flerovium
+         Fm                       Fermium
+         Fr                       Francium
+         Ga                       Gallium
+         Gd                       Gadolinium
+         Ge                       Germanium
+         H                        Hydrogen
+         He                       Helium
+         Hf                       Hafnium
+         Hg                       Mercury
+         Ho                       Holmium
+         Hs                       Hassium
+         I                        Iodine
+         In                       Indium
+         Ir                       Iridium
+         K                        Potassium
+         Kr                       Krypton
+         La                       Lanthanum
+         Li                       Lithium
+         Lr                       Lawrencium
+         Lu                       Lutetium
+         Lv                       Livermorium
+         Mc                       Moscovium
+         Md                       Mendelevium
+         Mg                       Magnesium
+         Mn                       Manganese
+         Mo                       Molybdenum
+         Mt                       Meitnerium
+         N                        Nitrogen
+         Na                       Sodium
+         Nb                       Niobium
+         Nd                       Neodymium
+         Ne                       Neon
+         Nh                       Nihonium
+         Ni                       Nickel
+         No                       Nobelium
+         Np                       Neptunium
+         O                        Oxygen
+         Og                       Oganesson
+         Os                       Osmium
+         P                        Phosphorus
+         Pa                       Protactinium
+         Pb                       Lead
+         Pd                       Palladium
+         Pm                       Promethium
+         Po                       Polonium
+         Pr                       Praseodymium
+         Pt                       Platinum
+         Pu                       Plutonium
+         Ra                       Radium
+         Rb                       Rubidium
+         Re                       Rhenium
+         Rf                       Rutherfordium
+         Rg                       Roentgenium
+         Rh                       Rhodium
+         Rn                       Radon
+         Ru                       Ruthenium
+         S                        Sulfur
+         Sb                       Antimony
+         Sc                       Scandium
+         Se                       Selenium
+         Sg                       Seaborgium
+         Si                       Silicon
+         Sm                       Samarium
+         Sn                       Tin
+         Sr                       Strontium
+         Ta                       Tantalum
+         Tb                       Terbium
+         Tc                       Technetium
+         Te                       Tellurium
+         Th                       Thorium
+         Ti                       Titanium
+         Tl                       Thallium
+         Tm                       Thulium
+         Ts                       Tennessine
+         U                        Uranium
+         V                        Vanadium
+         W                        Tungsten
+         Xe                       Xenon
+         Y                        Yttrium
+         Yb                       Ytterbium
+         Zn                       Zinc
+         Zr                       Zirconium
+
+save_
+
+save_units_code
+
+     loop_
+         _enumeration_set.state
+         _enumeration_set.detail
+
+   'none' "dimensionless - e.g. a ratio, factor, weight or scale"
+
+   'unspecified'
+   "no units supplied - the correct units should be derived based on the context"
+
+   'coulomb'        "electronic charge in coulombs"
+   'electron_volts' "electronic charge in electron volts eV"
+
+   'metres'       "length    'metres (metres * 10^(0))'"
+   'centimetres'  "length    'centimetres (metres * 10^( -2))'"
+   'millimetres'  "length    'millimetres (metres * 10^( -3))'"
+   'micrometres'  "length    'micrometres (metres * 10^( -6))'"
+   'nanometres'   "length    'nanometres  (metres * 10^( -9))'"
+   'angstroms'    "length    'angstroms   (metres * 10^(-10))'"
+   'picometres'   "length    'picometres  (metres * 10^(-12))'"
+   'femtometres'  "length    'femtometres (metres * 10^(-15))'"
+
+   'reciprocal_centimetres'
+   "per_length 'reciprocal centimetres (metres * 10^( -2)^-1)'"
+   'reciprocal_millimetres'
+   "per_length 'reciprocal millimetres (metres * 10^( -3)^-1)'"
+   'reciprocal_nanometres'
+   "per-length 'reciprocal nanometres  (metres * 10^( -9)^-1)'"
+   'reciprocal_angstroms'
+   "per-length 'reciprocal angstroms   (metres * 10^(-10)^-1)'"
+   'reciprocal_angstrom_squared'
+   "per-area 'reciprocal angstroms^2'"
+   'reciprocal_picometres'
+   "per-length 'reciprocal picometres  (metres * 10^(-12)^-1)'"
+
+   'reciprocal_angstroms_per_pixel'
+   "unit for electron diffraction camera constant calibration factor"
+
+   'nanometre_squared'
+   "length_squared 'nanometres squared (metres * 10^( -9))^2'"
+   'angstrom_squared'
+   "length_squared 'angstroms squared  (metres * 10^(-10))^2'"
+   '8pi_angstroms_squared'
+   "length_squared '8pi^2 * angstroms squared (metres * 10^(-10))^2'"
+   'picometre_squared'
+   "length_squared 'picometres squared (metres * 10^(-12))^2'"
+   'femtometre_squared'
+   "length_squared 'femtometres squared (metres * 10^(-15))^2'"
+
+   'nanometre_cubed'
+   "length_cubed 'nanometres cubed (metres * 10^( -9))^3'"
+   'angstrom_cubed'
+   "length_cubed 'angstroms cubed  (metres * 10^(-10))^3'"
+   'picometre_cubed'
+   "length_cubed 'picometres cubed (metres * 10^(-12))^3'"
+
+   'grams_per_centimetre_cubed' "density 'grams per cubic centimetre'"
+   'kilograms_per_metre_cubed' "density 'kilograms per cubic metre'"
+   'megagrams_per_metre_cubed' "density 'megagrams per cubic metre'"
+   'angstrom_cubed_per_dalton' "density 'angstrom cubed per dalton'"
+
+   'millimetres_squared_per_gram' "mass absorption 'square millimetres per gram'"
+   'centimetres_squared_per_gram' "mass absorption 'square centimetres per gram'"
+
+   'kilopascals'      "pressure      'kilopascals'"
+   'gigapascals'      "pressure      'gigapascals'"
+
+   'hours'            "time      'hours'"
+   'minutes'          "time      'minutes'"
+   'seconds'          "time      'seconds'"
+   'microseconds'     "time      'microseconds'"
+
+   'hertz'          "frequency      'reciprocal seconds'"
+
+   'degrees'          "angle      'degrees (of arc)'"
+   'cycles'           "phase      'angle in 360 degree arcs'"
+   'radians'          "angle      'radians'"
+   'degrees_squared'   "angle      'degrees (of arc)'"
+
+   'degree_per_minute' "rotation_per_time  'degrees (of arc) per minute'"
+
+   'Celsius'      "temperature     'degrees (of temperature) Celsius'"
+   'kelvins'      "temperature     'temperature in kelvins'"
+   'kelvins_per_minute' "cooling rate 'kelvins per minute'"
+
+   'electrons'    "electrons              'electrons'"
+
+   'electron_squared'  "electrons-squared    'electrons squared'"
+
+   'electrons_per_angstrom'
+   "electrostatic potential in Gaussian unit system: 1 V = 0.069420 e/angstrom (electron diffraction) 'electrons per angstrom  (electrons * (metres * 10^(-10))^(-1))'"
+
+   'electrons_per_nanometre_cubed'
+   "electron-density 'electrons per nanometres cubed (electrons * (metres * 10^( -9))^(-3))'"
+   'electrons_per_angstrom_cubed'
+   "electron-density 'electrons per angstroms  cubed (electrons * (metres * 10^(-10))^(-3))'"
+   'electrons_per_picometre_cubed'
+   "electron-density 'electrons per picometres cubed (electrons * (metres * 10^(-12))^(-3))'"
+
+   'femtometres_per_angstrom_cubed'
+   "scattering-length-density 'femtometres per angstroms cubed (10^-6 * (metres * 10^(-10))^(-2))'"
+
+   'dalton'      "standard atomic mass unit"
+
+   'pixels_per_millimetre'  "area resolution unit"
+   'pixels_per_element'     "area resolution unit"
+
+   'kilowatts'     "power       'kilowatts'"
+   'milliamperes'  "current     'milliamperes'"
+   'kilovolts'     "emf         'kilovolts'"
+
+   'volt_squared'     "emf         'volts squared'"
+   'Bohr_magnetons'   "magnetic moment"
+
+   'arbitrary'    "arbitrary    'arbitrary system of units'"
+
+   'counts_per_photon' "measure of gain used in array detectors"
+   'counts'            "counts from a detector"
+   'counts_per_second' "counts from a detector per second of count time"
+   'photons_per_second'  "photons registered in one second"
+
+   'microseconds_per_angstrom' "TOF coefficient '(seconds * 10^(-6)) * (metres * 10^(-10)^(-1))'"
+   'microseconds_per_angstrom_squared' "TOF coefficient '(seconds * 10^(-6)) * (metres * 10^(-10)^(-2))'"
+   'microseconds_per_angstrom_cubed' "TOF coefficient '(seconds * 10^(-6)) * (metres * 10^(-10)^(-3))'"
+   'angstroms_per_microsecond'       "TOF coefficient '(metres * 10^(-10)) * (seconds * 10^(-6)^(-1))'"
+    save_
+
+
+#---------------------------------------------------------------------------
+
+
+save_atomic_number
+
+    _units.code                   none
+
+     loop_
+         _enumeration_default.index
+         _enumeration_default.value
+    H    1    D    1    He   2    Li   3    Be     4
+    B    5    C    6    N    7    O    8    F      9
+    Ne  10    Na  11    Mg  12    Al  13    Si    14
+    P   15    S   16    Cl  17    Ar  18    K     19
+    Ca  20    Sc  21    Ti  22    V   23    Cr    24
+    Mn  25    Fe  26    Co  27    Ni  28    Cu    29
+    Zn  30    Ga  31    Ge  32    As  33    Se    34
+    Br  35    Kr  36    Rb  37    Sr  38    Y     39
+    Zr  40    Nb  41    Mo  42    Tc  43    Ru    44
+    Rh  45    Pd  46    Ag  47    Cd  48    In    49
+    Sn  50    Sb  51    Te  52    I   53    Xe    54
+    Cs  55    Ba  56    La  57    Ce  58    Pr    59
+    Nd  60    Pm  61    Sm  62    Eu  63    Gd    64
+    Tb  65    Dy  66    Ho  67    Er  68    Tm    69
+    Yb  70    Lu  71    Hf  72    Ta  73    W     74
+    Re  75    Os  76    Ir  77    Pt  78    Au    79
+    Hg  80    Tl  81    Pb  82    Bi  83    Po    84
+    At  85    Rn  86    Fr  87    Ra  88    Ac    89
+    Th  90    Pa  91    U   92    Np  93    Pu    94
+    Am  95    Cm  96    Bk  97    Cf  98    Es    99
+    Fm 100    Md 101    No 102    Lr 103    Rf   104
+    Db 105    Sg 106    Bh 107    Hs 108    Mt   109
+    Ds 110    Rg 111    Cn 112    Nh 113    Fl   114
+    Mc 115    Lv 116    Ts 117    Og 118
+
+save_
+
+
+save_electron_count
+
+    _units.code                   none
+
+     loop_
+         _enumeration_default.index
+         _enumeration_default.value
+     H     01      D     01      H1-   02      He    02      Li    03
+     Li1+  02      Be    04      Be2+  02      B     05      C     06
+     N     07      O     08      O1-   09      F     09      F1-   10
+     Ne    10      Na    11      Na1+  10      Mg    12      Mg2+  10
+     Al    13      Al3+  10      Si    14      Si4+  10      P     15
+     S     16      Cl    17      Cl1-  18      Ar    18      K     19
+     K1+   18      Ca    20      Ca2+  18      Sc    21      Sc3+  18
+     Ti    22      Ti2+  20      Ti3+  19      Ti4+  18      V     23
+     V2+   21      V3+   20      V5+   18      Cr    24      Cr2+  22
+     Cr3+  21      Mn    25      Mn2+  23      Mn3+  22      Mn4+  21
+     Fe    26      Fe2+  24      Fe3+  23      Co    27      Co2+  25
+     Co3+  24      Ni    28      Ni2+  26      Ni3+  25      Cu    29
+     Cu1+  28      Cu2+  27      Zn    30      Zn2+  28      Ga    31
+     Ga3+  28      Ge    32      Ge4+  28      As    33      Se    34
+     Br    35      Br1-  36      Kr    36      Rb    37      Rb1+  36
+     Sr    38      Sr2+  36      Y     39      Y3+   36      Zr    40
+     Zr4+  36      Nb    41      Nb3+  38      Nb5+  36      Mo    42
+     Mo3+  39      Mo5+  37      Mo6+  36      Tc    43      Ru    44
+     Ru3+  41      Ru4+  40      Rh    45      Rh3+  42      Rh4+  41
+     Pd    46      Pd2+  44      Pd4+  42      Ag    47      Ag1+  46
+     Ag2+  45      Cd    48      Cd2+  46      In    49      In3+  46
+     Sn    50      Sn2+  48      Sn4+  46      Sb    51      Sb3+  48
+     Sb5+  46      Te    52      I     53      I1-   54      Xe    54
+     Cs    55      Cs1+  54      Ba    56      Ba2+  54      La    57
+     La3+  54      Ce    58      Ce3+  55      Ce4+  54      Pr    59
+     Pr3+  56      Pr4+  55      Nd    60      Nd3+  57      Pm    61
+     Sm    62      Sm3+  59      Eu    63      Eu2+  61      Eu3+  60
+     Gd    64      Gd3+  61      Tb    65      Tb3+  62      Dy    66
+     Dy3+  63      Ho    67      Ho3+  64      Er    68      Er3+  65
+     Tm    69      Tm3+  66      Yb    70      Yb2+  68      Yb3+  67
+     Lu    71      Lu3+  68      Hf    72      Hf4+  68      Ta    73
+     Ta5+  68      W     74      W6+   68      Re    75      Os    76
+     Os4+  72      Ir    77      Ir3+  74      Ir4+  73      Pt    78
+     Pt2+  76      Pt4+  74      Au    79      Au1+  78      Au3+  76
+     Hg    80      Hg1+  79      Hg2+  78      Tl    81      Tl1+  80
+     Tl3+  78      Pb    82      Pb2+  80      Pb4+  78      Bi    83
+     Bi3+  80      Bi5+  78      Po    84      At    85      Rn    86
+     Fr    87      Ra    88      Ra2+  86      Ac    89      Ac3+  86
+     Th    90      Th4+  86      Pa    91      U     92      U3+   89
+     U4+   88      U6+   86      Np    93      Np3+  90      Np4+  89
+     Np6+  87      Pu    94      Pu3+  91      Pu4+  90      Pu6+  88
+     Am    95      Cm    96      Bk    97      Cf    98
+     save_
+
+
+save_ion_to_element
+
+     loop_
+         _enumeration_default.index
+         _enumeration_default.value
+     H     H       D     D       H1-   H       He    He      Li    Li
+     Li1+  Li      Be    Be      Be2+  Be      B     B       C     C
+     N     N       O     O       O1-   O       F     F       F1-   F
+     Ne    Ne      Na    Na      Na1+  Na      Mg    Mg      Mg2+  Mg
+     Al    Al      Al3+  Al      Si    Si      Si4+  Si      P     P
+     S     S       Cl    Cl      Cl1-  Cl      Ar    Ar      K     K
+     K1+   K       Ca    Ca      Ca2+  Ca      Sc    Sc      Sc3+  Sc
+     Ti    Ti      Ti2+  Ti      Ti3+  Ti      Ti4+  Ti      V     V
+     V2+   V       V3+   V       V5+   V       Cr    Cr      Cr2+  Cr
+     Cr3+  Cr      Mn    Mn      Mn2+  Mn      Mn3+  Mn      Mn4+  Mn
+     Fe    Fe      Fe2+  Fe      Fe3+  Fe      Co    Co      Co2+  Co
+     Co3+  Co      Ni    Ni      Ni2+  Ni      Ni3+  Ni      Cu    Cu
+     Cu1+  Cu      Cu2+  Cu      Zn    Zn      Zn2+  Zn      Ga    Ga
+     Ga3+  Ga      Ge    Ge      Ge4+  Ge      As    As      Se    Se
+     Br    Br      Br1-  Br      Kr    Kr      Rb    Rb      Rb1+  Rb
+     Sr    Sr      Sr2+  Sr      Y     Y       Y3+   Y       Zr    Zr
+     Zr4+  Zr      Nb    Nb      Nb3+  Nb      Nb5+  Nb      Mo    Mo
+     Mo3+  Mo      Mo5+  Mo      Mo6+  Mo      Tc    Tc      Ru    Ru
+     Ru3+  Ru      Ru4+  Ru      Rh    Rh      Rh3+  Rh      Rh4+  Rh
+     Pd    Pd      Pd2+  Pd      Pd4+  Pd      Ag    Ag      Ag1+  Ag
+     Ag2+  Ag      Cd    Cd      Cd2+  Cd      In    In      In3+  In
+     Sn    Sn      Sn2+  Sn      Sn4+  Sn      Sb    Sb      Sb3+  Sb
+     Sb5+  Sb      Te    Te      I     I       I1-   I       Xe    Xe
+     Cs    Cs      Cs1+  Cs      Ba    Ba      Ba2+  Ba      La    La
+     La3+  La      Ce    Ce      Ce3+  Ce      Ce4+  Ce      Pr    Pr
+     Pr3+  Pr      Pr4+  Pr      Nd    Nd      Nd3+  Nd      Pm    Pm
+     Sm    Sm      Sm3+  Sm      Eu    Eu      Eu2+  Eu      Eu3+  Eu
+     Gd    Gd      Gd3+  Gd      Tb    Tb      Tb3+  Tb      Dy    Dy
+     Dy3+  Dy      Ho    Ho      Ho3+  Ho      Er    Er      Er3+  Er
+     Tm    Tm      Tm3+  Tm      Yb    Yb      Yb2+  Yb      Yb3+  Yb
+     Lu    Lu      Lu3+  Lu      Hf    Hf      Hf4+  Hf      Ta    Ta
+     Ta5+  Ta      W     W       W6+   W       Re    Re      Os    Os
+     Os4+  Os      Ir    Ir      Ir3+  Ir      Ir4+  Ir      Pt    Pt
+     Pt2+  Pt      Pt4+  Pt      Au    Au      Au1+  Au      Au3+  Au
+     Hg    Hg      Hg1+  Hg      Hg2+  Hg      Tl    Tl      Tl1+  Tl
+     Tl3+  Tl      Pb    Pb      Pb2+  Pb      Pb4+  Pb      Bi    Bi
+     Bi3+  Bi      Bi5+  Bi      Po    Po      At    At      Rn    Rn
+     Fr    Fr      Ra    Ra      Ra2+  Ra      Ac    Ac      Ac3+  Ac
+     Th    Th      Th4+  Th      Pa    Pa      U     U       U3+   U
+     U4+   U       U6+   U       Np    Np      Np3+  Np      Np4+  Np
+     Np6+  Np      Pu    Pu      Pu3+  Pu      Pu4+  Pu      Pu6+  Pu
+     Am    Am      Cm    Cm      Bk    Bk      Cf    Cf
+     save_
+
+
+save_atomic_mass
+
+    _units.code                   dalton
+
+     loop_
+         _enumeration_default.index
+         _enumeration_default.value
+     H     1.008   D     2.008   H1-   1.008   He    4.003   Li    6.941
+     Li1+  6.941   Be    9.012   Be2+  9.012   B     10.811  C     12.011
+     N     14.007  O     15.999  O1-   15.999  F     18.998  F1-   18.998
+     Ne    20.179  Na    22.990  Na1+  22.990  Mg    24.305  Mg2+  24.305
+     Al    26.982  Al3+  26.982  Si    28.086  Si4+  28.086  P     30.974
+     S     32.066  Cl    35.453  Cl1-  35.453  Ar    39.948  K     39.098
+     K1+   39.098  Ca    40.078  Ca2+  40.078  Sc    44.956  Sc3+  44.956
+     Ti    47.88   Ti2+  47.88   Ti3+  47.88   Ti4+  47.88   V     50.942
+     V2+   50.942  V3+   50.942  V5+   50.942  Cr    51.996  Cr2+  51.996
+     Cr3+  51.996  Mn    54.938  Mn2+  54.938  Mn3+  54.938  Mn4+  54.938
+     Fe    55.847  Fe2+  55.847  Fe3+  55.847  Co    58.933  Co2+  58.933
+     Co3+  58.933  Ni    58.69   Ni2+  58.69   Ni3+  58.69   Cu    63.546
+     Cu1+  63.546  Cu2+  63.546  Zn    65.39   Zn2+  65.39   Ga    69.723
+     Ga3+  69.723  Ge    72.59   Ge4+  72.59   As    74.922  Se    78.96
+     Br    79.904  Br1-  79.904  Kr    83.80   Rb    85.468  Rb1+  85.468
+     Sr    87.62   Sr2+  87.62   Y     88.906  Y3+   88.906  Zr    91.224
+     Zr4+  91.224  Nb    92.906  Nb3+  92.906  Nb5+  92.906  Mo    95.94
+     Mo3+  95.94   Mo5+  95.94   Mo6+  95.94   Tc    98.906  Ru    101.07
+     Ru3+  101.07  Ru4+  101.07  Rh    102.906 Rh3+  102.906 Rh4+  102.906
+     Pd    106.42  Pd2+  106.42  Pd4+  106.42  Ag    107.868 Ag1+  107.868
+     Ag2+  107.868 Cd    112.41  Cd2+  112.41  In    114.82  In3+  114.82
+     Sn    118.71  Sn2+  118.71  Sn4+  118.71  Sb    121.75  Sb3+  121.75
+     Sb5+  121.75  Te    127.60  I     126.905 I1-   126.905 Xe    131.29
+     Cs    132.905 Cs1+  132.905 Ba    137.33  Ba2+  137.33  La    138.906
+     La3+  138.906 Ce    140.12  Ce3+  140.12  Ce4+  140.12  Pr    140.908
+     Pr3+  140.908 Pr4+  140.908 Nd    144.24  Nd3+  144.24  Pm    147.
+     Sm    150.36  Sm3+  150.36  Eu    151.96  Eu2+  151.96  Eu3+  151.96
+     Gd    157.25  Gd3+  157.25  Tb    158.926 Tb3+  158.926 Dy    162.5
+     Dy3+  162.5   Ho    164.93  Ho3+  164.93  Er    167.26  Er3+  167.26
+     Tm    168.934 Tm3+  168.934 Yb    173.04  Yb2+  173.04  Yb3+  173.04
+     Lu    174.967 Lu3+  174.967 Hf    178.49  Hf4+  178.49  Ta    180.948
+     Ta5+  180.948 W     183.85  W6+   183.85  Re    186.207 Os    190.2
+     Os4+  190.2   Ir    192.22  Ir3+  192.22  Ir4+  192.22  Pt    195.08
+     Pt2+  195.08  Pt4+  195.08  Au    196.966 Au1+  196.966 Au3+  196.966
+     Hg    200.59  Hg1+  200.59  Hg2+  200.59  Tl    204.383 Tl1+  204.383
+     Tl3+  204.383 Pb    207.2   Pb2+  207.2   Pb4+  207.2   Bi    208.980
+     Bi3+  208.980 Bi5+  208.980 Po    209.    At    210.    Rn    222.
+     Fr    223.    Ra    226.025 Ra2+  226.025 Ac    227.    Ac3+  227.
+     Th    232.038 Th4+  232.038 Pa    231.036 U     238.029 U3+   238.029
+     U4+   238.029 U6+   238.029 Np    237.048 Np3+  237.048 Np4+  237.048
+     Np6+  237.048 Pu    242.    Pu3+  242.    Pu4+  242.    Pu6+  242.
+     Am    243.    Cm    247.    Bk    247.    Cf    249.
+     save_
+
+
+save_radius_bond
+
+    _units.code                   angstroms
+
+     loop_
+         _enumeration_default.index
+         _enumeration_default.value
+     H     0.37    D     0.37    H1-   0.37    He    0.40    Li    1.23
+     Li1+  1.23    Be    0.89    Be2+  0.89    B     0.80    C     0.77
+     N     0.74    O     0.74    O1-   0.74    F     0.72    F1-   0.72
+     Ne    0.72    Na    1.57    Na1+  1.57    Mg    1.36    Mg2+  1.36
+     Al    1.25    Al3+  1.25    Si    1.17    Si4+  1.17    P     1.10
+     S     1.04    Cl    0.99    Cl1-  0.99    Ar    1.00    K     2.03
+     K1+   2.03    Ca    1.74    Ca2+  1.74    Sc    1.44    Sc3+  1.44
+     Ti    1.35    Ti2+  1.35    Ti3+  1.35    Ti4+  1.35    V     1.22
+     V2+   1.22    V3+   1.22    V5+   1.22    Cr    1.17    Cr2+  1.17
+     Cr3+  1.17    Mn    1.17    Mn2+  1.17    Mn3+  1.17    Mn4+  1.17
+     Fe    1.17    Fe2+  1.17    Fe3+  1.17    Co    1.16    Co2+  1.16
+     Co3+  1.16    Ni    1.15    Ni2+  1.15    Ni3+  1.15    Cu    1.17
+     Cu1+  1.17    Cu2+  1.17    Zn    1.25    Zn2+  1.25    Ga    1.25
+     Ga3+  1.25    Ge    1.22    Ge4+  1.22    As    1.21    Se    1.17
+     Br    1.14    Br1-  1.14    Kr    1.14    Rb    2.16    Rb1+  2.16
+     Sr    1.91    Sr2+  1.91    Y     1.62    Y3+   1.62    Zr    1.45
+     Zr4+  1.45    Nb    1.34    Nb3+  1.34    Nb5+  1.34    Mo    1.29
+     Mo3+  1.29    Mo5+  1.29    Mo6+  1.29    Tc    1.27    Ru    1.24
+     Ru3+  1.24    Ru4+  1.24    Rh    1.25    Rh3+  1.25    Rh4+  1.25
+     Pd    1.28    Pd2+  1.28    Pd4+  1.28    Ag    1.34    Ag1+  1.34
+     Ag2+  1.34    Cd    1.41    Cd2+  1.41    In    1.50    In3+  1.50
+     Sn    1.41    Sn2+  1.41    Sn4+  1.41    Sb    1.41    Sb3+  1.41
+     Sb5+  1.41    Te    1.37    I     1.33    I1-   1.33    Xe    1.33
+     Cs    2.35    Cs1+  2.35    Ba    1.98    Ba2+  1.98    La    1.69
+     La3+  1.69    Ce    1.65    Ce3+  1.65    Ce4+  1.65    Pr    1.65
+     Pr3+  1.65    Pr4+  1.65    Nd    1.64    Nd3+  1.64    Pm    1.63
+     Sm    1.66    Sm3+  1.66    Eu    1.85    Eu2+  1.85    Eu3+  1.85
+     Gd    1.61    Gd3+  1.61    Tb    1.59    Tb3+  1.59    Dy    1.59
+     Dy3+  1.59    Ho    1.58    Ho3+  1.58    Er    1.57    Er3+  1.57
+     Tm    1.56    Tm3+  1.56    Yb    1.70    Yb2+  1.70    Yb3+  1.70
+     Lu    1.56    Lu3+  1.56    Hf    1.44    Hf4+  1.44    Ta    1.34
+     Ta5+  1.34    W     1.30    W6+   1.30    Re    1.28    Os    1.26
+     Os4+  1.26    Ir    1.26    Ir3+  1.26    Ir4+  1.26    Pt    1.29
+     Pt2+  1.29    Pt4+  1.29    Au    1.34    Au1+  1.34    Au3+  1.34
+     Hg    1.44    Hg1+  1.44    Hg2+  1.44    Tl    1.55    Tl1+  1.55
+     Tl3+  1.55    Pb    1.54    Pb2+  1.54    Pb4+  1.54    Bi    1.52
+     Bi3+  1.52    Bi5+  1.52    Po    1.53    At    1.53    Rn    1.53
+     Fr    1.53    Ra    1.53    Ra2+  1.53    Ac    1.53    Ac3+  1.53
+     Th    1.65    Th4+  1.65    Pa    1.53    U     1.42    U3+   1.42
+     U4+   1.42    U6+   1.42    Np    1.42    Np3+  1.42    Np4+  1.42
+     Np6+  1.42    Pu    1.42    Pu3+  1.42    Pu4+  1.42    Pu6+  1.42
+     Am    1.42    Cm    1.42    Bk    1.42    Cf    1.42
+     save_
+
+
+save_length_neutron
+
+    _units.code                   femtometres
+
+     loop_
+         _enumeration_default.index
+         _enumeration_default.value
+     H     -3.739  D     6.671   H1-   -3.739  He    3.26    Li    -1.90
+     Li1+  -1.90   Be    7.79    Be2+  7.79    B     5.30    C     6.646
+     N     9.36    O     5.803   O1-   5.803   F     5.654   F1-   5.654
+     Ne    4.547   Na    3.63    Na1+  3.63    Mg    5.375   Mg2+  5.375
+     Al    3.449   Al3+  3.449   Si    4.149   Si4+  4.149   P     5.13
+     S     2.847   Cl    9.577   Cl1-  9.577   Ar    1.909   K     3.71
+     K1+   3.71    Ca    4.90    Ca2+  4.90    Sc    12.29   Sc3+  12.29
+     Ti    -3.438  Ti2+  -3.438  Ti3+  -3.438  Ti4+  -3.438  V     -0.3824
+     V2+   -0.3824 V3+   -0.3824 V5+   -0.3824 Cr    3.635   Cr2+  3.635
+     Cr3+  3.635   Mn    -3.73   Mn2+  -3.73   Mn3+  -3.73   Mn4+  -3.73
+     Fe    9.54    Fe2+  9.54    Fe3+  9.54    Co    2.50    Co2+  2.50
+     Co3+  2.50    Ni    10.3    Ni2+  10.3    Ni3+  10.3    Cu    7.718
+     Cu1+  7.718   Cu2+  7.718   Zn    5.689   Zn2+  5.689   Ga    7.287
+     Ga3+  7.287   Ge    8.192   Ge4+  8.192   As    6.58    Se    7.970
+     Br    6.795   Br1-  6.795   Kr    7.80    Rb    7.08    Rb1+  7.08
+     Sr    7.02    Sr2+  7.02    Y     7.75    Y3+   7.75    Zr    7.16
+     Zr4+  7.16    Nb    7.054   Nb3+  7.054   Nb5+  7.054   Mo    6.95
+     Mo3+  6.95    Mo5+  6.95    Mo6+  6.95    Tc    6.8     Ru    7.21
+     Ru3+  7.21    Ru4+  7.21    Rh    5.88    Rh3+  5.88    Rh4+  5.88
+     Pd    5.91    Pd2+  5.91    Pd4+  5.91    Ag    5.922   Ag1+  5.922
+     Ag2+  5.922   Cd    5.1     Cd2+  5.1     In    4.065   In3+  4.065
+     Sn    6.225   Sn2+  6.225   Sn4+  6.225   Sb    5.57    Sb3+  5.57
+     Sb5+  5.57    Te    5.80    I     5.28    I1-   5.28    Xe    4.85
+     Cs    5.42    Cs1+  5.42    Ba    5.06    Ba2+  5.06    La    8.24
+     La3+  8.24    Ce    4.84    Ce3+  4.84    Ce4+  4.84    Pr    4.45
+     Pr3+  4.45    Pr4+  4.45    Nd    7.69    Nd3+  7.69    Pm    12.6
+     Sm    4.2     Sm3+  4.2     Eu    6.73    Eu2+  6.73    Eu3+  6.73
+     Gd    9.5     Gd3+  9.5     Tb    7.38    Tb3+  7.38    Dy    16.9
+     Dy3+  16.9    Ho    8.08    Ho3+  8.08    Er    8.03    Er3+  8.03
+     Tm    7.07    Tm3+  7.07    Yb    12.41   Yb2+  12.41   Yb3+  12.41
+     Lu    7.21    Lu3+  7.21    Hf    7.77    Hf4+  7.77    Ta    6.91
+     Ta5+  6.91    W     4.77    W6+   4.77    Re    9.2     Os    11.0
+     Os4+  11.0    Ir    10.6    Ir3+  10.6    Ir4+  10.6    Pt    9.60
+     Pt2+  9.60    Pt4+  9.60    Au    7.63    Au1+  7.63    Au3+  7.63
+     Hg    12.692  Hg1+  12.692  Hg2+  12.692  Tl    8.776   Tl1+  8.776
+     Tl3+  8.776   Pb    9.401   Pb2+  9.401   Pb4+  9.401   Bi    8.530
+     Bi3+  8.530   Bi5+  8.530   Po    0.      At    0.      Rn    0.
+     Fr    0.      Ra    10.0    Ra2+  10.0    Ac    0.      Ac3+  0.
+     Th    10.63   Th4+  10.63   Pa    9.1     U     8.417   U3+   8.417
+     U4+   8.417   U6+   8.417   Np    10.55   Np3+  10.55   Np4+  10.55
+     Np6+  10.55   Pu    14.1    Pu3+  14.1    Pu4+  14.1    Pu6+  14.1
+     Am    8.3     Cm    9.5     Bk    9.5     Cf    0.
+     save_
+
+
+save_dispersion_real_cu
+
+    _units.code                   none
+
+     loop_
+         _enumeration_default.index
+         _enumeration_default.value
+    H    0.0      D     0.0      He    0.0      Li   0.001    Be   0.003
+    B    0.008    C     0.017    N     0.029    O    0.047    F    0.069
+    Ne   0.097    Na    0.129    Mg    0.165    Al   0.204    Si   0.244
+    P    0.283    S     0.319    Cl    0.348    Ar   0.366    K    0.365
+    Ca   0.341    Sc    0.285    Ti    0.189    V    0.035    Cr  -0.198
+    Mn  -0.568    Fe   -1.179    Co   -2.464    Ni  -2.956    Cu  -2.019
+    Zn  -1.612    Ga   -1.354    Ge   -1.163    As  -1.011    Se  -0.879
+    Br  -0.767    Kr   -0.665    Rb   -0.574    Sr  -0.465    Y   -0.386
+    Zr  -0.314    Nb   -0.248    Mo   -0.191    Tc  -0.145    Ru  -0.105
+    Rh  -0.077    Pd   -0.059    Ag   -0.06     Cd  -0.079    In  -0.126
+    Sn  -0.194    Sb   -0.287    Te   -0.418    I   -0.579    Xe  -0.783
+    Cs  -1.022    Ba   -1.334    La   -1.716    Ce  -2.17     Pr  -2.939
+    Nd  -3.431    Pm   -4.357    Sm   -5.696    Eu  -7.718    Gd  -9.242
+    Tb  -9.498    Dy  -10.423    Ho  -12.255    Er  -9.733    Tm  -8.488
+    Yb  -7.701    Lu   -7.133    Hf   -6.715    Ta  -6.351    W   -6.048
+    Re  -5.79     Os   -5.581    Ir   -5.391    Pt  -5.233    Au  -5.096
+    Hg  -4.99     Tl   -4.883    Pb   -4.818    Bi  -4.776    Po  -4.756
+    At  -4.772    Rn   -4.787    Fr   -4.833    Ra  -4.898    Ac  -4.994
+    Th  -5.091    Pa   -5.216    U    -5.359    Np  -5.529    Pu  -5.712
+    Am  -5.93     Cm   -6.176    Bk   -6.498    Cf  -6.798
+
+save_
+
+save_dispersion_imag_cu
+
+    _units.code                   none
+
+     loop_
+         _enumeration_default.index
+         _enumeration_default.value
+     H    0.0      D    0.0      He   0.0      Li   0.0      Be   0.001
+     B    0.004    C    0.009    N    0.018    O    0.032    F    0.053
+     Ne   0.083    Na   0.124    Mg   0.177    Al   0.246    Si   0.33
+     P    0.434    S    0.557    Cl   0.702    Ar   0.872    K    1.066
+     Ca   1.286    Sc   1.533    Ti   1.807    V    2.11     Cr   2.443
+     Mn   2.808    Fe   3.204    Co   3.608    Ni   0.509    Cu   0.589
+     Zn   0.678    Ga   0.777    Ge   0.886    As   1.006    Se   1.139
+     Br   1.283    Kr   1.439    Rb   1.608    Sr   1.82     Y    2.025
+     Zr   2.245    Nb   2.482    Mo   2.735    Tc   3.005    Ru   3.296
+     Rh   3.605    Pd   3.934    Ag   4.282    Cd   4.653    In   5.045
+     Sn   5.459    Sb   5.894    Te   6.352    I    6.835    Xe   7.348
+     Cs   7.904    Ba   8.46     La   9.036    Ce   9.648    Pr  10.535
+     Nd  10.933    Pm  11.614    Sm  12.32     Eu  11.276    Gd  11.946
+     Tb   9.242    Dy   9.748    Ho   3.704    Er   3.937    Tm   4.181
+     Yb   4.432    Lu   4.693    Hf   4.977    Ta   5.271    W    5.577
+     Re   5.891    Os   6.221    Ir   6.566    Pt   6.925    Au   7.297
+     Hg   7.686    Tl   8.089    Pb   8.505    Bi   8.93     Po   9.383
+     At   9.843    Rn  10.317    Fr  10.803    Ra  11.296    Ac  11.799
+     Th  12.33     Pa  12.868    U   13.409    Np  13.967    Pu  14.536
+     Am  15.087    Cm  15.634    Bk  16.317    Cf  16.93
+
+save_
+
+save_dispersion_real_mo
+
+    _units.code                   none
+
+     loop_
+         _enumeration_default.index
+         _enumeration_default.value
+    H    0.0      D    0.0      He    0.0      Li    0.0      Be   0.0
+    B    0.0      C    0.002    N     0.004    O     0.008    F    0.014
+    Ne   0.021    Na   0.03     Mg    0.042    Al    0.056    Si   0.072
+    P    0.09     S    0.11     Cl    0.132    Ar    0.155    K    0.179
+    Ca   0.203    Sc   0.226    Ti    0.248    V     0.267    Cr   0.284
+    Mn   0.295    Fe   0.301    Co    0.299    Ni    0.285    Cu   0.263
+    Zn   0.222    Ga   0.163    Ge    0.081    As   -0.03     Se  -0.178
+    Br  -0.374    Kr  -0.652    Rb   -1.044    Sr   -1.657    Y   -2.951
+    Zr  -2.965    Nb  -2.197    Mo   -1.825    Tc   -1.59     Ru  -1.42
+    Rh  -1.287    Pd  -1.177    Ag   -1.085    Cd   -1.005    In  -0.936
+    Sn  -0.873    Sb  -0.816    Te   -0.772    I    -0.726    Xe  -0.684
+    Cs  -0.644    Ba  -0.613    La   -0.588    Ce   -0.564    Pr  -0.53
+    Nd  -0.535    Pm  -0.53     Sm   -0.533    Eu   -0.542    Gd  -0.564
+    Tb  -0.591    Dy  -0.619    Ho   -0.666    Er   -0.723    Tm  -0.795
+    Yb  -0.884    Lu  -0.988    Hf   -1.118    Ta   -1.258    W   -1.421
+    Re  -1.598    Os  -1.816    Ir   -2.066    Pt   -2.352    Au  -2.688
+    Hg  -3.084    Tl  -3.556    Pb   -4.133    Bi   -4.861    Po  -5.924
+    At  -7.444    Rn  -8.862    Fr   -7.912    Ra   -7.62     Ac  -7.725
+    Th  -8.127    Pa  -8.96     U   -10.673    Np  -11.158    Pu  -9.725
+    Am  -8.926    Cm  -8.416    Bk   -7.99     Cf   -7.683
+
+save_
+
+save_dispersion_imag_mo
+
+    _units.code                   none
+
+     loop_
+         _enumeration_default.index
+         _enumeration_default.value
+    H     0.0       D    0.0      He   0.0      Li   0.0      Be   0.0
+    B     0.001     C    0.002    N    0.003    O    0.006    F    0.01
+    Ne    0.016     Na   0.025    Mg   0.036    Al   0.052    Si   0.071
+    P     0.095     S    0.124    Cl   0.159    Ar   0.201    K    0.25
+    Ca    0.306     Sc   0.372    Ti   0.446    V    0.53     Cr   0.624
+    Mn    0.729     Fe   0.845    Co   0.973    Ni   1.113    Cu   1.266
+    Zn    1.431     Ga   1.609    Ge   1.801    As   2.007    Se   2.223
+    Br    2.456     Kr   2.713    Rb   2.973    Sr   3.264    Y    3.542
+    Zr    0.56      Nb   0.621    Mo   0.688    Tc   0.759    Ru   0.836
+    Rh    0.919     Pd   1.007    Ag   1.101    Cd   1.202    In   1.31
+    Sn    1.424     Sb   1.546    Te   1.675    I    1.812    Xe   1.958
+    Cs    2.119     Ba   2.282    La   2.452    Ce   2.632    Pr   2.845
+    Nd    3.018     Pm   3.225    Sm   3.442    Eu   3.669    Gd   3.904
+    Tb    4.151     Dy   4.41     Ho   4.678    Er   4.958    Tm   5.248
+    Yb    5.548     Lu   5.858    Hf   6.185    Ta   6.523    W    6.872
+    Re    7.232     Os   7.605    Ir   7.99     Pt   8.388    Au   8.798
+    Hg    9.223     Tl   9.659    Pb  10.102    Bi  10.559    Po  11.042
+    At    9.961     Rn  10.403    Fr   7.754    Ra   8.105    Ac   8.472
+    Th    8.87      Pa   9.284    U    9.654    Np   4.148    Pu   4.33
+    Am    4.511     Cm   4.697    Bk   4.908    Cf   5.107
+
+save_
+
+
+save_cromer_mann_a1
+
+    _units.code                   none
+
+     loop_
+         _enumeration_default.index
+         _enumeration_default.value
+     H     .493002 D     .493002 H1-   .897661 He    0.8734  Li    1.1282
+     Li1+  .6968   Be    1.5919  Be2+  6.2603  B     2.0545  C     2.31
+     N     12.2126 O     3.0485  O1-   4.1916  F     3.5392  F1-   3.6322
+     Ne    3.9553  Na    4.7626  Na1+  3.2565  Mg    5.4204  Mg2+  3.4988
+     Al    6.4202  Al3+  4.17448 Si    6.2915  Si4+  4.43918 P     6.4345
+     S     6.9053  Cl    11.4604 Cl1-  18.2915 Ar    7.4845  K     8.2186
+     K1+   7.9578  Ca    8.6266  Ca2+  15.6348 Sc    9.189   Sc3+  13.4008
+     Ti    9.7595  Ti2+  9.11423 Ti3+  17.7344 Ti4+  19.5114 V     10.2971
+     V2+   10.106  V3+   9.43141 V5+   15.6887 Cr    10.6406 Cr2+  9.54034
+     Cr3+  9.6809  Mn    11.2819 Mn2+  10.8061 Mn3+  9.84521 Mn4+  9.96253
+     Fe    11.7695 Fe2+  11.0424 Fe3+  11.1764 Co    12.2841 Co2+  11.2296
+     Co3+  10.338  Ni    12.8376 Ni2+  11.4166 Ni3+  10.7806 Cu    13.338
+     Cu1+  11.9475 Cu2+  11.8168 Zn    14.0743 Zn2+  11.9719 Ga    15.2354
+     Ga3+  12.692  Ge    16.0816 Ge4+  12.9172 As    16.6723 Se    17.0006
+     Br    17.1789 Br1-  17.1718 Kr    17.3555 Rb    17.1784 Rb1+  17.5816
+     Sr    17.5663 Sr2+  18.0874 Y     17.776  Y3+   17.9268 Zr    17.8765
+     Zr4+  18.1668 Nb    17.6142 Nb3+  19.8812 Nb5+  17.9163 Mo    3.7025
+     Mo3+  21.1664 Mo5+  21.0149 Mo6+  17.8871 Tc    19.1301 Ru    19.2674
+     Ru3+  18.5638 Ru4+  18.5003 Rh    19.2957 Rh3+  18.8785 Rh4+  18.8545
+     Pd    19.3319 Pd2+  19.1701 Pd4+  19.2493 Ag    19.2808 Ag1+  19.1812
+     Ag2+  19.1643 Cd    19.2214 Cd2+  19.1514 In    19.1624 In3+  19.1045
+     Sn    19.1889 Sn2+  19.1094 Sn4+  18.9333 Sb    19.6418 Sb3+  18.9755
+     Sb5+  19.8685 Te    19.9644 I     20.1472 I1-   20.2332 Xe    20.2933
+     Cs    20.3892 Cs1+  20.3524 Ba    20.3361 Ba2+  20.1807 La    20.578
+     La3+  20.2489 Ce    21.1671 Ce3+  20.8036 Ce4+  20.3235 Pr    22.044
+     Pr3+  21.3727 Pr4+  20.9413 Nd    22.6845 Nd3+  21.961  Pm    23.3405
+     Sm    24.0042 Sm3+  23.1504 Eu    24.6274 Eu2+  24.0063 Eu3+  23.7497
+     Gd    25.0709 Gd3+  24.3466 Tb    25.8976 Tb3+  24.9559 Dy    26.507
+     Dy3+  25.5395 Ho    26.9049 Ho3+  26.1296 Er    27.6563 Er3+  26.722
+     Tm    28.1819 Tm3+  27.3083 Yb    28.6641 Yb2+  28.1209 Yb3+  27.8917
+     Lu    28.9476 Lu3+  28.4628 Hf    29.144  Hf4+  28.8131 Ta    29.2024
+     Ta5+  29.1587 W     29.0818 W6+   29.4936 Re    28.7621 Os    28.1894
+     Os4+  30.419  Ir    27.3049 Ir3+  30.4156 Ir4+  30.7058 Pt    27.0059
+     Pt2+  29.8429 Pt4+  30.9612 Au    16.8819 Au1+  28.0109 Au3+  30.6886
+     Hg    20.6809 Hg1+  25.0853 Hg2+  29.5641 Tl    27.5446 Tl1+  21.3985
+     Tl3+  30.8695 Pb    31.0617 Pb2+  21.7886 Pb4+  32.1244 Bi    33.3689
+     Bi3+  21.8053 Bi5+  33.5364 Po    34.6726 At    35.3163 Rn    35.5631
+     Fr    35.9299 Ra    35.7630 Ra2+  35.2150 Ac    35.6597 Ac3+  35.1736
+     Th    35.5645 Th4+  35.1007 Pa    35.8847 U     36.0228 U3+   35.5747
+     U4+   35.3715 U6+   34.8509 Np    36.1874 Np3+  35.7074 Np4+  35.5103
+     Np6+  35.0136 Pu    36.5254 Pu3+  35.8400 Pu4+  35.6493 Pu6+  35.1736
+     Am    36.6706 Cm    36.6488 Bk    36.7881 Cf    36.9185
+     save_
+
+
+save_cromer_mann_b1
+
+    _units.code                   angstrom_squared
+
+     loop_
+         _enumeration_default.index
+         _enumeration_default.value
+     H     10.5109 D     10.5109 H1-   53.1368 He    9.1037  Li    3.9546
+     Li1+  4.6237  Be    43.6427 Be2+  .0027   B     23.2185 C     20.8439
+     N     .0057   O     13.2771 O1-   12.8573 F     10.2825 F1-   5.27756
+     Ne    8.4042  Na    3.285   Na1+  2.6671  Mg    2.8275  Mg2+  2.1676
+     Al    3.0387  Al3+  1.93816 Si    2.4386  Si4+  1.64167 P     1.9067
+     S     1.4679  Cl    .0104   Cl1-  .0066   Ar    0.9072  K     12.7949
+     K1+   12.6331 Ca    10.4421 Ca2+  -.0074  Sc    9.0213  Sc3+  .29854
+     Ti    7.8508  Ti2+  7.5243  Ti3+  .22061  Ti4+  .178847 V     6.8657
+     V2+   6.8818  V3+   6.39535 V5+   .679003 Cr    6.1038  Cr2+  5.66078
+     Cr3+  5.59463 Mn    5.3409  Mn2+  5.2796  Mn3+  4.91797 Mn4+  4.8485
+     Fe    4.7611  Fe2+  4.6538  Fe3+  4.6147  Co    4.2791  Co2+  4.1231
+     Co3+  3.90969 Ni    3.8785  Ni2+  3.6766  Ni3+  3.5477  Cu    3.5828
+     Cu1+  3.3669  Cu2+  3.37484 Zn    3.2655  Zn2+  2.9946  Ga    3.0669
+     Ga3+  2.81262 Ge    2.8509  Ge4+  2.53718 As    2.6345  Se    2.4098
+     Br    2.1723  Br1-  2.2059  Kr    1.9384  Rb    1.7888  Rb1+  1.7139
+     Sr    1.5564  Sr2+  1.4907  Y     1.4029  Y3+   1.35417 Zr    1.27618
+     Zr4+  1.2148  Nb    1.18865 Nb3+  .019175 Nb5+  1.12446 Mo    .2772
+     Mo3+  .014734 Mo5+  .014345 Mo6+  1.03649 Tc    .864132 Ru    .80852
+     Ru3+  .847329 Ru4+  .844582 Rh    .751536 Rh3+  .764252 Rh4+  .760825
+     Pd    .698655 Pd2+  .696219 Pd4+  .683839 Ag    .6446   Ag1+  .646179
+     Ag2+  .645643 Cd    .5946   Cd2+  .597922 In    .5476   In3+  .551522
+     Sn    5.8303  Sn2+  .5036   Sn4+  5.764   Sb    5.3034  Sb3+  .467196
+     Sb5+  5.44853 Te    4.81742 I     4.347   I1-   4.3579  Xe    3.9282
+     Cs    3.569   Cs1+  3.552   Ba    3.216   Ba2+  3.21367 La    2.94817
+     La3+  2.9207  Ce    2.81219 Ce3+  2.77691 Ce4+  2.65941 Pr    2.77393
+     Pr3+  2.6452  Pr4+  2.54467 Nd    2.66248 Nd3+  2.52722 Pm    2.5627
+     Sm    2.47274 Sm3+  2.31641 Eu    2.3879  Eu2+  2.27783 Eu3+  2.22258
+     Gd    2.25341 Gd3+  2.13553 Tb    2.24256 Tb3+  2.05601 Dy    2.1802
+     Dy3+  1.9804  Ho    2.07051 Ho3+  1.91072 Er    2.07356 Er3+  1.84659
+     Tm    2.02859 Tm3+  1.78711 Yb    1.9889  Yb2+  1.78503 Yb3+  1.73272
+     Lu    1.90182 Lu3+  1.68216 Hf    1.83262 Hf4+  1.59136 Ta    1.77333
+     Ta5+  1.50711 W     1.72029 W6+   1.42755 Re    1.67191 Os    1.62903
+     Os4+  1.37113 Ir    1.59279 Ir3+  1.34323 Ir4+  1.30923 Pt    1.51293
+     Pt2+  1.32927 Pt4+  1.24813 Au    .4611   Au1+  1.35321 Au3+  1.2199
+     Hg    .545    Hg1+  1.39507 Hg2+  1.21152 Tl    .65515  Tl1+  1.4711
+     Tl3+  1.1008  Pb    .6902   Pb2+  1.3366  Pb4+  1.00566 Bi    .704
+     Bi3+  1.2356  Bi5+  .91654  Po    .700999 At    .685870 Rn    .6631
+     Fr    .646453 Ra    .616341 Ra2+  .604909 Ac    .589092 Ac3+  .579689
+     Th    .563359 Th4+  .555054 Pa    .547751 U     .5293   U3+   .520480
+     U4+   .516598 U6+   .507079 Np    .511929 Np3+  .502322 Np4+  .498626
+     Np6+  .489810 Pu    .499384 Pu3+  .484938 Pu4+  .481422 Pu6+  .473204
+     Am    .483629 Cm    .465154 Bk    .451018 Cf    .437533
+     save_
+
+
+save_cromer_mann_a2
+
+    _units.code                   none
+
+     loop_
+         _enumeration_default.index
+         _enumeration_default.value
+     H     .322912 D     .322912 H1-   .565616 He    0.6309  Li    .7508
+     Li1+  .7888   Be    1.1278  Be2+  .8849   B     1.3326  C     1.02
+     N     3.1322  O     2.2868  O1-   1.63969 F     2.6412  F1-   3.51057
+     Ne    3.1125  Na    3.1736  Na1+  3.9362  Mg    2.1735  Mg2+  3.8378
+     Al    1.9002  Al3+  3.3876  Si    3.0353  Si4+  3.20345 P     4.1791
+     S     5.2034  Cl    7.1964  Cl1-  7.2084  Ar    6.6623  K     7.4398
+     K1+   7.4917  Ca    7.3873  Ca2+  7.9518  Sc    7.3679  Sc3+  8.0273
+     Ti    7.3558  Ti2+  7.62174 Ti3+  8.73816 Ti4+  8.23473 V     7.3511
+     V2+   7.3541  V3+   7.7419  V5+   8.14208 Cr    7.3537  Cr2+  7.7509
+     Cr3+  7.81136 Mn    7.3573  Mn2+  7.362   Mn3+  7.87194 Mn4+  7.97057
+     Fe    7.3573  Fe2+  7.374   Fe3+  7.3863  Co    7.3409  Co2+  7.3883
+     Co3+  7.88173 Ni    7.292   Ni2+  7.4005  Ni3+  7.75868 Cu    7.1676
+     Cu1+  7.3573  Cu2+  7.11181 Zn    7.0318  Zn2+  7.3862  Ga    6.7006
+     Ga3+  6.69883 Ge    6.3747  Ge4+  6.70003 As    6.0701  Se    5.8196
+     Br    5.2358  Br1-  6.3338  Kr    6.7286  Rb    9.6435  Rb1+  7.6598
+     Sr    9.8184  Sr2+  8.1373  Y     10.2946 Y3+   9.1531  Zr    10.948
+     Zr4+  10.0562 Nb    12.0144 Nb3+  18.0653 Nb5+  13.3417 Mo    17.2356
+     Mo3+  18.2017 Mo5+  18.0992 Mo6+  11.175  Tc    11.0948 Ru    12.9182
+     Ru3+  13.2885 Ru4+  13.1787 Rh    14.3501 Rh3+  14.1259 Rh4+  13.9806
+     Pd    15.5017 Pd2+  15.2096 Pd4+  14.79   Ag    16.6885 Ag1+  15.9719
+     Ag2+  16.2456 Cd    17.6444 Cd2+  17.2535 In    18.5596 In3+  18.1108
+     Sn    19.1005 Sn2+  19.0548 Sn4+  19.7131 Sb    19.0455 Sb3+  18.933
+     Sb5+  19.0302 Te    19.0138 I     18.9949 I1-   18.997  Xe    19.0298
+     Cs    19.1062 Cs1+  19.1278 Ba    19.297  Ba2+  19.1136 La    19.599
+     La3+  19.3763 Ce    19.7695 Ce3+  19.559  Ce4+  19.8186 Pr    19.6697
+     Pr3+  19.7491 Pr4+  20.0539 Nd    19.6847 Nd3+  19.9339 Pm    19.6095
+     Sm    19.4258 Sm3+  20.2599 Eu    19.0886 Eu2+  19.9504 Eu3+  20.3745
+     Gd    19.0798 Gd3+  20.4208 Tb    18.2185 Tb3+  20.3271 Dy    17.6383
+     Dy3+  20.2861 Ho    17.294  Ho3+  20.0994 Er    16.4285 Er3+  19.7748
+     Tm    15.8851 Tm3+  19.332  Yb    15.4345 Yb2+  17.6817 Yb3+  18.7614
+     Lu    15.2208 Lu3+  18.121  Hf    15.1726 Hf4+  18.4601 Ta    15.2293
+     Ta5+  18.8407 W     15.43   W6+   19.3763 Re    15.7189 Os    16.155
+     Os4+  15.2637 Ir    16.7296 Ir3+  15.862  Ir4+  15.5512 Pt    17.7639
+     Pt2+  16.7224 Pt4+  15.9829 Au    18.5913 Au1+  17.8204 Au3+  16.9029
+     Hg    19.0417 Hg1+  18.4973 Hg2+  18.06   Tl    19.1584 Tl1+  20.4723
+     Tl3+  18.3841 Pb    13.0637 Pb2+  19.5682 Pb4+  18.8003 Bi    12.951
+     Bi3+  19.5026 Bi5+  25.0946 Po    15.4733 At    19.0211 Rn    21.2816
+     Fr    23.0547 Ra    22.9064 Ra2+  21.6700 Ac    23.1032 Ac3+  22.1112
+     Th    23.4219 Th4+  22.4418 Pa    23.2948 U     23.4128 U3+   22.5259
+     U4+   22.5326 U6+   22.7584 Np    23.5964 Np3+  22.6130 Np4+  22.5787
+     Np6+  22.7286 Pu    23.8083 Pu3+  22.7169 Pu4+  22.6460 Pu6+  22.7181
+     Am    24.0992 Cm    24.4096 Bk    24.7736 Cf    25.1995
+     save_
+
+
+save_cromer_mann_b2
+
+    _units.code                   angstrom_squared
+
+     loop_
+         _enumeration_default.index
+         _enumeration_default.value
+     H     26.1257 D     26.1257 H1-   15.187  He    3.3568  Li    1.0524
+     Li1+  1.9557  Be    1.8623  Be2+  .8313   B     1.021   C     10.2075
+     N     9.8933  O     5.7011  O1-   4.17236 F     4.2944  F1-   14.7353
+     Ne    3.4262  Na    8.8422  Na1+  6.1153  Mg    79.2611 Mg2+  4.7542
+     Al    .7426   Al3+  4.14553 Si    32.3337 Si4+  3.43757 P     27.157
+     S     22.2151 Cl    1.1662  Cl1-  1.1717  Ar    14.8407 K     .7748
+     K1+   .7674   Ca    .6599   Ca2+  .6089   Sc    .5729   Sc3+  7.9629
+     Ti    .5      Ti2+  .457585 Ti3+  7.04716 Ti4+  6.67018 V     .4385
+     V2+   .4409   V3+   .383349 V5+   5.40135 Cr    .392    Cr2+  .344261
+     Cr3+  .334393 Mn    .3432   Mn2+  .3435   Mn3+  .294393 Mn4+  .283303
+     Fe    .3072   Fe2+  .3053   Fe3+  .3005   Co    .2784   Co2+  .2726
+     Co3+  .238668 Ni    .2565   Ni2+  .2449   Ni3+  .22314  Cu    .247
+     Cu1+  .2274   Cu2+  .244078 Zn    .2333   Zn2+  .2031   Ga    .2412
+     Ga3+  .22789  Ge    .2516   Ge4+  .205855 As    .2647   Se    .2726
+     Br    16.5796 Br1-  19.3345 Kr    16.5623 Rb    17.3151 Rb1+  14.7957
+     Sr    14.0988 Sr2+  12.6963 Y     12.8006 Y3+   11.2145 Zr    11.916
+     Zr4+  10.1483 Nb    11.766  Nb3+  1.13305 Nb5+  .028781 Mo    1.0958
+     Mo3+  1.03031 Mo5+  1.02238 Mo6+  8.48061 Tc    8.14487 Ru    8.43467
+     Ru3+  8.37164 Ru4+  8.12534 Rh    8.21758 Rh3+  7.84438 Rh4+  7.62436
+     Pd    7.98929 Pd2+  7.55573 Pd4+  7.14833 Ag    7.4726  Ag1+  7.19123
+     Ag2+  7.18544 Cd    6.9089  Cd2+  6.80639 In    6.3776  In3+  6.3247
+     Sn    .5031   Sn2+  5.8378  Sn4+  .4655   Sb    .4607   Sb3+  5.22126
+     Sb5+  .467973 Te    .420885 I     .3814   I1-   .3815   Xe    0.344
+     Cs    .3107   Cs1+  .3086   Ba    .2756   Ba2+  .28331  La    .244475
+     La3+  .250698 Ce    .226836 Ce3+  .23154  Ce4+  .21885  Pr    .222087
+     Pr3+  .214299 Pr4+  .202481 Nd    .210628 Nd3+  .199237 Pm    0.202088
+     Sm    .196451 Sm3+  .174081 Eu    .1942   Eu2+  .17353  Eu3+  .16394
+     Gd    .181951 Gd3+  .155525 Tb    .196143 Tb3+  .149525 Dy    .202172
+     Dy3+  .143384 Ho    .19794  Ho3+  .139358 Er    .223545 Er3+  .13729
+     Tm    .238849 Tm3+  .136974 Yb    .25711  Yb2+  .15997  Yb3+  .13879
+     Lu    9.98519 Lu3+  .142292 Hf    9.5999  Hf4+  .128903 Ta    9.37046
+     Ta5+  .116741 W     9.2259  W6+   .104621 Re    9.09227 Os    8.97948
+     Os4+  6.84706 Ir    8.86553 Ir3+  7.10909 Ir4+  6.71983 Pt    8.81174
+     Pt2+  7.38979 Pt4+  6.60834 Au    8.6216  Au1+  7.7395  Au3+  6.82872
+     Hg    8.4484  Hg1+  7.65105 Hg2+  7.05639 Tl    8.70751 Tl1+  .517394
+     Tl3+  6.53852 Pb    2.3576  Pb2+  .488383 Pb4+  6.10926 Bi    2.9238
+     Bi3+  6.24149 Bi5+  .039042 Po    3.55078 At    3.97458 Rn    4.0691
+     Fr    4.17619 Ra    3.87135 Ra2+  3.57670 Ac    3.65155 Ac3+  3.41437
+     Th    3.46204 Th4+  3.24498 Pa    3.41519 U     3.3253  U3+   3.12293
+     U4+   3.05053 U6+   2.89030 Np    3.25396 Np3+  3.03807 Np4+  2.96627
+     Np6+  2.81099 Pu    3.26371 Pu3+  2.96118 Pu4+  2.89020 Pu6+  2.73848
+     Am    3.20647 Cm    3.08997 Bk    3.04619 Cf    3.00775
+     save_
+
+
+save_cromer_mann_a3
+
+    _units.code                   none
+
+     loop_
+         _enumeration_default.index
+         _enumeration_default.value
+     H     .140191 D     .140191 H1-   .415815 He    0.3112  Li    .6175
+     Li1+  .3414   Be    .5391   Be2+  .7993   B     1.0979  C     1.5886
+     N     2.0125  O     1.5463  O1-   1.52673 F     1.517   F1-   1.26064
+     Ne    1.4546  Na    1.2674  Na1+  1.3998  Mg    1.2269  Mg2+  1.3284
+     Al    1.5936  Al3+  1.20296 Si    1.9891  Si4+  1.19453 P     1.78
+     S     1.4379  Cl    6.2556  Cl1-  6.5337  Ar    0.6539  K     1.0519
+     K1+   6.359   Ca    1.5899  Ca2+  8.4372  Sc    1.6409  Sc3+  1.65943
+     Ti    1.6991  Ti2+  2.2793  Ti3+  5.25691 Ti4+  2.01341 V     2.0703
+     V2+   2.2884  V3+   2.15343 V5+   2.03081 Cr    3.324   Cr2+  3.58274
+     Cr3+  2.87603 Mn    3.0193  Mn2+  3.5268  Mn3+  3.56531 Mn4+  2.76067
+     Fe    3.5222  Fe2+  4.1346  Fe3+  3.3948  Co    4.0034  Co2+  4.7393
+     Co3+  4.76795 Ni    4.4438  Ni2+  5.3442  Ni3+  5.22746 Cu    5.6158
+     Cu1+  6.2455  Cu2+  5.78135 Zn    5.1652  Zn2+  6.4668  Ga    4.3591
+     Ga3+  6.06692 Ge    3.7068  Ge4+  6.06791 As    3.4313  Se    3.9731
+     Br    5.6377  Br1-  5.5754  Kr    5.5493  Rb    5.1399  Rb1+  5.8981
+     Sr    5.422   Sr2+  2.5654  Y     5.72629 Y3+   1.76795 Zr    5.41732
+     Zr4+  1.01118 Nb    4.04183 Nb3+  11.0177 Nb5+  10.799  Mo    12.8876
+     Mo3+  11.7423 Mo5+  11.4632 Mo6+  6.57891 Tc    4.64901 Ru    4.86337
+     Ru3+  9.32602 Ru4+  4.71304 Rh    4.73425 Rh3+  3.32515 Rh4+  2.53464
+     Pd    5.29537 Pd2+  4.32234 Pd4+  2.89289 Ag    4.8045  Ag1+  5.27475
+     Ag2+  4.3709  Cd    4.461   Cd2+  4.47128 In    4.2948  In3+  3.78897
+     Sn    4.4585  Sn2+  4.5648  Sn4+  3.4182  Sb    5.0371  Sb3+  5.10789
+     Sb5+  2.41253 Te    6.14487 I     7.5138  I1-   7.8069  Xe    8.9767
+     Cs    10.662  Cs1+  10.2821 Ba    10.888  Ba2+  10.9054 La    11.3727
+     La3+  11.6323 Ce    11.8513 Ce3+  11.9369 Ce4+  12.1233 Pr    12.3856
+     Pr3+  12.1329 Pr4+  12.4668 Nd    12.774  Nd3+  12.12   Pm    13.1235
+     Sm    13.4396 Sm3+  11.9202 Eu    13.7603 Eu2+  11.8034 Eu3+  11.8509
+     Gd    13.8518 Gd3+  11.8708 Tb    14.3167 Tb3+  12.2471 Dy    14.5596
+     Dy3+  11.9812 Ho    14.5583 Ho3+  11.9788 Er    14.9779 Er3+  12.1506
+     Tm    15.1542 Tm3+  12.3339 Yb    15.3087 Yb2+  13.3335 Yb3+  12.6072
+     Lu    15.1    Lu3+  12.8429 Hf    14.7586 Hf4+  12.7285 Ta    14.5135
+     Ta5+  12.8268 W     14.4327 W6+   13.0544 Re    14.5564 Os    14.9305
+     Os4+  14.7458 Ir    15.6115 Ir3+  13.6145 Ir4+  14.2326 Pt    15.7131
+     Pt2+  13.2153 Pt4+  13.7348 Au    25.5582 Au1+  14.3359 Au3+  12.7801
+     Hg    21.6575 Hg1+  16.8883 Hg2+  12.8374 Tl    15.538  Tl1+  18.7478
+     Tl3+  11.9328 Pb    18.442  Pb2+  19.1406 Pb4+  12.0175 Bi    16.5877
+     Bi3+  19.1053 Bi5+  19.2497 Po    13.1138 At    9.49887 Rn    8.0037
+     Fr    12.1439 Ra    12.4739 Ra2+  7.91342 Ac    12.5977 Ac3+  8.19216
+     Th    12.7473 Th4+  9.78554 Pa    14.1891 U     14.9491 U3+   12.2165
+     U4+   12.0291 U6+   14.0099 Np    15.6402 Np3+  12.9898 Np4+  12.7766
+     Np6+  14.3884 Pu    16.7707 Pu3+  13.5807 Pu4+  13.3595 Pu6+  14.7635
+     Am    17.3415 Cm    17.3990 Bk    17.8919 Cf    18.3317
+     save_
+
+
+save_cromer_mann_b3
+
+    _units.code                   angstrom_squared
+
+     loop_
+         _enumeration_default.index
+         _enumeration_default.value
+     H     3.14236 D     3.14236 H1-   186.576 He    22.9276 Li    85.3905
+     Li1+  .6316   Be    103.483 Be2+  2.2758  B     60.3498 C     .5687
+     N     28.9975 O     .3239   O1-   47.0179 F     .2615   F1-   .442258
+     Ne    0.2306  Na    .3136   Na1+  .2001   Mg    .3808   Mg2+  .185
+     Al    31.5472 Al3+  .228753 Si    .6785   Si4+  .2149   P     .526
+     S     .2536   Cl    18.5194 Cl1-  19.5424 Ar    43.8983 K     213.187
+     K1+   -.002   Ca    85.7484 Ca2+  10.3116 Sc    136.108 Sc3+  -.28604
+     Ti    35.6338 Ti2+  19.5361 Ti3+  -.15762 Ti4+  -.29263 V     26.8938
+     V2+   20.3004 V3+   15.1908 V5+   9.97278 Cr    20.2626 Cr2+  13.3075
+     Cr3+  12.8288 Mn    17.8674 Mn2+  14.343  Mn3+  10.8171 Mn4+  10.4852
+     Fe    15.3535 Fe2+  12.0546 Fe3+  11.6729 Co    13.5359 Co2+  10.2443
+     Co3+  8.35583 Ni    12.1763 Ni2+  8.873   Ni3+  7.64468 Cu    11.3966
+     Cu1+  8.6625  Cu2+  7.9876  Zn    10.3163 Zn2+  7.0826  Ga    10.7805
+     Ga3+  6.36441 Ge    11.4468 Ge4+  5.47913 As    12.9479 Se    15.2372
+     Br    .2609   Br1-  .2871   Kr    0.2261  Rb    .2748   Rb1+  .1603
+     Sr    .1664   Sr2+  24.5651 Y     .125599 Y3+   22.6599 Zr    .117622
+     Zr4+  21.6054 Nb    .204785 Nb3+  10.1621 Nb5+  9.28206 Mo    11.004
+     Mo3+  9.53659 Mo5+  8.78809 Mo6+  .058881 Tc    21.5707 Ru    24.7997
+     Ru3+  .017662 Ru4+  .036495 Rh    25.8749 Rh3+  21.2487 Rh4+  19.3317
+     Pd    25.2052 Pd2+  22.5057 Pd4+  17.9144 Ag    24.6605 Ag1+  21.7326
+     Ag2+  21.4072 Cd    24.7008 Cd2+  20.2521 In    25.8499 In3+  17.3595
+     Sn    26.8909 Sn2+  23.3752 Sn4+  14.0049 Sb    27.9074 Sb3+  19.5902
+     Sb5+  14.1259 Te    28.5284 I     27.766  I1-   29.5259 Xe    26.4659
+     Cs    24.3879 Cs1+  23.7128 Ba    20.2073 Ba2+  20.0558 La    18.7726
+     La3+  17.8211 Ce    17.6083 Ce3+  16.5408 Ce4+  15.7992 Pr    16.7669
+     Pr3+  15.323  Pr4+  14.8137 Nd    15.885  Nd3+  14.1783 Pm    15.1009
+     Sm    14.3996 Sm3+  12.1571 Eu    13.7546 Eu2+  11.6096 Eu3+  11.311
+     Gd    12.9331 Gd3+  10.5782 Tb    12.6648 Tb3+  10.0499 Dy    12.1899
+     Dy3+  9.34972 Ho    11.4407 Ho3+  8.80018 Er    11.3604 Er3+  8.36225
+     Tm    10.9975 Tm3+  7.96778 Yb    10.6647 Yb2+  8.18304 Yb3+  7.64412
+     Lu    .261033 Lu3+  7.33727 Hf    .275116 Hf4+  6.76232 Ta    .295977
+     Ta5+  6.31524 W     .321703 W6+   5.93667 Re    .3505   Os    .382661
+     Os4+  .165191 Ir    .417916 Ir3+  .204633 Ir4+  .167252 Pt    .424593
+     Pt2+  .263297 Pt4+  .16864  Au    1.4826  Au1+  .356752 Au3+  .212867
+     Hg    1.5729  Hg1+  .443378 Hg2+  .284738 Tl    1.96347 Tl1+  7.43463
+     Tl3+  .219074 Pb    8.618   Pb2+  6.7727  Pb4+  .147041 Bi    8.7937
+     Bi3+  .469999 Bi5+  5.71414 Po    9.55642 At    11.3824 Rn    14.0422
+     Fr    23.1052 Ra    19.9887 Ra2+  12.6010 Ac    18.5990 Ac3+  12.9187
+     Th    17.8309 Th4+  13.4661 Pa    16.9235 U     16.0927 U3+   12.7148
+     U4+   12.5723 U6+   13.1767 Np    15.3622 Np3+  12.1449 Np4+  11.9484
+     Np6+  12.3300 Pu    14.9455 Pu3+  11.5331 Pu4+  11.3160 Pu6+  11.5530
+     Am    14.3136 Cm    13.4346 Bk    12.8946 Cf    12.4044
+     save_
+
+
+save_cromer_mann_a4
+
+    _units.code                   none
+
+    loop_
+         _enumeration_default.index
+         _enumeration_default.value
+     H     .04081  D     .04081  H1-   .116973 He    0.178   Li    .4653
+     Li1+  .1563   Be    .7029   Be2+  .1647   B     .7068   C     .865
+     N     1.1663  O     .867    O1-   -20.307 F     1.0243  F1-   .940706
+     Ne    1.1251  Na    1.1128  Na1+  1.0032  Mg    2.3073  Mg2+  .8497
+     Al    1.9646  Al3+  .528137 Si    1.541   Si4+  .41653  P     1.4908
+     S     1.5863  Cl    1.6455  Cl1-  2.3386  Ar    1.6442  K     .8659
+     K1+   1.1915  Ca    1.0211  Ca2+  .8537   Sc    1.468   Sc3+  1.57936
+     Ti    1.9021  Ti2+  .087899 Ti3+  1.92134 Ti4+  1.5208  V     2.0571
+     V2+   .0223   V3+   .016865 V5+   -9.576  Cr    1.4922  Cr2+  .509107
+     Cr3+  .113575 Mn    2.2441  Mn2+  .2184   Mn3+  .323613 Mn4+  .054447
+     Fe    2.3045  Fe2+  .4399   Fe3+  .0724   Co    2.3488  Co2+  .7108
+     Co3+  .725591 Ni    2.38    Ni2+  .9773   Ni3+  .847114 Cu    1.6735
+     Cu1+  1.5578  Cu2+  1.14523 Zn    2.41    Zn2+  1.394   Ga    2.9623
+     Ga3+  1.0066  Ge    3.683   Ge4+  .859041 As    4.2779  Se    4.3543
+     Br    3.9851  Br1-  3.7272  Kr    3.5375  Rb    1.5292  Rb1+  2.7817
+     Sr    2.6694  Sr2+  -34.193 Y     3.26588 Y3+   -33.108 Zr    3.65721
+     Zr4+  -2.6479 Nb    3.53346 Nb3+  1.94715 Nb5+  .337905 Mo    3.7429
+     Mo3+  2.30951 Mo5+  .740625 Mo6+  0.      Tc    2.71263 Ru    1.56756
+     Ru3+  3.00964 Ru4+  2.18535 Rh    1.28918 Rh3+  -6.1989 Rh4+  -5.6526
+     Pd    .605844 Pd2+  0.      Pd4+  -7.9492 Ag    1.0463  Ag1+  .357534
+     Ag2+  0.      Cd    1.6029  Cd2+  0.      In    2.0396  In3+  0.
+     Sn    2.4663  Sn2+  .487    Sn4+  .0193   Sb    2.6827  Sb3+  .288753
+     Sb5+  0.      Te    2.5239  I     2.2735  I1-   2.8868  Xe    1.99
+     Cs    1.4953  Cs1+  .9615   Ba    2.6959  Ba2+  .773634 La    3.28719
+     La3+  .336048 Ce    3.33049 Ce3+  .612376 Ce4+  .144583 Pr    2.82428
+     Pr3+  .97518  Pr4+  .296689 Nd    2.85137 Nd3+  1.51031 Pm    2.87516
+     Sm    2.89604 Sm3+  2.71488 Eu    2.9227  Eu2+  3.87243 Eu3+  3.26503
+     Gd    3.54545 Gd3+  3.7149  Tb    2.95354 Tb3+  3.773   Dy    2.96577
+     Dy3+  4.50073 Ho    3.63837 Ho3+  4.93676 Er    2.98233 Er3+  5.17379
+     Tm    2.98706 Tm3+  5.38348 Yb    2.98963 Yb2+  5.14657 Yb3+  5.47647
+     Lu    3.71601 Lu3+  5.59415 Hf    4.30013 Hf4+  5.59927 Ta    4.76492
+     Ta5+  5.38695 W     5.11982 W6+   5.06412 Re    5.44174 Os    5.67589
+     Os4+  5.06795 Ir    5.83377 Ir3+  5.82008 Ir4+  5.53672 Pt    5.7837
+     Pt2+  6.35234 Pt4+  5.92034 Au    5.86    Au1+  6.58077 Au3+  6.52354
+     Hg    5.9676  Hg1+  6.48216 Hg2+  6.89912 Tl    5.52593 Tl1+  6.82847
+     Tl3+  7.00574 Pb    5.9696  Pb2+  7.01107 Pb4+  6.96886 Bi    6.4692
+     Bi3+  7.10295 Bi5+  6.91555 Po    7.02588 At    7.42518 Rn    7.4433
+     Fr    2.11253 Ra    3.21097 Ra2+  7.65078 Ac    4.08655 Ac3+  7.05545
+     Th    4.80703 Th4+  5.29444 Pa    4.17287 U     4.1880  U3+   5.37073
+     U4+   4.79840 U6+   1.21457 Np    4.18550 Np3+  5.43227 Np4+  4.92159
+     Np6+  1.75669 Pu    3.47947 Pu3+  5.66016 Pu4+  5.18831 Pu6+  2.28678
+     Am    3.49331 Cm    4.21665 Bk    4.23284 Cf    4.24391
+     save_
+
+
+save_cromer_mann_b4
+
+    _units.code                   angstrom_squared
+
+     loop_
+         _enumeration_default.index
+         _enumeration_default.value
+     H     57.7997 D     57.7997 H1-   3.56709 He    0.9821  Li    168.261
+     Li1+  10.0953 Be    .542    Be2+  5.1146  B     .1403   C     51.6512
+     N     .5826   O     32.9089 O1-   -.01404 F     26.1476 F1-   47.3437
+     Ne    21.7814 Na    129.424 Na1+  14.039  Mg    7.1937  Mg2+  10.1411
+     Al    85.0886 Al3+  8.28524 Si    81.6937 Si4+  6.65365 P     68.1645
+     S     56.172  Cl    47.7784 Cl1-  60.4486 Ar    33.3929 K     41.6841
+     K1+   31.9128 Ca    178.437 Ca2+  25.9905 Sc    51.3531 Sc3+  16.0662
+     Ti    116.105 Ti2+  61.6558 Ti3+  15.9768 Ti4+  12.9464 V     102.478
+     V2+   115.122 V3+   63.969  V5+   .940464 Cr    98.7399 Cr2+  32.4224
+     Cr3+  32.8761 Mn    83.7543 Mn2+  41.3235 Mn3+  24.1281 Mn4+  27.573
+     Fe    76.8805 Fe2+  31.2809 Fe3+  38.5566 Co    71.1692 Co2+  25.6466
+     Co3+  18.3491 Ni    66.3421 Ni2+  22.1626 Ni3+  16.9673 Cu    64.8126
+     Cu1+  25.8487 Cu2+  19.897  Zn    58.7097 Zn2+  18.0995 Ga    61.4135
+     Ga3+  14.4122 Ge    54.7625 Ge4+  11.603  As    47.7972 Se    43.8163
+     Br    41.4328 Br1-  58.1535 Kr    39.3972 Rb    164.934 Rb1+  31.2087
+     Sr    132.376 Sr2+  -.0138  Y     104.354 Y3+   -.01319 Zr    87.6627
+     Zr4+  -.10276 Nb    69.7957 Nb3+  28.3389 Nb5+  25.7228 Mo    61.6584
+     Mo3+  26.6307 Mo5+  23.3452 Mo6+  0.      Tc    86.8472 Ru    94.2928
+     Ru3+  22.887  Ru4+  20.8504 Rh    98.6062 Rh3+  -.01036 Rh4+  -.0102
+     Pd    76.8986 Pd2+  0.      Pd4+  .005127 Ag    99.8156 Ag1+  66.1147
+     Ag2+  0.      Cd    87.4825 Cd2+  0.      In    92.8029 In3+  0.
+     Sn    83.9571 Sn2+  62.2061 Sn4+  -.7583  Sb    75.2825 Sb3+  55.5113
+     Sb5+  0.      Te    70.8403 I     66.8776 I1-   84.9304 Xe    64.2658
+     Cs    213.904 Cs1+  59.4565 Ba    167.202 Ba2+  51.746  La    133.124
+     La3+  54.9453 Ce    127.113 Ce3+  43.1692 Ce4+  62.2355 Pr    143.644
+     Pr3+  36.4065 Pr4+  45.4643 Nd    137.903 Nd3+  30.8717 Pm    132.721
+     Sm    128.007 Sm3+  24.8242 Eu    123.174 Eu2+  26.5156 Eu3+  22.9966
+     Gd    101.398 Gd3+  21.7029 Tb    115.362 Tb3+  21.2773 Dy    111.874
+     Dy3+  19.581  Ho    92.6566 Ho3+  18.5908 Er    105.703 Er3+  17.8974
+     Tm    102.961 Tm3+  17.2922 Yb    100.417 Yb2+  20.39   Yb3+  16.8153
+     Lu    84.3298 Lu3+  16.3535 Hf    72.029  Hf4+  14.0366 Ta    63.3644
+     Ta5+  12.4244 W     57.056  W6+   11.1972 Re    52.0861 Os    48.1647
+     Os4+  18.003  Ir    45.0011 Ir3+  20.3254 Ir4+  17.4911 Pt    38.6103
+     Pt2+  22.9426 Pt4+  16.9392 Au    36.3956 Au1+  26.4043 Au3+  18.659
+     Hg    38.3246 Hg1+  28.2262 Hg2+  20.7482 Tl    45.8149 Tl1+  28.8482
+     Tl3+  17.2114 Pb    47.2579 Pb2+  23.8132 Pb4+  14.714  Bi    48.0093
+     Bi3+  20.3185 Bi5+  12.8285 Po    47.0045 At    45.4715 Rn    44.2473
+     Fr    150.645 Ra    142.325 Ra2+  29.8436 Ac    117.020 Ac3+  25.9443
+     Th    99.1722 Th4+  23.9533 Pa    105.251 U     100.613 U3+   26.3394
+     U4+   23.4582 U6+   25.2017 Np    97.4908 Np3+  25.4928 Np4+  22.7502
+     Np6+  22.6581 Pu    105.980 Pu3+  24.3992 Pu4+  21.8301 Pu6+  20.9303
+     Am    102.273 Cm    88.4834 Bk    86.0030 Cf    83.7881
+     save_
+
+
+save_cromer_mann_c
+
+    _units.code                   none
+
+     loop_
+         _enumeration_default.index
+         _enumeration_default.value
+     H     .003038 D     .003038 H1-   .002389 He    0.0064  Li    .0377
+     Li1+  .0167   Be    .0385   Be2+  -6.1092 B     -.1932  C     .2156
+     N     -11.529 O     .2508   O1-   21.9412 F     .2776   F1-   .653396
+     Ne    0.3515  Na    .6760   Na1+  .4040   Mg    .8584   Mg2+  .4853
+     Al    1.1151  Al3+  .706786 Si    1.1407  Si4+  .746297 P     1.1149
+     S     .8669   Cl    -9.5574 Cl1-  -16.378 Ar    1.44450 K     1.4228
+     K1+   -4.9978 Ca    1.3751  Ca2+  -14.875 Sc    1.3329  Sc3+  -6.6667
+     Ti    1.2807  Ti2+  .897155 Ti3+  -14.652 Ti4+  -13.280 V     1.2199
+     V2+   1.2298  V3+   .656565 V5+   1.71430 Cr    1.1832  Cr2+  .616898
+     Cr3+  .518275 Mn    1.0896  Mn2+  1.0874  Mn3+  .393974 Mn4+  .251877
+     Fe    1.0369  Fe2+  1.0097  Fe3+  .9707   Co    1.0118  Co2+  .9324
+     Co3+  .286667 Ni    1.0341  Ni2+  .8614   Ni3+  .386044 Cu    1.1910
+     Cu1+  .8900   Cu2+  1.14431 Zn    1.3041  Zn2+  .7807   Ga    1.7189
+     Ga3+  1.53545 Ge    2.1313  Ge4+  1.45572 As    2.5310  Se    2.8409
+     Br    2.9557  Br1-  3.1776  Kr    2.825   Rb    3.4873  Rb1+  2.0782
+     Sr    2.5064  Sr2+  41.4025 Y     1.91213 Y3+   40.2602 Zr    2.06929
+     Zr4+  9.41454 Nb    3.75591 Nb3+  -12.912 Nb5+  -6.3934 Mo    4.3875
+     Mo3+  -14.421 Mo5+  -14.316 Mo6+  .344941 Tc    5.40428 Ru    5.37874
+     Ru3+  -3.1892 Ru4+  1.42357 Rh    5.32800 Rh3+  11.8678 Rh4+  11.2835
+     Pd    5.26593 Pd2+  5.29160 Pd4+  13.0174 Ag    5.1790  Ag1+  5.21572
+     Ag2+  5.21404 Cd    5.0694  Cd2+  5.11937 In    4.9391  In3+  4.99635
+     Sn    4.7821  Sn2+  4.7861  Sn4+  3.9182  Sb    4.5909  Sb3+  4.69626
+     Sb5+  4.69263 Te    4.35200 I     4.0712  I1-   4.0714  Xe    3.7118
+     Cs    3.3352  Cs1+  3.2791  Ba    2.7731  Ba2+  3.02902 La    2.14678
+     La3+  2.40860 Ce    1.86264 Ce3+  2.09013 Ce4+  1.59180 Pr    2.05830
+     Pr3+  1.77132 Pr4+  1.24285 Nd    1.98486 Nd3+  1.47588 Pm    2.02876
+     Sm    2.20963 Sm3+  .954586 Eu    2.5745  Eu2+  1.36389 Eu3+  .759344
+     Gd    2.41960 Gd3+  .645089 Tb    3.58324 Tb3+  .691967 Dy    4.29728
+     Dy3+  .689690 Ho    4.56796 Ho3+  .852795 Er    5.92046 Er3+  1.17613
+     Tm    6.75621 Tm3+  1.63929 Yb    7.56672 Yb2+  3.70983 Yb3+  2.26001
+     Lu    7.97628 Lu3+  2.97573 Hf    8.58154 Hf4+  2.39699 Ta    9.24354
+     Ta5+  1.78555 W     9.88750 W6+   1.01074 Re    10.4720 Os    11.0005
+     Os4+  6.49804 Ir    11.4722 Ir3+  8.27903 Ir4+  6.96824 Pt    11.6883
+     Pt2+  9.85329 Pt4+  7.39534 Au    12.0658 Au1+  11.2299 Au3+  9.09680
+     Hg    12.6089 Hg1+  12.0205 Hg2+  10.6268 Tl    13.1746 Tl1+  12.5258
+     Tl3+  9.80270 Pb    13.4118 Pb2+  12.4734 Pb4+  8.08428 Bi    13.5782
+     Bi3+  12.4711 Bi5+  -6.7994 Po    13.6770 At    13.7108 Rn    13.6905
+     Fr    13.7247 Ra    13.6211 Ra2+  13.5431 Ac    13.5266 Ac3+  13.4637
+     Th    13.4314 Th4+  13.3760 Pa    13.4287 U     13.3966 U3+   13.3092
+     U4+   13.2671 U6+   13.1665 Np    13.3573 Np3+  13.2544 Np4+  13.2116
+     Np6+  13.1130 Pu    13.3812 Pu3+  13.1991 Pu4+  13.1555 Pu6+  13.0582
+     Am    13.3592 Cm    13.2887 Bk    13.2754 Cf    13.2674
+     save_
+
+
+save_hi_ang_fox_c0
+
+    _units.code                   none
+
+     loop_
+         _enumeration_default.index
+         _enumeration_default.value
+     H     -4.8    D     -4.8    H1-   -4.8    He    0.52543 Li    0.89463
+     Li1+  0.89463 Be    1.2584  Be2+  1.2584  B     1.6672  C     1.70560
+     N     1.54940 O     1.30530 O1-   1.30530 F     1.16710 F1-   1.16710
+     Ne    1.09310 Na    0.84558 Na1+  0.84558 Mg    0.71877 Mg2+  0.71877
+     Al    0.67975 Al3+  0.67975 Si    0.70683 Si4+  0.70683 P     0.85532
+     S     1.10400 Cl    1.42320 Cl1-  1.42320 Ar    1.82020 K     2.26550
+     K1+   2.26550 Ca    2.71740 Ca2+  2.71740 Sc    3.11730 Sc3+  3.11730
+     Ti    3.45360 Ti2+  3.45360 Ti3+  3.45360 Ti4+  3.45360 V     3.71270
+     V2+   3.71270 V3+   3.71270 V5+   3.71270 Cr    3.87870 Cr2+  3.87870
+     Cr3+  3.87870 Mn    3.98550 Mn2+  3.98550 Mn3+  3.98550 Mn4+  3.98550
+     Fe    3.99790 Fe2+  3.99790 Fe3+  3.99790 Co    3.95900 Co2+  3.95900
+     Co3+  3.95900 Ni    3.86070 Ni2+  3.86070 Ni3+  3.86070 Cu    3.72510
+     Cu1+  3.72510 Cu2+  3.72510 Zn    3.55950 Zn2+  3.55950 Ga    3.37560
+     Ga3+  3.37560 Ge    3.17800 Ge4+  3.17800 As    2.97740 Se    2.78340
+     Br    2.60610 Br1-  2.60610 Kr    2.44280 Rb    2.30990 Rb1+  2.30990
+     Sr    2.21070 Sr2+  2.21070 Y     2.14220 Y3+   2.14220 Zr    2.12690
+     Zr4+  2.12690 Nb    2.12120 Nb3+  2.12120 Nb5+  2.12120 Mo    2.18870
+     Mo3+  2.18870 Mo5+  2.18870 Mo6+  2.18870 Tc    2.25730 Ru    2.37300
+     Ru3+  2.37300 Ru4+  2.37300 Rh    2.50990 Rh3+  2.50990 Rh4+  2.50990
+     Pd    2.67520 Pd2+  2.67520 Pd4+  2.67520 Ag    2.88690 Ag1+  2.88690
+     Ag2+  2.88690 Cd    3.08430 Cd2+  3.08430 In    3.31400 In3+  3.31400
+     Sn    3.49840 Sn2+  3.49840 Sn4+  3.49840 Sb    3.70410 Sb3+  3.70410
+     Sb5+  3.70410 Te    3.88240 I     4.08010 I1-   4.08010 Xe    4.24610
+     Cs    4.38910 Cs1+  4.38910 Ba    4.51070 Ba2+  4.51070 La    4.60250
+     La3+  4.60250 Ce    4.69060 Ce3+  4.69060 Ce4+  4.69060 Pr    4.72150
+     Pr3+  4.72150 Pr4+  4.72150 Nd    4.75090 Nd3+  4.75090 Pm    4.74070
+     Sm    4.71700 Sm3+  4.71700 Eu    4.66940 Eu2+  4.66940 Eu3+  4.66940
+     Gd    4.61010 Gd3+  4.61010 Tb    4.52550 Tb3+  4.52550 Dy    4.45230
+     Dy3+  4.45230 Ho    4.37660 Ho3+  4.37660 Er    4.29460 Er3+  4.29460
+     Tm    4.21330 Tm3+  4.21330 Yb    4.13430 Yb2+  4.13430 Yb3+  4.13430
+     Lu    4.04230 Lu3+  4.04230 Hf    3.95160 Hf4+  3.95160 Ta    3.85000
+     Ta5+  3.85000 W     3.76510 W6+   3.76510 Re    3.67600 Os    3.60530
+     Os4+  3.60530 Ir    3.53130 Ir3+  3.53130 Ir4+  3.53130 Pt    3.47070
+     Pt2+  3.47070 Pt4+  3.47070 Au    3.41630 Au1+  3.41630 Au3+  3.41630
+     Hg    3.37350 Hg1+  3.37350 Hg2+  3.37350 Tl    3.34590 Tl1+  3.34590
+     Tl3+  3.34590 Pb    3.32330 Pb2+  3.32330 Pb4+  3.32330 Bi    3.31880
+     Bi3+  3.31880 Bi5+  3.31880 Po    3.32030 At    3.34250 Rn    3.37780
+     Fr    3.41990 Ra    3.47530 Ra2+  3.47530 Ac    3.49020 Ac3+  3.49020
+     Th    3.61060 Th4+  3.61060 Pa    3.68630 U     3.76650 U3+   3.76650
+     U4+   3.76650 U6+   3.76650 Np    3.82870 Np3+  3.82870 Np4+  3.82870
+     Np6+  3.82870 Pu    3.88970 Pu3+  3.88970 Pu4+  3.88970 Pu6+  3.88970
+     Am    3.95060 Cm    4.01470 Bk    4.07780 Cf    4.14210
+     save_
+
+
+save_hi_ang_fox_c1
+
+    _units.code                   angstroms
+
+     loop_
+         _enumeration_default.index
+         _enumeration_default.value
+     H     -.5      D     -.5      H1-   -.5      He    -3.433   Li    -2.4366
+     Li1+  -2.4366  Be    -1.9459  Be2+  -1.9459  B     -1.8556  C     -1.56760
+     N     -1.20190 O     -0.83742 O1-   -0.83742 F     -0.63203 F1-   -0.63203
+     Ne    -0.50221 Na    -0.26294 Na1+  -0.26294 Mg    -0.13144 Mg2+  -0.13144
+     Al    -0.08756 Al3+  -0.08756 Si    -0.09888 Si4+  -0.09888 P     -0.21262
+     S     -0.40325 Cl    -0.63936 Cl1-  -0.63936 Ar    -0.92776 K     -1.24530
+     K1+   -1.24530 Ca    -1.55670 Ca2+  -1.55670 Sc    -1.81380 Sc3+  -1.81380
+     Ti    -2.01150 Ti2+  -2.01150 Ti3+  -2.01150 Ti4+  -2.01150 V     -2.13920
+     V2+   -2.13920 V3+   -2.13920 V5+   -2.13920 Cr    -2.19000 Cr2+  -2.19000
+     Cr3+  -2.19000 Mn    -2.18850 Mn2+  -2.18850 Mn3+  -2.18850 Mn4+  -2.18850
+     Fe    -2.11080 Fe2+  -2.11080 Fe3+  -2.11080 Co    -1.99650 Co2+  -1.99650
+     Co3+  -1.99650 Ni    -1.88690 Ni2+  -1.88690 Ni3+  -1.88690 Cu    -1.65500
+     Cu1+  -1.65500 Cu2+  -1.65500 Zn    -1.45100 Zn2+  -1.45100 Ga    -1.23910
+     Ga3+  -1.23910 Ge    -1.02230 Ge4+  -1.02230 As    -0.81038 Se    -0.61110
+     Br    -0.43308 Br1-  -0.43308 Kr    -0.27244 Rb    -0.14328 Rb1+  -0.14328
+     Sr    -0.04770 Sr2+  -0.04770 Y      0.01935 Y3+    0.01935 Zr     0.08618
+     Zr4+   0.08618 Nb     0.05381 Nb3+   0.05381 Nb5+   0.05381 Mo    -0.00655
+     Mo3+  -0.00655 Mo5+  -0.00655 Mo6+  -0.00655 Tc    -0.05737 Ru    -0.15040
+     Ru3+  -0.15040 Ru4+  -0.15040 Rh    -0.25906 Rh3+  -0.25906 Rh4+  -0.25906
+     Pd    -0.39137 Pd2+  -0.39137 Pd4+  -0.39137 Ag    -0.56119 Ag1+  -0.56119
+     Ag2+  -0.56119 Cd    -0.71450 Cd2+  -0.71450 In    -0.89697 In3+  -0.89697
+     Sn    -1.02990 Sn2+  -1.02990 Sn4+  -1.02990 Sb    -1.18270 Sb3+  -1.18270
+     Sb5+  -1.18270 Te    -1.30980 I     -1.45080 I1-   -1.45080 Xe    -1.56330
+     Cs    -1.65420 Cs1+  -1.65420 Ba    -1.72570 Ba2+  -1.72570 La    -1.77070
+     La3+  -1.77070 Ce    -1.81790 Ce3+  -1.81790 Ce4+  -1.81790 Pr    -1.81390
+     Pr3+  -1.81390 Pr4+  -1.81390 Nd    -1.80800 Nd3+  -1.80800 Pm    -1.76600
+     Sm    -1.71410 Sm3+  -1.71410 Eu    -1.64140 Eu2+  -1.64140 Eu3+  -1.64140
+     Gd    -1.55750 Gd3+  -1.55750 Tb    -1.45520 Tb3+  -1.45520 Dy    -1.36440
+     Dy3+  -1.36440 Ho    -1.27460 Ho3+  -1.27460 Er    -1.18170 Er3+  -1.18170
+     Tm    -1.09060 Tm3+  -1.09060 Yb    -1.00310 Yb2+  -1.00310 Yb3+  -1.00310
+     Lu    -0.90518 Lu3+  -0.90518 Hf    -0.80978 Hf4+  -0.80978 Ta    -0.70599
+     Ta5+  -0.70599 W     -0.61807 W6+   -0.61807 Re    -0.52688 Os    -0.45420
+     Os4+  -0.45420 Ir    -0.37856 Ir3+  -0.37856 Ir4+  -0.37856 Pt    -0.31534
+     Pt2+  -0.31534 Pt4+  -0.31534 Au    -0.25987 Au1+  -0.25987 Au3+  -0.25987
+     Hg    -0.21428 Hg1+  -0.21428 Hg2+  -0.21428 Tl    -0.18322 Tl1+  -0.18322
+     Tl3+  -0.18322 Pb    -0.15596 Pb2+  -0.15596 Pb4+  -0.15596 Bi    -0.14554
+     Bi3+  -0.14554 Bi5+  -0.14554 Po    -0.13999 At    -0.15317 Rn    -0.17800
+     Fr    -0.20823 Ra    -0.25005 Ra2+  -0.25005 Ac    -0.25109 Ac3+  -0.25109
+     Th    -0.35409 Th4+  -0.35409 Pa    -0.41329 U     -0.47542 U3+   -0.47542
+     U4+   -0.47542 U6+   -0.47542 Np    -0.51955 Np3+  -0.51955 Np4+  -0.51955
+     Np6+  -0.51955 Pu    -0.56296 Pu3+  -0.56296 Pu4+  -0.56296 Pu6+  -0.56296
+     Am    -0.60554 Cm    -0.65062 Bk    -0.69476 Cf    -0.73977
+     save_
+
+
+save_hi_ang_fox_c2
+
+    _units.code                   angstrom_squared
+
+     loop_
+         _enumeration_default.index
+         _enumeration_default.value
+    H     0.0       D     0.0      H1-   0.0       He    0.480070 Li    0.232500
+    Li1+  0.232500  Be    0.130460 Be2+  0.130460  B     0.160440 C     0.118930
+    N     0.051064  O    -0.016738 O1-  -0.016738 F     -0.040207 F1-  -0.040207
+    Ne   -0.053648  Na   -0.087884 Na1+ -0.087884 Mg    -0.120900 Mg2+ -0.120900
+    Al   -0.095431  Al3+ -0.095431 Si   -0.098356 Si4+  -0.098356 P    -0.037390
+    S     0.020094  Cl    0.084722 Cl1-  0.084722 Ar     0.159220 K     0.238330
+    K1+   0.238330  Ca    0.313170 Ca2+  0.313170 Sc     0.371390 Sc3+  0.371390
+    Ti    0.413170  Ti2+  0.413170 Ti3+  0.413170 Ti4+   0.413170 V     0.435610
+    V2+   0.435610  V3+   0.435610 V5+   0.435610 Cr     0.438670 Cr2+  0.438670
+    Cr3+  0.438670  Mn    0.427960 Mn2+  0.427960 Mn3+   0.427960 Mn4+  0.427960
+    Fe    0.398170  Fe2+  0.398170 Fe3+  0.398170 Co     0.360630 Co2+  0.360630
+    Co3+  0.360630  Ni    0.312390 Ni2+  0.312390 Ni3+   0.312390 Cu    0.260290
+    Cu1+  0.260290  Cu2+  0.260290 Zn    0.203390 Zn2+   0.203390 Ga    0.146160
+    Ga3+  0.146160  Ge    0.089119 Ge4+  0.089119 As     0.034861 Se   -0.014731
+    Br   -0.057381  Br1- -0.057381 Kr   -0.095570 Rb    -0.122600 Rb1+ -0.122600
+    Sr   -0.141100  Sr2+ -0.141100 Y    -0.152240 Y3+   -0.152240 Zr   -0.149190
+    Zr4+ -0.149190  Nb   -0.150070 Nb3+ -0.150070 Nb5+  -0.150070 Mo   -0.125340
+    Mo3+ -0.125340  Mo5+ -0.125340 Mo6+ -0.125340 Tc    -0.107450 Ru   -0.077694
+    Ru3+ -0.077694  Ru4+ -0.077694 Rh   -0.044719 Rh3+  -0.044719 Rh4+ -0.044719
+    Pd   -0.005894  Pd2+ -0.005894 Pd4+ -0.005894 Ag     0.042189 Ag1+  0.042189
+    Ag2+  0.042189  Cd    0.084482 Cd2+  0.084482 In     0.135030 In3+  0.135030
+    Sn    0.168990  Sn2+  0.168990 Sn4+  0.168990 Sb     0.208920 Sb3+  0.208920
+    Sb5+  0.208920  Te    0.241170 I     0.276730 I1-    0.276730 Xe    0.304200
+    Cs    0.325450  Cs1+  0.325450 Ba    0.341320 Ba2+   0.341320 La    0.349970
+    La3+  0.349970  Ce    0.360280 Ce3+  0.360280 Ce4+   0.360280 Pr    0.356480
+    Pr3+  0.356480  Pr4+  0.356480 Nd    0.351970 Nd3+   0.351970 Pm    0.337430
+    Sm    0.320800  Sm3+  0.320800 Eu    0.298580 Eu2+   0.298580 Eu3+  0.298580
+    Gd    0.273190  Gd3+  0.273190 Tb    0.243770 Tb3+   0.243770 Dy    0.217540
+    Dy3+  0.217540  Ho    0.192540 Ho3+  0.192540 Er     0.167060 Er3+  0.167060
+    Tm    0.142390  Tm3+  0.142390 Yb    0.118810 Yb2+   0.118810 Yb3+  0.118810
+    Lu    0.092889  Lu3+  0.092889 Hf    0.067951 Hf4+   0.067951 Ta    0.041103
+    Ta5+  0.041103  W     0.018568 W6+   0.018568 Re    -0.004706 Os   -0.022529
+    Os4+ -0.022529  Ir   -0.041174 Ir3+ -0.041174 Ir4+  -0.041174 Pt   -0.056487
+    Pt2+ -0.056487  Pt4+ -0.056487 Au   -0.069030 Au1+  -0.069030 Au3+ -0.069030
+    Hg   -0.079013  Hg1+ -0.079013 Hg2+ -0.079013 Tl    -0.084911 Tl1+ -0.084911
+    Tl3+ -0.084911  Pb   -0.089878 Pb2+ -0.089878 Pb4+  -0.089878 Bi   -0.090198
+    Bi3+ -0.090198  Bi5+ -0.090198 Po   -0.089333 At    -0.083350 Rn   -0.074320
+    Fr   -0.064000  Ra   -0.050660 Ra2+ -0.050660 Ac    -0.049651 Ac3+ -0.049651
+    Th   -0.018926  Th4+ -0.018926 Pa   -0.001192 U      0.016850 U3+   0.016850
+    U4+   0.016850  U6+   0.016850 Np    0.029804 Np3+   0.029804 Np4+  0.029804
+    Np6+  0.029804  Pu    0.042597 Pu3+  0.042597 Pu4+   0.042597 Pu6+  0.042597
+    Am    0.054967  Cm    0.067922 Bk    0.080547 Cf     0.093342
+     save_
+
+
+save_hi_ang_fox_c3
+
+    _units.code                   angstrom_cubed
+
+     loop_
+         _enumeration_default.index
+         _enumeration_default.value
+ H     0.0       D     0.0       H1-   0.0       He   -0.0254760 Li   -0.0071949
+ Li1+ -0.0071949 Be   -0.0004297 Be2+ -0.0004297 B    -0.0065981 C    -0.0042715
+ N     0.0002472 O     0.0047500 O1-   0.0047500 F     0.0054352 F1-   0.0054352
+ Ne    0.0060957 Na    0.0076974 Na1+  0.0076974 Mg    0.0082738 Mg2+  0.0082738
+ Al    0.0072294 Al3+  0.0072294 Si    0.0055631 Si4+  0.0055631 P     0.0020731
+ S    -0.0026058 Cl   -0.0076135 Cl1- -0.0076135 Ar   -0.0132510 K    -0.0191290
+ K1+  -0.0191290 Ca   -0.0245670 Ca2+ -0.0245670 Sc   -0.0285330 Sc3+ -0.0285330
+ Ti   -0.0311710 Ti2+ -0.0311710 Ti3+ -0.0311710 Ti4+ -0.0311710 V    -0.0322040
+ V2+  -0.0322040 V3+  -0.0322040 V5+  -0.0322040 Cr   -0.0317520 Cr2+ -0.0317520
+ Cr3+ -0.0317520 Mn   -0.0302150 Mn2+ -0.0302150 Mn3+ -0.0302150 Mn4+ -0.0302150
+ Fe   -0.0271990 Fe2+ -0.0271990 Fe3+ -0.0271990 Co   -0.0237050 Co2+ -0.0237050
+ Co3+ -0.0237050 Ni   -0.0194290 Ni2+ -0.0194290 Ni3+ -0.0194290 Cu   -0.0149760
+ Cu1+ -0.0149760 Cu2+ -0.0149760 Zn   -0.0102160 Zn2+ -0.0102160 Ga   -0.0055471
+ Ga3+ -0.0055471 Ge   -0.0009984 Ge4+ -0.0009984 As    0.0032231 Se    0.0069837
+ Br    0.0100950 Br1-  0.0100950 Kr    0.0127070 Rb    0.0145320 Rb1+  0.0145320
+ Sr    0.0155410 Sr2+  0.0155410 Y     0.0159630 Y3+   0.0159630 Zr    0.0151820
+ Zr4+  0.0151820 Nb    0.0150150 Nb3+  0.0150150 Nb5+  0.0150150 Mo    0.0124010
+ Mo3+  0.0124010 Mo5+  0.0124010 Mo6+  0.0124010 Tc    0.0106630 Ru    0.0079060
+ Ru3+  0.0079060 Ru4+  0.0079060 Rh    0.0049443 Rh3+  0.0049443 Rh4+  0.0049443
+ Pd    0.0015404 Pd2+  0.0015404 Pd4+  0.0015404 Ag   -0.0025659 Ag1+ -0.0025659
+ Ag2+ -0.0025659 Cd   -0.0060990 Cd2+ -0.0060990 In   -0.0103910 In3+ -0.0103910
+ Sn   -0.0129860 Sn2+ -0.0129860 Sn4+ -0.0129860 Sb   -0.0161640 Sb3+ -0.0161640
+ Sb5+ -0.0161640 Te   -0.0186420 I    -0.0213920 I1-  -0.0213920 Xe   -0.0234290
+ Cs   -0.0249220 Cs1+ -0.0249220 Ba   -0.0259590 Ba2+ -0.0259590 La   -0.0264050
+ La3+ -0.0264050 Ce   -0.0270670 Ce3+ -0.0270670 Ce4+ -0.0270670 Pr   -0.0265180
+ Pr3+ -0.0265180 Pr4+ -0.0265180 Nd   -0.0259010 Nd3+ -0.0259010 Pm   -0.0244210
+ Sm   -0.0228170 Sm3+ -0.0228170 Eu   -0.0207460 Eu2+ -0.0207460 Eu3+ -0.0207460
+ Gd   -0.0184040 Gd3+ -0.0184040 Tb   -0.0157950 Tb3+ -0.0157950 Dy   -0.0134550
+ Dy3+ -0.0134550 Ho   -0.0113090 Ho3+ -0.0113090 Er   -0.0091467 Er3+ -0.0091467
+ Tm   -0.0070804 Tm3+ -0.0070804 Yb   -0.0051120 Yb2+ -0.0051120 Yb3+ -0.0051120
+ Lu   -0.0029820 Lu3+ -0.0029820 Hf   -0.0009620 Hf4+ -0.0009620 Ta    0.0011842
+ Ta5+  0.0011842 W     0.0029787 W6+   0.0029787 Re    0.0048180 Os    0.0061700
+ Os4+  0.0061700 Ir    0.0075967 Ir3+  0.0075967 Ir4+  0.0075967 Pt    0.0087492
+ Pt2+  0.0087492 Pt4+  0.0087492 Au    0.0096224 Au1+  0.0096224 Au3+  0.0096224
+ Hg    0.0102850 Hg1+  0.0102850 Hg2+  0.0102850 Tl    0.0105970 Tl1+  0.0105970
+ Tl3+  0.0105970 Pb    0.0108380 Pb2+  0.0108380 Pb4+  0.0108380 Bi    0.0106850
+ Bi3+  0.0106850 Bi5+  0.0106850 Po    0.0104380 At    0.0097641 Rn    0.0088510
+ Fr    0.0078354 Ra    0.0065836 Ra2+  0.0065836 Ac    0.0064340 Ac3+  0.0064340
+ Th    0.0036849 Th4+  0.0036849 Pa    0.0020878 U     0.0005060 U3+   0.0005060
+ U4+   0.0005060 U6+   0.0005060 Np   -0.0006566 Np3+ -0.0006566 Np4+ -0.0006566
+ Np6+ -0.0006566 Pu   -0.0018080 Pu3+ -0.0018080 Pu4+ -0.0018080 Pu6+ -0.0018080
+ Am   -0.0029112 Cm   -0.0040588 Bk   -0.0051729 Cf   -0.0062981
+
+save_
+
+save_colour_hue
+
+    loop_
+      _enumeration_default.index
+      _enumeration_default.value
+         H                        white
+         D                        blue_light
+         H1-                      white
+         He                       ?
+         Li                       ?
+         Li1+                     ?
+         Be                       ?
+         Be2+                     ?
+         B                        ?
+         C                        grey_steel
+         N                        blue
+         O                        red
+         O1-                      red
+         F                        green
+         F1-                      green
+         Ne                       ?
+         Na                       violet_magenta
+         Na1+                     violet_magenta
+         Mg                       violet_magenta
+         Mg2+                     violet_magenta
+         Al                       violet_magenta
+         Al3+                     violet_magenta
+         Si                       ?
+         Si4+                     ?
+         P                        violet_magenta
+         S                        yellow
+         Cl                       green
+         Cl1-                     green
+         Ar                       ?
+         K                        violet_magenta
+         K1+                      violet_magenta
+         Ca                       violet_magenta
+         Ca2+                     violet_magenta
+         Sc                       ?
+         Sc3+                     ?
+         Ti                       violet_magenta
+         Ti2+                     violet_magenta
+         Ti3+                     violet_magenta
+         Ti4+                     violet_magenta
+         V                        violet_magenta
+         V2+                      violet_magenta
+         V3+                      violet_magenta
+         V5+                      violet_magenta
+         Cr                       violet_magenta
+         Cr2+                     violet_magenta
+         Cr3+                     violet_magenta
+         Mn                       violet_magenta
+         Mn2+                     violet_magenta
+         Mn3+                     violet_magenta
+         Mn4+                     violet_magenta
+         Fe                       violet_magenta
+         Fe2+                     violet_magenta
+         Fe3+                     violet_magenta
+         Co                       violet_magenta
+         Co2+                     violet_magenta
+         Co3+                     violet_magenta
+         Ni                       violet_magenta
+         Ni2+                     violet_magenta
+         Ni3+                     violet_magenta
+         Cu                       violet_magenta
+         Cu1+                     violet_magenta
+         Cu2+                     violet_magenta
+         Zn                       violet_magenta
+         Zn2+                     violet_magenta
+         Ga                       violet_magenta
+         Ga3+                     violet_magenta
+         Ge                       violet_magenta
+         Ge4+                     violet_magenta
+         As                       violet_magenta
+         Se                       yellow
+         Br                       green
+         Br1-                     green
+         Kr                       ?
+         Rb                       ?
+         Rb1+                     ?
+         Sr                       ?
+         Sr2+                     ?
+         Y                        ?
+         Y3+                      ?
+         Zr                       ?
+         Zr4+                     ?
+         Nb                       ?
+         Nb3+                     ?
+         Nb5+                     ?
+         Mo                       ?
+         Mo3+                     violet_magenta
+         Mo5+                     violet_magenta
+         Mo6+                     violet_magenta
+         Tc                       ?
+         Ru                       ?
+         Ru3+                     ?
+         Ru4+                     ?
+         Rh                       ?
+         Rh3+                     ?
+         Rh4+                     ?
+         Pd                       ?
+         Pd2+                     ?
+         Pd4+                     ?
+         Ag                       violet_magenta
+         Ag1+                     violet_magenta
+         Ag2+                     violet_magenta
+         Cd                       violet_magenta
+         Cd2+                     violet_magenta
+         In                       ?
+         In3+                     ?
+         Sn                       violet_magenta
+         Sn2+                     violet_magenta
+         Sn4+                     violet_magenta
+         Sb                       violet_magenta
+         Sb3+                     violet_magenta
+         Sb5+                     violet_magenta
+         Te                       ?
+         I                        green
+         I1-                      green
+         Xe                       ?
+         Cs                       ?
+         Cs1+                     ?
+         Ba                       ?
+         Ba2+                     ?
+         La                       ?
+         La3+                     ?
+         Ce                       ?
+         Ce3+                     ?
+         Ce4+                     ?
+         Pr                       ?
+         Pr3+                     ?
+         Pr4+                     ?
+         Nd                       ?
+         Nd3+                     ?
+         Pm                       ?
+         Sm                       ?
+         Sm3+                     ?
+         Eu                       ?
+         Eu2+                     ?
+         Eu3+                     ?
+         Gd                       ?
+         Gd3+                     ?
+         Tb                       ?
+         Tb3+                     ?
+         Dy                       ?
+         Dy3+                     ?
+         Ho                       ?
+         Ho3+                     ?
+         Er                       ?
+         Er3+                     ?
+         Tm                       ?
+         Tm3+                     ?
+         Yb                       ?
+         Yb2+                     ?
+         Yb3+                     ?
+         Lu                       ?
+         Lu3+                     ?
+         Hf                       ?
+         Hf4+                     ?
+         Ta                       ?
+         Ta5+                     ?
+         W                        ?
+         W6+                      ?
+         Re                       ?
+         Os                       ?
+         Os4+                     ?
+         Ir                       ?
+         Ir3+                     ?
+         Ir4+                     ?
+         Pt                       violet_magenta
+         Pt2+                     violet_magenta
+         Pt4+                     violet_magenta
+         Au                       violet_magenta
+         Au1+                     violet_magenta
+         Au3+                     violet_magenta
+         Hg                       violet_magenta
+         Hg1+                     violet_magenta
+         Hg2+                     violet_magenta
+         Tl                       ?
+         Tl1+                     ?
+         Tl3+                     ?
+         Pb                       violet_magenta
+         Pb2+                     violet_magenta
+         Pb4+                     violet_magenta
+         Bi                       violet_magenta
+         Bi3+                     violet_magenta
+         Bi5+                     violet_magenta
+         Po                       ?
+         At                       ?
+         Rn                       ?
+         Fr                       ?
+         Ra                       ?
+         Ra2+                     ?
+         Ac                       ?
+         Ac3+                     ?
+         Th                       ?
+         Th4+                     ?
+         Pa                       ?
+         U                        ?
+         U3+                      ?
+         U4+                      ?
+         U6+                      ?
+         Np                       ?
+         Np3+                     ?
+         Np4+                     ?
+         Np6+                     ?
+         Pu                       ?
+         Pu3+                     ?
+         Pu4+                     ?
+         Pu6+                     ?
+         Am                       ?
+         Cm                       ?
+         Bk                       ?
+         Cf                       ?
+
+save_
+
+save_wyckoff_letter
+
+    loop_
+      _enumeration_set.state
+         a
+         b
+         c
+         d
+         e
+         f
+         g
+         h
+         i
+         j
+         k
+         l
+         m
+         n
+         o
+         p
+         q
+         r
+         s
+         t
+         u
+         v
+         w
+         x
+         y
+         z
+         \a
+         α
+
+save_
+
+#=============================================================================
+#  The dictionary's creation history.
+#============================================================================
+
+    loop_
+      _dictionary_audit.version
+      _dictionary_audit.date
+      _dictionary_audit.revision
+         1.0.1                    2005-12-12
+;
+       Initial version of the TEMPLATES dictionary created from the
+       definitions used in CORE_3 dictionary version 3.5.02
+;
+         1.1.0                    2006-02-12
+;
+       Remove dictionary attributes from a save frame.
+       Change category core_templates to template
+;
+         1.2.1                    2006-02-21
+;
+       File structure to conform with prototype version dictionaries.
+;
+         1.2.2                    2006-03-07
+;
+       Added the template _template.relational_id for the ddl3 dictionary.
+;
+         1.2.3                    2006-06-20
+;
+       Apply DDL 3.6.04 attributes.
+;
+         1.2.4                    2006-06-27
+;
+       Change filename to com_val.dic.
+       apply DDL 3.6.05 changes.
+       add 'context' and 'method' enumerated lists
+       add 'enumeration_default' blocks to this file
+;
+         1.2.5                    2006-08-30
+;
+       In type.contents change constrction of Otag to 'ANchar [_]'
+;
+         1.2.6                    2006-11-13
+;
+       Remove method and context frames
+;
+         1.2.7                    2006-12-14
+;
+       Apply DDL3 3.7.01 attributes.
+;
+         1.2.8                    2007-10-11
+;
+       Correct definitions of Ctag and Otag in _type.contents
+;
+         1.2.9                    2011-03-25
+;
+       Change the syntax of "Filename" in type_contents enumeration set.
+;
+         1.3.1                    2011-08-03
+;
+       Remove definition.id lines in keeping with nested imports.
+;
+         1.3.2                    2011-12-01
+;
+       Update the DDL version. No Matrix types present.
+;
+         1.3.3                    2012-05-07
+;
+       Update the DDL version. Change dictionary class to Template
+;
+         1.3.4                    2012-07-08
+;
+       Remove type.contents enumeration list
+;
+         1.3.5                    2012-10-16
+;
+       Change all element symbols in the ion-to-elemnt default list to Upper
+       and lower case characters (from all upper).
+;
+         1.4.1                    2013-03-08
+;
+       Changes arising from alerts issued by ALIGN.
+;
+         1.4.2                    2013-04-16
+;
+       Changed type.source 'Measured' to 'Recorded'
+;
+         1.4.3                    2014-06-09
+;
+       Inserted dummy line at top of each frame; this is skipped on import
+;
+         1.4.4                    2016-04-01
+;
+       Added Bohr magnetons and radians to the units list (James Hester)
+;
+         1.4.5                    2016-05-13
+;
+       Added Schoenflies group list (James Hester)
+;
+         1.4.6                    2017-12-12
+;
+       Updated atom symbol list for newly-named elements (James Hester)
+;
+         1.4.7                    2019-12-09
+;
+       Updated the human-readable descriptions of the 'kelvins' and
+       'kelvins_per_minute' enumeration states in the _units_code save frame.
+;
+         1.4.8                    2023-06-14
+;
+       Corrected a few typos in the 'units_code' save frame.
+
+       Added deuterium (D) to the 'element_symbol' save frame.
+
+       Corrected several discrepancies in the 'colour_hue' save frame:
+       replaced colour value 'unknown' with CIF special value '?',
+       renamed colour 'steel_grey' to 'grey_steel', renamed colour
+       'violet' to 'violet_magenta'.
+
+       Added the 'grey_steel' colour to the 'colour_RGB' save frame.
+
+       Added the 'Wyckoff_letter' save frame.
+
+       Changed the DDL conformance version number from 3.11.04 to 4.1.0.
+
+       Changed a duplicate version number in the DICTIONARY_AUDIT loop
+       from 1.0.1 to 1.1.0.
+
+       Added the 'micrometres', 'counts', 'photons per second' and
+       'femtometres_per_angstrom_cubed' enumeration states to the
+       'units_code' save frame.
+
+       Added units for TOF coefficients.
+
+       Corrected the descriptions of the 'electrons_per_nanometre_cubed',
+       'electrons_per_angstrom_cubed', 'electrons_per_picometre_cubed' and
+       'femtometre_squared' enumeration states in the 'units_code' save frame.
+;
+         1.4.9                    2024-12-18
+;
+       # Please update the date above and describe the change below until
+       # ready for the next release
+
+       Altered hi_ang_Fox_c2 and hi_ang_Fox_c3 values to have them be the
+       correct magnitude, rather than their 10x and 100x values, respectively.
+
+       Corrected atom codes in several save frames.
+
+       Corrected the electron count of U6+ in the 'electron_count' save frame.
+
+       Added Flerovium (Fl), Livermorium (Lv), Moscovium (Mc), Nihonium (Nh),
+       Oganesson (Og), and Tennessine (Ts) to the 'element_symbol' save frame.
+
+       Updated the values for V2+, V3+ and V5+ in the 'length_neutron' save
+       frame to match those of V.
+
+       Altered key of atomic_number, dispersion_real_Cu,
+       dispersion_imag_Cu, dispersion_real_Mo, and dispersion_imag_Mo to be
+       keyed on _atom_type.element_symbol.
+
+       The enumeration for wyckoff_letter includes both \a and α to represent
+       the Greek letter 'alpha'.
+
+       Added hertz and counts_per_second to units_code.
+
+       Renamed the 'photons per second' unit to 'photons_per_second'.
+
+       Added BIncStrDB to save_database_list. (bm)
+
+       Added electrons_per_angstrom and reciprocal_angstroms_per_pixel
+       for electron diffraction; extended description of the former. (bm)
+;

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "name": "cifvsc",
   "displayName": "CIF Syntax Support",
   "publisher": "MatthewRowles",
-  "description": "Crystallographic Information File",
+  "description": "Crystallographic Information File (CIF)",
   "version": "0.1.1",
   "icon": "icon.png",
   "repository": {
@@ -17,6 +17,15 @@
   },
   "categories": [
     "Programming Languages"
+  ],
+  "files": [
+    "out",
+    "dictionaries",
+    "syntaxes",
+    "language-configuration.json",
+    "icon.png",
+    "README.md",
+    "LICENSE"
   ],
   "contributes": {
     "commands": [


### PR DESCRIPTION
A good set of default dictionaries are provided so that the user doesn't need to download their own. Also beefed up the parsing with a better heuristic for detecting DDL version (https://github.com/cod-developers/cod-tools/blob/11adb93cd531a87d7c07493785de3da9123f9cff/scripts/cif_validate#L4321) see also #20 

Hopefully should be better.